### PR TITLE
스페이스 페이지의 버튼 그룹 내 텍스트가 넘치는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/tab/TabHead.svelte
+++ b/apps/penxle.com/src/lib/components/tab/TabHead.svelte
@@ -6,16 +6,14 @@
   export { _class as class };
 </script>
 
-<div>
-  <ul
-    class={clsx(
-      'flex w-fit',
-      variant === 'primary' && 'gap-2',
-      variant === 'secondary' && 'border-b border-secondary',
-      _class,
-    )}
-    role="tablist"
-  >
-    <slot />
-  </ul>
-</div>
+<ul
+  class={clsx(
+    'flex w-fit',
+    variant === 'primary' && 'gap-2',
+    variant === 'secondary' && 'border-b border-secondary',
+    _class,
+  )}
+  role="tablist"
+>
+  <slot />
+</ul>

--- a/apps/penxle.com/src/routes/(default)/[space]/+layout@.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/+layout@.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { graphql } from '$glitch';
   import { Button, Tag } from '$lib/components';
-  import { TabContentItem, TabHead, TabHeadItem } from '$lib/components/tab';
+  import { TabHead, TabHeadItem } from '$lib/components/tab';
   import Footer from '../Footer.svelte';
   import Header from '../Header.svelte';
 
@@ -24,117 +24,94 @@
 
 <Header {$query} />
 
