### PR TITLE
에디터 모드 전환 버튼 버그 수정

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/components/TiptapBubbleMenu.svelte
+++ b/apps/penxle.com/src/lib/tiptap/components/TiptapBubbleMenu.svelte
@@ -48,12 +48,14 @@
   });
 
   onMount(() => {
-    editor.registerPlugin(
-      new Plugin({
-        key: new PluginKey(key),
-        view: () => ({ update }),
-      }),
-    );
+    if (!editor?.isDestroyed) {
+      editor.registerPlugin(
+        new Plugin({
+          key: new PluginKey(key),
+          view: () => ({ update }),
+        }),
+      );
+    }
 
     return () => {
       editor.unregisterPlugin(key);

--- a/apps/penxle.com/src/lib/tiptap/components/TiptapFloatingMenu.svelte
+++ b/apps/penxle.com/src/lib/tiptap/components/TiptapFloatingMenu.svelte
@@ -47,12 +47,14 @@
   };
 
   onMount(() => {
-    editor.registerPlugin(
-      new Plugin({
-        key: new PluginKey(key),
-        view: () => ({ update }),
-      }),
-    );
+    if (!editor?.isDestroyed) {
+      editor.registerPlugin(
+        new Plugin({
+          key: new PluginKey(key),
+          view: () => ({ update }),
+        }),
+      );
+    }
 
     return () => {
       editor.unregisterPlugin(key);

--- a/apps/penxle.com/src/routes/publish/Header.svelte
+++ b/apps/penxle.com/src/routes/publish/Header.svelte
@@ -87,7 +87,7 @@
     handler();
   }
 
-  postKind.set(((browser && localStorage.getItem('postKind')) as PostKind) || 'article');
+  postKind.set(((browser && localStorage.getItem('postKind')) as PostKind) || 'ARTICLE');
 
   postKind.subscribe((type) => {
     if (browser) return (localStorage.postKind = type);


### PR DESCRIPTION
1. localStorage에 postKind가 지정되어있지 않을 경우 postKind를 글 모드로 지정, 이 때 대소문자 오타가 있어 수정함 (article -> ARTICLE)
 
2. 글, 그림모드 전환 시 오류 발생
<img width="588" alt="image" src="https://github.com/penxle/penxle/assets/76952602/27089364-6f07-4e0f-8d10-79544ed3077c">


아래 내용 참고해 버블메뉴, 플로팅 메뉴 코드 수정함
https://github.com/ueberdosis/tiptap/issues/1451