### PR TITLE
$glitch에 FragmentType 유틸리티 추가

### DIFF
--- a/packages/glitch/src/codegen/entrypoint.ts
+++ b/packages/glitch/src/codegen/entrypoint.ts
@@ -15,6 +15,16 @@ export const generateMainTypes = (): AST.Program => {
       ],
       AST.b.stringLiteral('./base'),
     ),
+    AST.b.exportNamedDeclaration(
+      null,
+      [
+        AST.b.exportSpecifier.from({
+          local: AST.b.identifier('FragmentType'),
+          exported: AST.b.identifier('FragmentType'),
+        }),
+      ],
+      AST.b.stringLiteral('@penxle/glitch/runtime'),
+    ),
   ]);
 
   return program;

--- a/packages/glitch/src/codegen/fragments.ts
+++ b/packages/glitch/src/codegen/fragments.ts
@@ -4,6 +4,10 @@ import type { GlitchContext } from '../types';
 export const generateFragmentTypes = (context: GlitchContext): AST.Program => {
   const program = AST.b.program([
     AST.b.importDeclaration([AST.b.importNamespaceSpecifier(AST.b.identifier('base'))], AST.b.stringLiteral('./base')),
+    AST.b.importDeclaration(
+      [AST.b.importNamespaceSpecifier(AST.b.identifier('types'))],
+      AST.b.stringLiteral('./types'),
+    ),
   ]);
 
   for (const { kind, name } of context.artifacts) {
@@ -16,6 +20,11 @@ export const generateFragmentTypes = (context: GlitchContext): AST.Program => {
         AST.b.tsTypeAliasDeclaration(
           AST.b.identifier(name),
           AST.b.tsTypeLiteral([
+            AST.b.tsPropertySignature(
+              AST.b.stringLiteral(' $fragmentType'),
+              AST.b.tsTypeAnnotation(AST.b.tsTypeReference(AST.b.identifier(`types.${name}`))),
+              true,
+            ),
             AST.b.tsPropertySignature(
               AST.b.stringLiteral(' $fragmentRefs'),
               AST.b.tsTypeAnnotation(

--- a/packages/glitch/src/runtime/index.ts
+++ b/packages/glitch/src/runtime/index.ts
@@ -22,5 +22,5 @@ export const fragment = (ref: unknown) => {
 };
 
 export { createQueryStore } from '../store/query';
-export type { MakeRequired } from '../types';
+export type { FragmentType, MakeRequired } from '../types';
 export type { TypedDocumentNode } from '@graphql-typed-document-node/core';

--- a/packages/glitch/src/types.ts
+++ b/packages/glitch/src/types.ts
@@ -8,6 +8,11 @@ export type MakeRequired<T, K extends string> = T & {
     : MakeRequired<T[P], K extends `${Exclude<P, symbol>}.${infer R}` ? R : never>;
 };
 
+export type FragmentType<T extends { ' $fragmentType'?: unknown }> = Omit<
+  NonNullable<T[' $fragmentType']>,
+  ' $fragmentName'
+>;
+
 export type ValidOperationDocumentNode = {
   kind: graphql.Kind.DOCUMENT;
   definitions: [graphql.OperationDefinitionNode & { name: graphql.NameNode }];


### PR DESCRIPTION
```
import type { FragmentType, Image_image } from '$glitch';

type A = FragmentType<Image_image>;
// A = { id: string; placeholder: string; url: string; ... }
```