-<main class="flex flex-col items-center w-full">
-  <div class="flex center w-full border-b">
-    <div class="pt-6 px-4 bg-cardprimary w-full max-w-200">
-      <div class="flex flex-wrap items-start">
-        <div class="w-full sm:(flex items-center) sm:mb-8">
-          <div class="flex items-start justify-between">
-            <div class="square-15 rounded-2xl bg-black sm:(square-30 rounded-3xl mr-6)" />
-            <button
-              class="square-9 flex center rounded-xl transition duration-300 hover:bg-primary sm:hidden"
-              type="button"
-            >
-              <span class="i-lc-share square-6 text-icon-secondary" />
-            </button>
-          </div>
-          <div class="flex items-start justify-between w-full">
-            <div class="w-full">
-              <div class="my-5 sm:(mt-0 mb-3)">
-                <h1 class="title-20-eb mb-2 sm:(title-24-eb mb-3)">{$query.space.name}</h1>
-                <div class="flex items-center mb-2">
-                  <span class="text-secondary body-16-sb">관심 독자</span>
-                  <span class="text-primary ml-2 subtitle-18-b">3</span>
-                  <span class="ml-3 text-secondary body-16-sb">포스트</span>
-                  <span class="text-primary ml-2 subtitle-18-b">17</span>
-                </div>
-                <p class="body-15-sb text-secondary">penxle.com/penxle.. 외 2개</p>
-              </div>
-              <div class="flex flex-wrap gap-2 sm:hidden">
-                <Tag>#태그</Tag>
-                <Tag>#태그</Tag>
-                <Tag>#태그</Tag>
-                <Tag>#태그</Tag>
-                <Tag>#태그</Tag>
-              </div>
-              <div class="flex flex-wrap gap-2 <sm:hidden">
-                <Tag size="sm">#태그</Tag>
-                <Tag size="sm">#태그</Tag>
-                <Tag size="sm">#태그</Tag>
-                <Tag size="sm">#태그</Tag>
-                <Tag size="sm">#태그</Tag>
-              </div>
-            </div>
-            <div class="flex items-center gap-2 <sm:hidden">
-              {#if $query.space.meAsMember}
-                <Button href={`/${$query.space.slug}/publish/post`} size="md" type="link">포스트 작성</Button>
-                <Button color="tertiary" size="md" variant="outlined">
-                  <span class="i-lc-share mr-2" />
-                  공유하기
-                </Button>
-                <a
-                  class="border border-secondary rounded-xl square-9 p-1 flex center transition duration-300 hover:border-primary"
-                  href={`/${$query.space.slug}/settings`}
-                >
-                  <span class="i-lc-settings square-6 text-secondary" />
-                </a>
-              {:else}
-                <Button class="w-full" size="md">+ 관심</Button>
-                <Button color="tertiary" size="md" variant="outlined">
-                  <span class="i-lc-share mr-2" />
-                  공유하기
-                </Button>
-              {/if}
-            </div>
-          </div>
+<main class="flex flex-col items-center">
+  <div class="pt-6 px-4 bg-cardprimary w-full max-w-200 sm:(flex gap-6) sm:mb-8">
+    <div class="flex items-start justify-between">
+      <div class="square-15 rounded-2xl bg-black sm:(square-30 rounded-3xl self-center)" />
+      <button class="square-9 flex center rounded-xl transition duration-300 hover:bg-primary sm:hidden" type="button">
+        <span class="i-lc-share square-6 text-icon-secondary" />
+      </button>
+    </div>
+    <div class="flex-1">
+      <div class="my-5 sm:(mt-0 mb-3)">
+        <h1 class="title-20-eb mb-2 sm:(title-24-eb mb-3)">{$query.space.name}</h1>
+        <div class="flex items-center mb-2">
+          <span class="text-secondary body-16-sb">관심 독자</span>
+          <span class="text-primary ml-2 subtitle-18-b">3</span>
+          <span class="ml-3 text-secondary body-16-sb">포스트</span>
+          <span class="text-primary ml-2 subtitle-18-b">17</span>
         </div>
-        <div class="flex gap-2 w-full mt-6 mb-3 sm:hidden">
-          {#if $query.space.meAsMember}
-            <Button class="<sm:w-full" href={`/${$query.space.slug}/publish/post`} size="xl" type="link">
-              포스트 작성
-            </Button>
-            <Button
-              class="square-12.5"
-              color="tertiary"
-              href={`/${$query.space.slug}/settings`}
-              size="xl"
-              type="link"
-              variant="outlined"
-            >
-              <span class="i-lc-settings square-6 text-secondary" />
-            </Button>
-          {:else}
-            <Button class="w-full" size="xl">관심 스페이스 등록하기</Button>
-          {/if}
-        </div>
+        <p class="body-15-sb text-secondary">penxle.com/penxle.. 외 2개</p>
       </div>
-
-      <TabHead class="border-none" variant="secondary">
-        <TabHeadItem id={1} href="/{$query.space.slug}" variant="secondary">
-          <span>홈</span>
-        </TabHeadItem>
-        <TabHeadItem id={2} href="/{$query.space.slug}/collections" variant="secondary">
-          <span>컬렉션</span>
-        </TabHeadItem>
-        <TabHeadItem id={3} href="/{$query.space.slug}/about" variant="secondary">
-          <span>소개</span>
-        </TabHeadItem>
-      </TabHead>
-
-      <div class="flex center bg-gray-5 sm:bg-cardprimary! min-h-100%">
-        <TabContentItem id={1}>
-          <div class="flex flex-col center gap-5">
-            <span class="text-3.75 font-bold text-secondary">아직 스페이스에 업로드된 포스트가 없어요</span>
-            {#if $query.space.meAsMember}
-              <Button href={`/${$query.space.slug}/publish/post`} size="lg" type="link">포스트 작성하기</Button>
-            {/if}
-          </div>
-        </TabContentItem>
-        <TabContentItem id={2}>컬렉션</TabContentItem>
-        <TabContentItem id={3}>소개</TabContentItem>
+      <div class="flex flex-wrap gap-2 sm:hidden">
+        <Tag>#태그</Tag>
+        <Tag>#태그</Tag>
+        <Tag>#태그</Tag>
+        <Tag>#태그</Tag>
+        <Tag>#태그</Tag>
+      </div>
+      <div class="flex flex-wrap gap-2 <sm:hidden">
+        <Tag size="sm">#태그</Tag>
+        <Tag size="sm">#태그</Tag>
+        <Tag size="sm">#태그</Tag>
+        <Tag size="sm">#태그</Tag>
+        <Tag size="sm">#태그</Tag>
       </div>
     </div>
+    <div class="flex self-start items-center gap-2 <sm:hidden">
+      {#if $query.space.meAsMember}
+        <Button href={`/${$query.space.slug}/publish/post`} size="md" type="link">포스트 작성</Button>
+        <Button color="tertiary" size="md" variant="outlined">
+          <span class="i-lc-share mr-2" />
+          공유하기
+        </Button>
+        <a
+          class="border border-secondary rounded-xl square-9 p-1 flex center transition duration-300 hover:border-primary"
+          href={`/${$query.space.slug}/settings`}
+        >
+          <span class="i-lc-settings square-6 text-secondary" />
+        </a>
+      {:else}
+        <Button class="flex-1" size="md">+ 관심</Button>
+        <Button color="tertiary" size="md" variant="outlined">
+          <span class="i-lc-share mr-2" />
+          공유하기
+        </Button>
+      {/if}
+    </div>
   </div>
+  <div class="flex gap-2 w-full mt-6 mb-3 px-4 sm:hidden">
+    {#if $query.space.meAsMember}
+      <Button class="<sm:w-full" href={`/${$query.space.slug}/publish/post`} size="xl" type="link">포스트 작성</Button>
+      <Button
+        class="square-12.5"
+        color="tertiary"
+        href={`/${$query.space.slug}/settings`}
+        size="xl"
+        type="link"
+        variant="outlined"
+      >
+        <span class="i-lc-settings square-6 text-secondary" />
+      </Button>
+    {:else}
+      <Button class="w-full" size="xl">관심 스페이스 등록하기</Button>
+    {/if}
+  </div>
+
+  <TabHead class="w-full max-w-200 border-none" variant="secondary">
+    <TabHeadItem id={1} href="/{$query.space.slug}" variant="secondary">
+      <span>홈</span>
+    </TabHeadItem>
+    <TabHeadItem id={2} href="/{$query.space.slug}/collections" variant="secondary">
+      <span>컬렉션</span>
+    </TabHeadItem>
+    <TabHeadItem id={3} href="/{$query.space.slug}/about" variant="secondary">
+      <span>소개</span>
+    </TabHeadItem>
+  </TabHead>
+
+  <hr class="w-full border-color-alphagray-10" />
+
   <slot />
 </main>
 


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/5278201/277309513-921db742-e3d3-4cfd-8af3-50bc7c8c5cad.png)
![](https://user-images.githubusercontent.com/5278201/277309588-c92e3135-f862-4ab7-8707-2bd61fccec73.png)

FireFox 와 Safari 에서 버튼 텍스트가 넘치는 현상이 있었습니다.
스페이스 페이지의 레이아웃 구조 상 문제로 파악을 하여 코드 간소화 작업을 거쳐 해당 문제를 제거했습니다.
