### PR TITLE
css url path 임시로 절대 주소로 변경함

### DIFF
--- a/apps/penxle.com/src/routes/editor/ArticleFloatingMenu.svelte
+++ b/apps/penxle.com/src/routes/editor/ArticleFloatingMenu.svelte
@@ -148,19 +148,19 @@
     }
 
     &[data-kind='4'] {
-      --uno: bg-[url(/horizontal-rules/4.svg)] h-1.8rem;
+      --uno: bg-[url(https://staging.penxle.com/horizontal-rules/4.svg)] h-1.8rem;
     }
 
     &[data-kind='5'] {
-      --uno: bg-[url(/horizontal-rules/5.svg)] h-0.875rem;
+      --uno: bg-[url(https://staging.penxle.com/horizontal-rules/5.svg)] h-0.875rem;
     }
 
     &[data-kind='6'] {
-      --uno: bg-[url(/horizontal-rules/6.svg)] h-0.91027rem;
+      --uno: bg-[url(https://staging.penxle.com/horizontal-rules/6.svg)] h-0.91027rem;
     }
 
     &[data-kind='7'] {
-      --uno: bg-[url(/horizontal-rules/7.svg)] h-1.25rem;
+      --uno: bg-[url(https://staging.penxle.com/horizontal-rules/7.svg)] h-1.25rem;
     }
   }
 
@@ -170,17 +170,17 @@
     &[data-kind='2'] {
       --uno: border-l-none;
       &:before {
-        --uno: block content-[url(/blockquotes/carbon.svg)] w-2rem;
+        --uno: block content-[url(https://staging.penxle.com/blockquotes/carbon.svg)] w-2rem;
       }
     }
 
     &[data-kind='3'] {
       --uno: border-l-none;
       &:before {
-        --uno: block content-[url(/blockquotes/carbon.svg)] w-2rem m-x-auto;
+        --uno: block content-[url(https://staging.penxle.com/blockquotes/carbon.svg)] w-2rem m-x-auto;
       }
       &:after {
-        --uno: block content-[url(/blockquotes/carbon.svg)] w-2rem rotate-180 m-x-auto;
+        --uno: block content-[url(https://staging.penxle.com/blockquotes/carbon.svg)] w-2rem rotate-180 m-x-auto;
       }
     }
   }

--- a/apps/penxle.com/src/styles/prose.css
+++ b/apps/penxle.com/src/styles/prose.css
@@ -42,19 +42,19 @@
   }
 
   & hr[data-kind='4'] {
-    --uno: bg-[url(/horizontal-rules/4.svg)] h-1.8rem;
+    --uno: bg-[url(https://staging.penxle.com/horizontal-rules/4.svg)] h-1.8rem;
   }
 
   & hr[data-kind='5'] {
-    --uno: bg-[url(/horizontal-rules/5.svg)] h-0.875rem;
+    --uno: bg-[url(https://staging.penxle.com/horizontal-rules/5.svg)] h-0.875rem;
   }
 
   & hr[data-kind='6'] {
-    --uno: bg-[url(/horizontal-rules/6.svg)] h-0.91027rem;
+    --uno: bg-[url(https://staging.penxle.com/horizontal-rules/6.svg)] h-0.91027rem;
   }
 
   & hr[data-kind='7'] {
-    --uno: bg-[url(/horizontal-rules/7.svg)] h-1.25rem;
+    --uno: bg-[url(https://staging.penxle.com/horizontal-rules/7.svg)] h-1.25rem;
   }
 
   & blockquote {
@@ -64,17 +64,17 @@
   & blockquote[data-kind='2'] {
     --uno: border-l-none;
     &:before {
-      --uno: block content-[url(/blockquotes/carbon.svg)] w-2rem;
+      --uno: block content-[url(https://staging.penxle.com/blockquotes/carbon.svg)] w-2rem;
     }
   }
 
   & blockquote[data-kind='3'] {
     --uno: border-l-none;
     &:before {
-      --uno: block content-[url(/blockquotes/carbon.svg)] w-2rem m-x-auto;
+      --uno: block content-[url(https://staging.penxle.com/blockquotes/carbon.svg)] w-2rem m-x-auto;
     }
     &:after {
-      --uno: block content-[url(/blockquotes/carbon.svg)] w-2rem rotate-180 m-x-auto;
+      --uno: block content-[url(https://staging.penxle.com/blockquotes/carbon.svg)] w-2rem rotate-180 m-x-auto;
     }
   }
 


### PR DESCRIPTION
vite 문제인지 lightningcss 문제인지 모르겠는데 여튼 css 상대 url이 빌드시에 이상하게 변환되는 문제가 있어 일단 임시로 모든 url이 staging.penxle.com 바라보게 변경함

나중에 제대로 고칠 예정
