### PR TITLE
썸네일 플레이스홀더 이미지 필요하지 않음

### DIFF
--- a/apps/penxle.com/src/lib/components/pages/PostManageTable.svelte
+++ b/apps/penxle.com/src/lib/components/pages/PostManageTable.svelte
@@ -2,7 +2,6 @@
   import { PostVisibility } from '@prisma/client';
   import clsx from 'clsx';
   import dayjs from 'dayjs';
-  import Logo from '$assets/icons/logo.svg?component';
   import { fragment, graphql } from '$glitch';
   import { Avatar, Badge, Button, Image, Modal, Tag, Tooltip } from '$lib/components';
   import { Checkbox, Switch } from '$lib/components/forms';
@@ -250,9 +249,7 @@
           target="_blank"
         >
           {#if post.revision.thumbnail}
-            <Image class="square-2.625rem rounded-2 min-w-1rem" $image={post.revision.thumbnail.thumbnail} />
-          {:else}
-            <Logo class="square-2.625rem min-w-1rem" />
+            <Image class="square-2.625rem rounded-2" $image={post.revision.thumbnail.thumbnail} />
           {/if}
           <dl class="truncate [&>dt]:truncate">
             <dt class="body-15-b">


### PR DESCRIPTION
![](https://gist.github.com/assets/5278201/a25b1317-6b78-4f41-a41c-02aa27226e86)

디자인 상에 썸네일이 없는 경우 없는 채로 놔두고 있어서 수정하게
되었습니다.