### PR TITLE
DB 트랜잭션 레벨 ReadCommitted로 변경

### DIFF
--- a/apps/penxle.com/src/lib/server/context.ts
+++ b/apps/penxle.com/src/lib/server/context.ts
@@ -31,7 +31,7 @@ export type UserContext = {
 export type Context = RequestEvent & App.Locals & DefaultContext & Partial<UserContext>;
 
 export const createContext = async (context: RequestEvent): Promise<Context> => {
-  const db = await prismaClient.$begin({ isolation: 'RepeatableRead' });
+  const db = await prismaClient.$begin({ isolation: 'ReadCommitted' });
   let deviceId = context.cookies.get('penxle-did');
   if (!deviceId) {
     deviceId = nanoid(32);


### PR DESCRIPTION
현재 트랜잭션 구조상 `RepeatableRead`를 이용할 때 트랜잭션 재시도를 할 방법이 없어, 일단 기본 트랜잭션 레벨을 `ReadCommitted` 로 한 단계 낮춰 설정한 뒤 동시 접근이 예상되는 부분에서 double-checked locking을 통해 동시성 제어를 시도하는 방향으로 전환함 (현재 포인트 충전의 경우 해당 방식으로 구현되어 있음)
