### PR TITLE
데이터독 tracing 설정 조정

### DIFF
--- a/apps/literoom/pulumi/index.ts
+++ b/apps/literoom/pulumi/index.ts
@@ -30,7 +30,7 @@ const lambda = new aws.lambda.Function('literoom', {
   handler: 'index.handler',
   sourceCodeHash: pkg.metadata.hash,
 
-  layers: ['arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:48'],
+  layers: ['arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:50'],
 
   environment: {
     variables: {
@@ -43,9 +43,7 @@ const lambda = new aws.lambda.Function('literoom', {
 
       DD_CAPTURE_LAMBDA_PAYLOAD: 'true',
       DD_LOGS_INJECTION: 'true',
-      DD_PROFILING_ENABLED: 'true',
-      DD_SERVERLESS_LOGS_ENABLED: 'true',
-      DD_TRACE_ENABLED: 'true',
+      DD_TRACE_SAMPLE_RATE: '0.1',
     },
   },
 

--- a/packages/pulumi/src/components/site.ts
+++ b/packages/pulumi/src/components/site.ts
@@ -99,7 +99,7 @@ export class Site extends pulumi.ComponentResource {
 
         publish: true,
 
-        layers: isProd ? ['arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:48'] : undefined,
+        layers: isProd ? ['arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:50'] : undefined,
 
         environment: {
           variables: {
@@ -116,6 +116,7 @@ export class Site extends pulumi.ComponentResource {
               DD_CAPTURE_LAMBDA_PAYLOAD: 'true',
               DD_DBM_PROPAGATION_MODE: 'full',
               DD_LOGS_INJECTION: 'true',
+              DD_TRACE_SAMPLE_RATE: '0.1',
             }),
           },
         },


### PR DESCRIPTION
- 람다 extension 버전 48 -> 50 업그레이드
- trace sample rate 기본값 (1.0) 에서 0.1 로 조정
- 불필요한 설정 정리