### PR TITLE
서버사이드 토스트 발송을 위한 context.flash 메서드 추가

### DIFF
--- a/apps/penxle.com/schema.graphql
+++ b/apps/penxle.com/schema.graphql
@@ -81,6 +81,11 @@ input FinalizeImageUploadInput {
   name: String!
 }
 
+type Flash {
+  message: String!
+  type: String!
+}
+
 input FollowSpaceInput {
   spaceId: ID!
 }
@@ -283,6 +288,7 @@ type Query {
   auth(scope: AuthScope!): Void
   authLayoutBackgroundImage: Image
   draftRevision(revisionId: ID!): PostRevision!
+  flash: Flash
   me: User
   post(permalink: String!): Post!
   provisionedUser(token: String!): ProvisionedUser!

--- a/apps/penxle.com/src/lib/glitch/keys.ts
+++ b/apps/penxle.com/src/lib/glitch/keys.ts
@@ -1,3 +1,5 @@
 import type { GraphCacheConfig } from '$glitch';
 
-export const keys: GraphCacheConfig['keys'] = {};
+export const keys: GraphCacheConfig['keys'] = {
+  Flash: () => null,
+};

--- a/apps/penxle.com/src/lib/server/cache.ts
+++ b/apps/penxle.com/src/lib/server/cache.ts
@@ -10,7 +10,6 @@ export const useCache = async <T>(key: string, fn: () => Promise<T>, ttl = 60 * 
   }
 
   const value = await fn();
-  // spell-checker:disable-next-line
   await redis.setex(key, ttl, JSON.stringify(value));
 
   return value;

--- a/apps/penxle.com/src/lib/server/graphql/schemas/index.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/index.ts
@@ -1,5 +1,6 @@
 import './enums';
 import './image';
+import './internal';
 import './playground';
 import './post';
 import './space';

--- a/apps/penxle.com/src/lib/server/graphql/schemas/internal.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/internal.ts
@@ -1,0 +1,32 @@
+import { redis } from '$lib/server/cache';
+import { builder } from '../builder';
+
+/**
+ * * Types
+ */
+
+const Flash = builder.simpleObject('Flash', {
+  fields: (t) => ({
+    type: t.string(),
+    message: t.string(),
+  }),
+});
+
+/**
+ * * Queries
+ */
+
+builder.queryFields((t) => ({
+  flash: t.field({
+    type: Flash,
+    nullable: true,
+    resolve: async (_, __, context) => {
+      const payload = await redis.getdel(`flash:${context.deviceId}`);
+      if (!payload) {
+        return null;
+      }
+
+      return JSON.parse(payload);
+    },
+  }),
+}));

--- a/apps/penxle.com/src/routes/+layout.svelte
+++ b/apps/penxle.com/src/routes/+layout.svelte
@@ -3,7 +3,24 @@
   import 'virtual:uno.css';
 
   import { AutoUpdater, StackIndicator } from '@penxle/ui';
-  import { ToastProvider } from '$lib/notification';
+  import { onMount } from 'svelte';
+  import { graphql } from '$glitch';
+  import { toast, ToastProvider } from '$lib/notification';
+
+  $: query = graphql(`
+    query RootLayout_Query {
+      flash {
+        type
+        message
+      }
+    }
+  `);
+
+  onMount(() => {
+    if ($query.flash) {
+      toast[$query.flash.type as 'success' | 'error']($query.flash.message);
+    }
+  });
 </script>
 
 <div class="min-h-screen flex flex-col">

--- a/apps/penxle.com/src/routes/+layout.ts
+++ b/apps/penxle.com/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+// eslint-disable-next-line unicorn/no-empty-file

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -39,6 +39,7 @@
     "ridibatang",
     "runasroot",
     "serde",
+    "setex",
     "signup",
     "sindresorhus",
     "ssos",


### PR DESCRIPTION
서버사이드에서 다음 프론트 full reload시 토스트를 보내고 싶다면?

```
await context.flash('error', '에러 메시지');
```

를 호출해 다음 프론트 로드시 토스트를 예약할 수 있음
sso나 payment 등 api route에서 에러 메시지를 flash하고 리다이렉트하는데 유용하게 쓰일 것으로 예상함
