### PR TITLE
팁탭 transform steps 서버에서 적용함

### DIFF
--- a/apps/penxle.com/schema.graphql
+++ b/apps/penxle.com/schema.graphql
@@ -359,6 +359,7 @@ input RevisePostInput {
   postId: ID
   revisionKind: PostRevisionKind!
   spaceId: ID!
+  steps: JSON!
   subtitle: String
   thumbnailBounds: JSON
   thumbnailId: ID

--- a/apps/penxle.com/src/lib/tiptap/components/TiptapEditor.svelte
+++ b/apps/penxle.com/src/lib/tiptap/components/TiptapEditor.svelte
@@ -10,6 +10,7 @@
   export { _class as class };
   export let editor: Editor | undefined = undefined;
   export let content: JSONContent | undefined = undefined;
+  export let steps: unknown[] = [];
 
   let element: HTMLDivElement;
 
@@ -32,6 +33,10 @@
         },
       },
       onTransaction: ({ transaction }) => {
+        for (const step of transaction.steps) {
+          steps.push(step.toJSON());
+        }
+
         editor = editor;
         if (transaction.docChanged) {
           content = editor?.getJSON();

--- a/apps/penxle.com/src/routes/publish/+page.svelte
+++ b/apps/penxle.com/src/routes/publish/+page.svelte
@@ -19,12 +19,13 @@
   let subtitle: string;
   let editor: TiptapEditor;
   let content: JSONContent;
+  let steps: unknown[] = [];
 </script>
 
 <Helmet title="새 글 작성하기" />
 
 <main class="flex grow flex-col">
-  <Header {$query} {content} {subtitle} {title} />
-  <Editor bind:title bind:editor bind:subtitle bind:content />
+  <Header {$query} {content} {subtitle} {title} bind:steps />
+  <Editor bind:title bind:editor bind:subtitle bind:content bind:steps />
   <Toolbar {editor} />
 </main>

--- a/apps/penxle.com/src/routes/publish/Editor.svelte
+++ b/apps/penxle.com/src/routes/publish/Editor.svelte
@@ -9,6 +9,7 @@
   export let subtitle: string;
   export let content: JSONContent;
   export let editor: Editor;
+  export let steps: unknown[];
 
   let enableSubtitle = false;
   let enableCoverImage = false;
@@ -89,5 +90,5 @@
 </div>
 
 <div class="mx-auto w-3xl flex grow">
-  <TiptapEditor class="mt-4 max-w-full grow whitespace-pre-wrap" bind:editor bind:content />
+  <TiptapEditor class="mt-4 max-w-full grow whitespace-pre-wrap" bind:editor bind:content bind:steps />
 </div>

--- a/apps/penxle.com/src/routes/publish/Header.svelte
+++ b/apps/penxle.com/src/routes/publish/Header.svelte
@@ -13,6 +13,7 @@
   export let title: string;
   export let subtitle: string;
   export let content: JSONContent;
+  export let steps: unknown[];
 
   let postId: string | undefined;
   let spaceId: string;
@@ -57,8 +58,10 @@
       spaceId,
       subtitle,
       content,
+      steps,
     });
 
+    steps = [];
     postId = resp.id;
 
     return resp;


### PR DESCRIPTION
글을 수정해도 밑줄, 오래 머무른 구간 등이 남을 수 있도록 에디터 변경 내역을 서버로 전송하고 서버에서 처리함

현재 POC 구현 상태 (빠르게 수정하면 일부 수정 내역이 꼬이는 것 같기도... 테스트 좀 더 해봐야)

생각해보니 동시 편집 때문에 안 될 것 같기도... 어떻게 하는게 좋을지 좀 더 생각해봅시다