### PR TITLE
prisma transaction client에 $lock 메서드 추가

### DIFF
--- a/apps/penxle.com/package.json
+++ b/apps/penxle.com/package.json
@@ -45,6 +45,7 @@
     "@pulumi/pulumi": "^3.87.0",
     "@resvg/resvg-js": "^2.4.1",
     "@sentry/sveltekit": "^7.73.0",
+    "@sindresorhus/string-hash": "^2.0.0",
     "@svelte-kits/store": "^0.1.2",
     "@sveltejs/kit": "^1.25.1",
     "@tiptap/core": "^2.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,9 @@ importers:
       '@sentry/sveltekit':
         specifier: ^7.73.0
         version: 7.73.0(@sveltejs/kit@1.25.1)(svelte@4.2.1)
+      '@sindresorhus/string-hash':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@svelte-kits/store':
         specifier: ^0.1.2
         version: 0.1.2(@sveltejs/kit@1.25.1)(svelte@4.2.1)
@@ -5285,14 +5288,12 @@ packages:
   /@sindresorhus/fnv1a@3.0.0:
     resolution: {integrity: sha512-M6pmbdZqAryzjZ4ELAzrdCMoMZk5lH/fshKrapfSeXdf2W+GDqZvPmfXaNTZp43//FVbSwkTPwpEMnehSyskkQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: false
 
   /@sindresorhus/string-hash@2.0.0:
     resolution: {integrity: sha512-eNmMOd5DZkiu9LxIeHdh1XvDbcpFXV4HdBqg9hlg8YNKDvE6qmHiJ+Vy+rFrzXofRYmtheNv4A3ESad8unxwwA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       '@sindresorhus/fnv1a': 3.0.0
-    dev: false
 
   /@smithy/abort-controller@2.0.11:
     resolution: {integrity: sha512-MSzE1qR2JNyb7ot3blIOT3O3H0Jn06iNDEgHRaqZUwBgx5EG+VIx24Y21tlKofzYryIOcWpIohLrIIyocD6LMA==}


### PR DESCRIPTION
포인트, 수익금 등 배타적인 접근이 필요한 리소스 접근 제어를 위한 `$lock` 메서드를 `TransactionClient` 에 추가함

```
await db.$lock('test');
```

위와 같이 호출했을 경우 해당 시점부터 현재 트랜잭션이 끝나기 전(보통 request scope)까지 해당 키로 배타적인 락이 걸림.
callback function을 통해 명시적으로 scope 제한을 하고 싶었으나 1. prisma client가 nested transaction 지원을 안 하고, 2. `pg_advisory_xact_lock` 또한 `SAVEPOINT`를 통한 nested transaction 지원을 안 하는 관계로 이미 트랜잭션이 열린 이상 해당 scope에 묶이는 수밖에 없음.

위 이유로 배타적인 접근이 필요한 리소스에 접근할 예정인 경우 최대한 빠른 시점(mutation 첫 줄 등)에 선제적으로 `db.$lock()` 을 호출하는 것이 권장됨.
