### PR TITLE
마케팅 수신 동의 토스트 메시지 길이 줄임

### DIFF
--- a/apps/penxle.com/src/routes/(default)/me/accounts/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/accounts/+page.svelte
@@ -279,7 +279,9 @@
       on:change={async () => {
         const consent = !$query.me.marketingConsent;
         await updateUserMarketingConsent({ consent });
-        toast.success(`펜슬의 마케팅 수신 동의가 ${dayjs().formatAsDate()} ${consent ? '승인' : '거부'} 처리되었어요`);
+        toast.success(`${dayjs().formatAsDate()} ${consent ? '승인' : '거부'} 처리되었어요`, {
+          title: '펜슬 마케팅 수신 동의',
+        });
       }}
     />
   </div>


### PR DESCRIPTION
QA-17 수정을 시도했으나 디자인 및 구현상 당장은 작업이 어려워 일단 마케팅 수신 동의 토스트 메시지 길이를 줄이는 방식으로 우회함
앞으로 일단은 토스트 메시지 길이를 최대한 짧게 가져가는걸 베이스로 삼아야 할 듯?

<img width="333" alt="CleanShot 2023-09-30 at 11 38 17" src="https://github.com/penxle/penxle/assets/337728/6646b681-7caa-46ca-a4fb-a3e11101d6c6">
