### PR TITLE
mixpanel proxy에 alb 붙임

### DIFF
--- a/apps/bedrock/pulumi/aws/alb.ts
+++ b/apps/bedrock/pulumi/aws/alb.ts
@@ -1,0 +1,49 @@
+import * as aws from '@pulumi/aws';
+import { certificates } from '$aws/acm';
+import { instances } from '$aws/ec2';
+import { securityGroups, subnets, vpc } from '$aws/vpc';
+
+const mixpanelTargetGroup = new aws.alb.TargetGroup('mixpanel-proxy', {
+  name: 'mixpanel-proxy',
+
+  vpcId: vpc.id,
+  targetType: 'instance',
+  protocol: 'HTTP',
+  port: 80,
+
+  healthCheck: {
+    matcher: '404',
+  },
+});
+
+new aws.alb.TargetGroupAttachment('mixpanel-proxy', {
+  targetGroupArn: mixpanelTargetGroup.arn,
+  targetId: instances.mixpanel.id,
+});
+
+const mixpanelLoadBalancer = new aws.alb.LoadBalancer('mixpanel-proxy', {
+  name: 'mixpanel-proxy',
+
+  subnets: [subnets.public.az1.id, subnets.public.az2.id],
+  securityGroups: [securityGroups.public.id],
+});
+
+new aws.alb.Listener('mixpanel-proxy', {
+  loadBalancerArn: mixpanelLoadBalancer.arn,
+
+  protocol: 'HTTPS',
+  port: 443,
+  sslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06',
+  certificateArn: certificates.pnxl_co.arn,
+
+  defaultActions: [
+    {
+      type: 'forward',
+      targetGroupArn: mixpanelTargetGroup.arn,
+    },
+  ],
+});
+
+export const alb = {
+  mixpanel: mixpanelLoadBalancer,
+};

--- a/apps/bedrock/pulumi/aws/ec2.ts
+++ b/apps/bedrock/pulumi/aws/ec2.ts
@@ -108,7 +108,7 @@ runcmd:
   tags: { Name: 'tailscale-exit-node-az2' },
 });
 
-const mixpanelProxy = new aws.ec2.Instance('mixpanel-proxy', {
+const mixpanel = new aws.ec2.Instance('mixpanel-proxy', {
   ami: 'ami-034bd1a31f7fbf204', // Amazon Linux 2023 AMI 2023.1.20230809.0 arm64 HVM kernel-6.1
   instanceType: 't4g.nano',
 
@@ -152,7 +152,7 @@ runcmd:
 });
 
 export const instances = {
-  mixpanelProxy,
+  mixpanel,
   rdsPooler,
 };
 

--- a/apps/bedrock/pulumi/aws/route53.ts
+++ b/apps/bedrock/pulumi/aws/route53.ts
@@ -1,6 +1,7 @@
 // spell-checker:words amazonses aspmx
 
 import * as aws from '@pulumi/aws';
+import { alb } from '$aws/alb';
 import { distributions } from '$aws/cloudfront';
 import { instances } from '$aws/ec2';
 import { elasticache } from '$aws/elasticache';
@@ -125,6 +126,19 @@ new aws.route53.Record('redis.pnxl.co', {
   ttl: 300,
 });
 
+new aws.route53.Record('x.pnxl.co', {
+  zoneId: zones.pnxl_co.zoneId,
+  type: 'A',
+  name: 'x.pnxl.co',
+  aliases: [
+    {
+      name: alb.mixpanel.dnsName,
+      zoneId: alb.mixpanel.zoneId,
+      evaluateTargetHealth: false,
+    },
+  ],
+});
+
 new aws.route53.Record('pnxl.net', {
   zoneId: zones.pnxl_net.zoneId,
   type: 'A',
@@ -143,13 +157,5 @@ new aws.route53.Record('c.pnxl.net', {
   type: 'CNAME',
   name: 'c.pnxl.net',
   records: ['penxle-data.b-cdn.net'],
-  ttl: 300,
-});
-
-new aws.route53.Record('t.pnxl.net', {
-  zoneId: zones.pnxl_net.zoneId,
-  type: 'A',
-  name: 't.pnxl.net',
-  records: [instances.mixpanelProxy.publicIp],
   ttl: 300,
 });

--- a/apps/penxle.com/src/lib/analytics/mixpanel.ts
+++ b/apps/penxle.com/src/lib/analytics/mixpanel.ts
@@ -3,7 +3,7 @@ import { PUBLIC_MIXPANEL_TOKEN } from '$env/static/public';
 
 export const setupMixpanel = () => {
   Mixpanel.init(PUBLIC_MIXPANEL_TOKEN, {
-    api_host: 'https://t.pnxl.net',
+    api_host: 'https://x.pnxl.co',
     ignore_dnt: true,
     persistence: 'localStorage',
   });


### PR DESCRIPTION
ec2에서 구동중인 mixpanel proxy에 https 인증서 부착을 위해 alb 세팅하고 `https://x.pnxl.co` 도메인 할당함