### PR TITLE
팁탭 빈 paragraph 렌더링시에 br 끼워넣음

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/nodes/paragraph.ts
+++ b/apps/penxle.com/src/lib/tiptap/nodes/paragraph.ts
@@ -32,8 +32,8 @@ export const Paragraph = Node.create({
     return [{ tag: 'p' }];
   },
 
-  renderHTML({ HTMLAttributes }) {
-    return ['p', HTMLAttributes, 0];
+  renderHTML({ node, HTMLAttributes }) {
+    return !this.editor?.isEditable && node.childCount === 0 ? ['p', HTMLAttributes, ['br']] : ['p', HTMLAttributes, 0];
   },
 
   addCommands() {


### PR DESCRIPTION
p 내용이 비어있을 경우 최초 ssr 렌더링시에 layout shift가 발생함
예시 url: https://staging.penxle.com/aaa/247818449671