### PR TITLE
사파리에서 에디터 focus시 생기는 outline 제거

### DIFF
--- a/apps/penxle.com/src/styles/prose.css
+++ b/apps/penxle.com/src/styles/prose.css
@@ -84,3 +84,11 @@
 .prosemirror-drop-cursor {
   --uno: bg-brand-50;
 }
+
+/*
+  * reset
+*/
+
+.ProseMirror-focused {
+  --uno: outline-none;
+}


### PR DESCRIPTION
사파리, 파이어폭스에서 팁탭 에디터 포커스 시 생기는 outline 제거함

<img width="700" alt="image" src="https://github.com/penxle/penxle/assets/76952602/106c6bd5-1472-42d6-9de2-2abe703db5f3">