### PR TITLE
스페이스 설정 페이지의 버튼이 레이아웃 밖으로 넘어가는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/dashboard/settings/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/dashboard/settings/+page.svelte
@@ -146,8 +146,8 @@
   <h2>스페이스 설정</h2>
 </div>
 
-<div class="<sm:(px-4 py-6 max-w-218 bg-white border border-secondary rounded-xl)">
-  <form class="sm:(px-4 py-6 max-w-218 bg-white border border-secondary rounded-xl) sm:px-6" use:form>
+<div class="<sm:(px-4 py-6 bg-white border border-secondary rounded-xl) max-w-218">
+  <form class="sm:(p-6 max-w-218 bg-white border border-secondary rounded-xl) sm:px-6" use:form>
     <input name="spaceId" type="hidden" value={$query.space.id} />
 
     <div class="space-y-3">


### PR DESCRIPTION
<img width="1036" alt="image" src="https://github.com/penxle/penxle/assets/76952602/c3019bd4-ecec-475e-b79c-b197d09415ed">
