### PR TITLE
디자인 컬러팔레트 등록

### DIFF
--- a/packages/lib/src/unocss/colors.ts
+++ b/packages/lib/src/unocss/colors.ts
@@ -137,6 +137,35 @@ export const partialShadedColors = {
   },
 };
 
+export const designColors = {
+  bg: {
+    primary: '#F9F9F8',
+    cardprimary: '#FFFFFF',
+  },
+  text: {
+    primary: '#1C1917',
+    secondary: '#78716C',
+    disabled: '#A8A29E',
+  },
+  surface: {
+    primary: '#F1F1F0',
+    secondary: '#E7E5E4',
+  },
+  action: {
+    primary: '#F66062',
+  },
+  border: {
+    primary: '#A8A29E',
+    secondary: '#D6D3D1',
+    tertiary: '#1C1917',
+  },
+  icon: {
+    primary: '#1C1917',
+    secondary: '#A8A29E',
+    tertiary: '#D6D3D1',
+  },
+};
+
 type Color = keyof typeof shadedColors;
 type Shade = keyof (typeof shadedColors)[keyof typeof shadedColors];
 

--- a/packages/lib/src/unocss/preset.ts
+++ b/packages/lib/src/unocss/preset.ts
@@ -2,7 +2,7 @@ import { lookupCollection } from '@iconify/json';
 import { FileSystemIconLoader } from '@iconify/utils/lib/loader/node-loaders';
 import { presetIcons } from '@unocss/preset-icons';
 import { presetUno } from '@unocss/preset-uno';
-import { basicColors, partialShadedColors, shadedColors, specialColors } from './colors';
+import { basicColors, designColors, partialShadedColors, shadedColors, specialColors } from './colors';
 import type { Preset } from '@unocss/core';
 import type { Theme } from '@unocss/preset-uno';
 
@@ -45,6 +45,7 @@ export const presetPenxle = (): Preset<Theme> => ({
   shortcuts: [
     [/^square-(.*)$/, ([, c]) => `w-${c} h-${c}`],
     ['center', 'justify-center items-center'],
+    [/^([^-]+)-(primary|secondary|tertiary|disabled|cardprimary)$/, ([, c, d]) => `${c}-${c}-${d}`],
   ],
   extendTheme: (theme) => ({
     ...theme,
@@ -53,6 +54,7 @@ export const presetPenxle = (): Preset<Theme> => ({
       ...basicColors,
       ...shadedColors,
       ...partialShadedColors,
+      ...designColors,
     },
     breakpoints: {
       sm: '800px',


### PR DESCRIPTION
디자인에서 사용하고 있는 bg, text, surface 등의 primary 컬러가 각각 다르다는 문제를 해결하기 위함
`bg-primary`, `text-primary`처럼 입력 시 실제로는 `bg-bg-primary`처럼 지정되도록 shortcut 등록함