### PR TITLE
포인트 DB 테이블 설계

### DIFF
--- a/apps/penxle.com/prisma/schema.prisma
+++ b/apps/penxle.com/prisma/schema.prisma
@@ -35,6 +35,53 @@ model Image {
   @@map("images")
 }
 
+model PointBalance {
+  id         String         @id
+  userId     String         @map("user_id")
+  user       User           @relation(fields: [userId], references: [id])
+  purchaseId String?        @map("purchase_id")
+  purchase   PointPurchase? @relation(fields: [purchaseId], references: [id])
+  kind       PointKind
+  initial    Int
+  leftover   Int
+  createdAt  DateTime       @default(now()) @map("created_at") @db.Timestamptz
+  expiresAt  DateTime       @map("expires_at") @db.Timestamptz
+
+  @@index([userId, kind])
+  @@map("point_balances")
+}
+
+model PointPurchase {
+  id            String             @id
+  userId        String             @map("user_id")
+  user          User               @relation(fields: [userId], references: [id])
+  pointAmount   Int                @map("point_amount")
+  paymentAmount Int                @map("payment_amount")
+  paymentMethod PaymentMethod      @map("payment_method")
+  paymentKey    String             @unique @map("payment_key")
+  paymentData   Json               @map("payment_data")
+  state         PointPurchaseState
+  createdAt     DateTime           @default(now()) @map("created_at") @db.Timestamptz
+  expiresAt     DateTime           @map("expires_at") @db.Timestamptz
+  completedAt   DateTime?          @map("completed_at") @db.Timestamptz
+
+  balances PointBalance[]
+
+  @@map("point_purchases")
+}
+
+model PointTransaction {
+  id        String                @id
+  userId    String                @map("user_id")
+  user      User                  @relation(fields: [userId], references: [id])
+  cause     PointTransactionCause
+  amount    Int
+  targetId  String?               @map("target_id")
+  createdAt DateTime              @default(now()) @map("created_at") @db.Timestamptz
+
+  @@map("point_transactions")
+}
+
 model ProvisionedUser {
   id        String                    @id
   token     String                    @unique
@@ -207,6 +254,9 @@ model User {
   contentFilterPreferences       UserContentFilterPreference[]
   marketingConsent               UserMarketingConsent?
   notificationPreferences        UserNotificationPreference[]
+  pointBalances                  PointBalance[]
+  pointPurchases                 PointPurchase[]
+  pointTransactions              PointTransaction[]
   sessions                       UserSession[]
   singleSignOns                  UserSingleSignOn[]
   spaces                         SpaceMember[]
@@ -343,6 +393,46 @@ enum ContentFilterAction {
   EXPOSE
 
   @@map("_content_filter_action")
+}
+
+enum PaymentMethod {
+  CREDIT_CARD
+  BANK_ACCOUNT
+  VIRTUAL_BANK_ACCOUNT
+  PHONE_BILL
+  GIFTCARD_HAPPYMONEY
+  GIFTCARD_CULTURELAND
+  TOSS_PAY
+  PAYPAL
+
+  @@map("_payment_method")
+}
+
+enum PointKind {
+  PAID
+  FREE
+
+  @@map("_point_kind")
+}
+
+enum PointPurchaseState {
+  PENDING
+  COMPLETED
+  UNDONE
+
+  @@map("_point_purchase_state")
+}
+
+enum PointTransactionCause {
+  INTERNAL
+  PURCHASE
+  UNDO_PURCHASE
+  REFUND
+  EXPIRE
+  UNLOCK_CONTENT
+  PATRONIZE
+
+  @@map("_point_transaction_cause")
 }
 
 enum PreferenceType {


### PR DESCRIPTION
## `PointBalance`
포인트 잔고에 대해 담고 있는 테이블. 포인트 충전시 `initial`과 `leftover`가 충전된 값으로 채워짐.
포인트 사용시 `createdAt` 기준으로, 오래된 순서대로 먼저 이용하고 포인트를 사용한 만큼 `leftover`에서 차감함. `leftover`가 0이 된 경우 해당 테이블에서 삭제함. `createdAt`이 동일할 경우 `kind`가 `FREE`인 포인트를 먼저 이용함.
`expiresAt`은 포인트 만료 기간(5년)으로 채워지며, `purchaseId`는 해당 포인트를 구매한 `PointPurchase`의 `id`로 채워짐 (어드민 등에서 지급했을 경우 해당 필드는 `null`임). `expiresAt` 이 경과할 경우 해당 레코드는 삭제됨.
특정 유저의 이용 가능한 현재 총 포인트는 `userId` 를 기준으로 `leftover`에 sum을 실행해 동적으로 계산함.

## `PointPurchase`
포인트 결제 내역을 담고 있는 테이블. 포인트 충전을 시작할 시 `state`가 `PENDING`인 상태로 생성됨. `pointAmount`는 결제가 성공할 경우 충전될 포인트 양을 담고 있고, `paymentMethod`는 선택한 결제 수단으로, `paymentAmount`는 결제할 금액으로, `paymentKey`는 포트원 및 PG사에서 쓰일 랜덤 생성된 문자열이 들어감. `expiresAt` 은 해당 결제 요청이 유효한 시간이며, 보통 결제 시작 시점부터 1시간 정도로 채워질 듯. 결제가 성공할 경우 `state`가 `COMPLETED` 로 변경되며, `PointBalance` 테이블에 `kind`를 `PAID`, `purchaseId`가 자기 자신의 `id`로 하는 레코드가 생성됨. 동시에 `paymentData` 컬럼에 해당 결제에 대한 성공 응답을 포함시켜 업데이트함.
유저는 이용약관에 따라 포인트를 한번도 사용하지 않았을 경우 청약 철회 (`UNDO`)를 요청할 수 있으며, 청약 철회 가능 여부는 해당 결제건이 결제 완료(`completedAt`) 이후 7일 이내이며, 해당 결제건의 `balances`들이 모두 `initial === leftover` 를 충족할 경우 가능함. 청약 철회를 실행할 경우 해당 `PointPurchase`의 `state`는 `UNDONE` 으로 변경되며 연결된 `balances` 들은 모두 삭제됨.
유저는 이용약관에 따라 사용하고 남은 일부 포인트의 환불(`REFUND`)을 요청할 수 있으며, 환불 가능 여부는 해당 결제건의 `balances` 중 `kind`가 `PAID`인 `PointBalance`가 `leftover / initial <= 0.2` 를 충족할 경우 가능함.
`expiresAt` 이내에 결제를 완료하지 못했을 경우 해당 레코드는 삭제됨.

## `PointTransaction`
포인트의 모든 변경 내역을 담고 있는 테이블. 포인트가 충전되거나 소모될 시 해당 테이블에 필히 기록되며, `amount`는 포인트 충전일 경우 양의 정수, 포인트 소모일 경우 음의 정수를 담음. `cause` 필드는 해당 포인트 변경의 원인을 기록하며, `targetId` 에는 `cause`에 따라 다른 레코드를 가리키게 됨. 예를 들어 포인트 충전일 경우 `PointPurchase`의 `id`를, `PATRONIZE`의 경우 해당 `Post` 의 `id` 를 가리킬 수 있겠음.