### PR TITLE
포스트 삭제 후 redirect가 안되는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/[post]/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/[post]/+page.svelte
@@ -190,6 +190,11 @@
     mutation SpacePostPage_DeletePost_Mutation($input: DeletePostInput!) {
       deletePost(input: $input) {
         id
+
+        space {
+          id
+          slug
+        }
       }
     }
   `);
@@ -552,8 +557,8 @@
     <Button
       size="md"
       on:click={async () => {
-        await deletePost({ postId: $query.post.id });
-        await goto(`/${$query.post.space.slug}`);
+        const resp = await deletePost({ postId: $query.post.id });
+        await goto(`/${resp.space.slug}`);
         toast.success('포스트를 삭제했어요');
       }}
     >


### PR DESCRIPTION
포스트가 삭제된 이후에는 캐시 invalidation으로 인해 `$query`의 값이 더이상 존재하지 않음

그에 따라 포스트 삭제 mutation의 응답으로 space의 slug를 받아와 redirect 시행하도록 수정함
