### PR TITLE
자동저장에도 저장 버튼에서 사용하는 플래그 값을 동일하게 참조하기

### DIFF
--- a/apps/penxle.com/src/routes/publish/Header/Header.svelte
+++ b/apps/penxle.com/src/routes/publish/Header/Header.svelte
@@ -66,7 +66,7 @@
   let currentSpace: (typeof $query.me.spaces)[0];
   $: currentSpace = $query.me.spaces[0];
 
-  $: canPublish = !!title;
+  $: canPublish = browser && !!title && content;
 
   const { form, setData } = createMutationForm({
     initialValues: { ...postOption, password: hasPassword ? '' : null },
@@ -141,7 +141,7 @@
     await revise('AUTO_SAVE');
   });
 
-  $: if (browser && title && content) {
+  $: if (canPublish) {
     handler();
   }
 


### PR DESCRIPTION
에디터 내용이 클라이언트 사이드로 주입이 되고 있는데, 내용이 보이기 전에 저장 UI가 먼저 활성화 되는 문제가 있어서,
canPublish 에 browser 값을 편입시켜서 서버사이드 시점에는 저장 UI를 비활성화하게 수정했습니다.