### PR TITLE
content.content 필드가 비어 있는 채로 임시저장 시 오류를 응답받아 수정함

### DIFF
--- a/apps/penxle.com/src/routes/publish/Header/Header.svelte
+++ b/apps/penxle.com/src/routes/publish/Header/Header.svelte
@@ -66,7 +66,7 @@
   let currentSpace: (typeof $query.me.spaces)[0];
   $: currentSpace = $query.me.spaces[0];
 
-  $: canPublish = browser && !!title && content;
+  $: canPublish = browser && !!title && content.content;
 
   const { form, setData } = createMutationForm({
     initialValues: { ...postOption, password: hasPassword ? '' : null },


### PR DESCRIPTION
{
    "errors": [
        {
            "message": "잘못된 내용이에요",
            "extensions": {
                "__app": {
                    "kind": "FormValidationError",
                    "extra": {
                        "field": "content",
                        "internal": true
                    }
                }
            }
        }
    ],
    "data": null
}