### PR TITLE
penxle.com 람다 concurrency 재조정

### DIFF
--- a/apps/penxle.com/pulumi/index.ts
+++ b/apps/penxle.com/pulumi/index.ts
@@ -15,7 +15,8 @@ const site = new penxle.Site('penxle.com', {
   },
 
   concurrency: {
-    provisioned: 2,
+    provisioned: 5,
+    reserved: 100,
   },
 
   iam: {


### PR DESCRIPTION
유저 테스트에 앞서 스테이징에서 cold start 이슈가 계속 발생해 람다 concurrency 옵션을 재조정함

- provisioned concurrency 2 -> 5 상향 ($137.27 per month)
- reserved concurrency 0 -> 100 상향
