### PR TITLE
unocss variant group이 제대로 파싱되지 않는 버그 해결

### DIFF
--- a/packages/lib/src/vite/unocss/preprocess.ts
+++ b/packages/lib/src/vite/unocss/preprocess.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from '@unocss/config';
-import { createGenerator } from '@unocss/core';
+import { createGenerator, expandVariantGroup } from '@unocss/core';
 import * as csstree from 'css-tree';
 import MagicString from 'magic-string';
 import { traverse } from 'object-traversal';
@@ -72,7 +72,7 @@ export const unoPreprocess = (uno?: UnoGenerator): PreprocessorGroup => {
       };
 
       const transformClasses = async (classes: string) => {
-        const list = classes.split(/\s+/);
+        const list = expandVariantGroup(classes).split(/\s+/);
         const knowns = new Set<string>();
         const unknowns = new Set<string>();
 


### PR DESCRIPTION
`sm:(flex flex-col)` 등의 variant group을 이용할 때 최초 로딩시에는 제대로 파싱이 되지만 서버 시작 이후 HMR을 통해 리로드시 파싱이 실패해 제대로 extraction이 되지 않아 일부 css class가 생성이 안 되던 문제 해결
