### PR TITLE
createMutationForm의 onSuccess와 onError가 string message를 받을 수 있도록 함

### DIFF
--- a/apps/penxle.com/src/lib/form/mutation-form.ts
+++ b/apps/penxle.com/src/lib/form/mutation-form.ts
@@ -9,11 +9,11 @@ import type { MutationStore } from '$glitch';
 import type { MaybePromise, Unwrap } from '$lib/types';
 
 type MutationFormConfig<D, Z extends AnyZodObject> = {
+  mutation: MutationStore<D, { input: TypeOf<Z> }>;
   schema: Z | ZodEffects<Z> | { validate: Z; warn: Z };
   initialValues?: RecursivePartial<TypeOf<Z>>;
-  mutation: MutationStore<D, { input: TypeOf<Z> }>;
-  onSuccess?: (data: Unwrap<D>) => MaybePromise<void>;
-  onError?: (error: AppError) => MaybePromise<void>;
+  onSuccess?: (data: Unwrap<D>) => MaybePromise<void> | string;
+  onError?: (error: AppError) => MaybePromise<void> | string;
 };
 
 export const createMutationForm = <D, Z extends AnyZodObject>(config: MutationFormConfig<D, Z>) => {
@@ -34,20 +34,28 @@ export const createMutationForm = <D, Z extends AnyZodObject>(config: MutationFo
     extend,
     onSubmit: async (values) => {
       const data = await mutation(values);
-      await onSuccess?.(data);
+      if (typeof onSuccess === 'string') {
+        toast.success(onSuccess);
+      } else {
+        await onSuccess?.(data);
+      }
     },
     onError: async (error) => {
       if (error instanceof FormValidationError) {
         return { [error.field]: error.message } as AssignableErrors<TypeOf<Z>>;
       } else if (error instanceof AppError) {
         if (onError) {
-          await onError(error);
+          if (typeof onError === 'string') {
+            toast.error(onError);
+          } else {
+            await onError(error);
+          }
         } else {
           toast.error(error.message);
         }
       } else {
         console.error(error);
-        toast.error('An unknown error occurred');
+        toast.error('알 수 없는 오류가 발생했어요');
       }
 
       return;


### PR DESCRIPTION
`createMutationForm`의 `onSuccess` 혹은 `onError` 에 함수가 아닌 문자열을 넣을 시 해당 문자열을 toast로 띄읕주도록 하는 편의 기능 추가
