### PR TITLE
api 라우트로 이동하는 경우 goto 이용하지 않음

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/schemas/user.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/user.ts
@@ -335,7 +335,7 @@ builder.mutationFields((t) => ({
   issueUserEmailAuthorizationUrl: t.field({
     type: IssueUserEmailAuthorizationUrlResult,
     args: { input: t.arg({ type: IssueUserEmailAuthorizationUrlInput }) },
-    resolve: async (_, { input }, { db }) => {
+    resolve: async (_, { input }, { db, ...context }) => {
       const emailVerification = await db.userEmailVerification.findFirst({
         where: {
           email: input.email,
@@ -350,7 +350,7 @@ builder.mutationFields((t) => ({
 
       return {
         url: qs.stringifyUrl({
-          url: '/api/email',
+          url: `${context.url.origin}/api/email`,
           query: { token: emailVerification.token },
         }),
       };

--- a/apps/penxle.com/src/routes/(auth)/login/code/+page.svelte
+++ b/apps/penxle.com/src/routes/(auth)/login/code/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { graphql } from '$glitch';
   import { Button } from '$lib/components';
@@ -20,8 +19,8 @@
       }
     `),
     schema: IssueUserEmailAuthorizationUrlSchema,
-    onSuccess: async (resp) => {
-      await goto(resp.url);
+    onSuccess: (resp) => {
+      location.href = resp.url;
     },
   });
 </script>


### PR DESCRIPTION
svelte 페이지가 아닌 경로로 이동하는 경우 svelte의 goto를 쓰면 일단 페이지 찾을 수 없음 오류가 발생하고 폴백을 통해 타겟 주소로 라우팅이 됨.

유저가 느끼는 관점에서는 큰 문제가 없으나 중간에 페이지 찾을 수 없음 오류가 sentry에 로깅되는 이슈가 있어 `location.href` 를 바로 이용하는 방식으로 전환함.
