### PR TITLE
포스트 DB 구조 변경

### DIFF
--- a/apps/penxle.com/prisma/schema.prisma
+++ b/apps/penxle.com/prisma/schema.prisma
@@ -65,11 +65,10 @@ model Image {
   hash        String
   createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  profilesUsingThisAsAvatar               Profile[]
-  spacesUsingThisAsIcon                   Space[]
-  postRevisionsUsingThisAsImage           PostRevisionImage[]
-  postRevisionsUsingThisAsThumbnail       PostRevisionThumbnail[]
-  postRevisionsUsingThisAsThumbnailOrigin PostRevisionThumbnail[] @relation("origin")
+  profilesUsingThisAsAvatar                 Profile[]
+  spacesUsingThisAsIcon                     Space[]
+  postRevisionsUsingThisAsCroppedThumbnail  PostRevision[]
+  postRevisionsUsingThisAsOriginalThumbnail PostRevision[] @relation("origin")
 
   @@map("images")
 }
@@ -123,41 +122,36 @@ model PointTransaction {
 }
 
 model Post {
-  id        String      @id
-  permalink String      @unique
-  shortlink String      @unique
-  spaceId   String      @map("space_id")
-  space     Space       @relation(fields: [spaceId], references: [id])
-  memberId  String      @map("member_id")
-  member    SpaceMember @relation(fields: [memberId], references: [id])
-  userId    String      @map("user_id")
-  user      User        @relation(fields: [userId], references: [id])
-  optionId  String      @unique @map("option_id")
-  option    PostOption  @relation(fields: [optionId], references: [id])
-  state     PostState
-  createdAt DateTime    @default(now()) @map("created_at") @db.Timestamptz
+  id                  String        @id
+  permalink           String        @unique
+  spaceId             String        @map("space_id")
+  space               Space         @relation(fields: [spaceId], references: [id])
+  memberId            String        @map("member_id")
+  member              SpaceMember   @relation(fields: [memberId], references: [id])
+  userId              String        @map("user_id")
+  user                User          @relation(fields: [userId], references: [id])
+  publishedRevisionId String?       @map("published_revision_id")
+  publishedRevision   PostRevision? @relation(name: "published_revision", fields: [publishedRevisionId], references: [id])
 
-  likes          PostLike[]
-  revisions      PostRevision[]
-  views          PostView[]
-  purchases      PostPurchase[]
-  reactions      PostReaction[]
-  contentFilters PostContentFilter[]
-  tags           PostTag[]
-  bookmarks      BookmarkGroupPost[]
+  state                  PostState
+  contentFilters         ContentFilterCategory[] @map("content_filters")
+  visibility             PostVisibility
+  discloseStats          Boolean                 @map("disclose_stats")
+  receiveFeedback        Boolean                 @map("receive_feedback")
+  receivePatronage       Boolean                 @map("receive_patronage")
+  receiveTagContribution Boolean                 @map("receive_tag_contribution")
+  password               String?
+  createdAt              DateTime                @default(now()) @map("created_at") @db.Timestamptz
+  publishedAt            DateTime?               @map("published_at") @db.Timestamptz
+
+  likes     PostLike[]
+  revisions PostRevision[]
+  views     PostView[]
+  purchases PostPurchase[]
+  reactions PostReaction[]
+  bookmarks BookmarkGroupPost[]
 
   @@map("posts")
-}
-
-model PostContentFilter {
-  id        String                @id
-  postId    String                @map("post_id")
-  post      Post                  @relation(fields: [postId], references: [id])
-  category  ContentFilterCategory
-  createdAt DateTime              @default(now()) @map("created_at") @db.Timestamptz
-
-  @@unique([postId, category])
-  @@map("post_content_filters")
 }
 
 model PostLike {
@@ -170,22 +164,6 @@ model PostLike {
 
   @@unique([postId, userId])
   @@map("post_likes")
-}
-
-model PostOption {
-  id                     String         @id
-  price                  Int?
-  visibility             PostVisibility
-  discloseStats          Boolean        @map("disclose_stats")
-  receiveFeedback        Boolean        @map("receive_feedback")
-  receivePatronage       Boolean        @map("receive_patronage")
-  receiveTagContribution Boolean        @map("receive_tag_contribution")
-  password               String?
-  createdAt              DateTime       @default(now()) @map("created_at") @db.Timestamptz
-
-  post Post?
-
-  @@map("post_options")
 }
 
 model PostPurchase {
@@ -217,66 +195,61 @@ model PostReaction {
 }
 
 model PostRevision {
-  id          String                  @id
-  postId      String                  @map("post_id")
-  post        Post                    @relation(fields: [postId], references: [id])
-  userId      String                  @map("user_id")
-  user        User                    @relation(fields: [userId], references: [id])
-  kind        PostRevisionKind
-  contentKind PostRevisionContentKind
-  title       String
-  subtitle    String?
-  content     Json
-  paidContent Json?                   @map("paid_content")
-  createdAt   DateTime                @default(now()) @map("created_at") @db.Timestamptz
+  id            String               @id
+  postId        String               @map("post_id")
+  post          Post                 @relation(fields: [postId], references: [id])
+  userId        String               @map("user_id")
+  user          User                 @relation(fields: [userId], references: [id])
+  freeContentId String               @map("free_content_id")
+  freeContent   PostRevisionContent  @relation(name: "free_content", fields: [freeContentId], references: [id])
+  paidContentId String?              @map("paid_content_id")
+  paidContent   PostRevisionContent? @relation(name: "paid_content", fields: [paidContentId], references: [id])
 
-  thumbnail PostRevisionThumbnail?
-  images    PostRevisionImage[]
-  purchases PostPurchase[]
+  contentKind PostRevisionContentKind
+  price       Int?
+
+  croppedThumbnailId  String? @map("cropped_thumbnail_id")
+  croppedThumbnail    Image?  @relation(fields: [croppedThumbnailId], references: [id])
+  originalThumbnailId String? @map("original_thumbnail_id")
+  originalThumbnail   Image?  @relation("origin", fields: [originalThumbnailId], references: [id])
+  thumbnailBounds     Json?
+
+  kind      PostRevisionKind
+  title     String
+  subtitle  String?
+  createdAt DateTime         @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime         @default(now()) @map("updated_at") @db.Timestamptz
+
+  purchases                         PostPurchase[]
+  tags                              PostRevisionTag[]
+  postsUsingThisAsPublishedRevision Post[]            @relation(name: "published_revision")
 
   @@index([createdAt])
   @@map("post_revisions")
 }
 
-model PostRevisionThumbnail {
-  id          String       @id
-  revisionId  String       @unique @map("revision_id")
-  revision    PostRevision @relation(fields: [revisionId], references: [id])
-  thumbnailId String       @map("thumbnail_id")
-  thumbnail   Image        @relation(fields: [thumbnailId], references: [id])
-  originId    String       @map("origin_id")
-  origin      Image        @relation("origin", fields: [originId], references: [id])
-  bounds      Json
-  createdAt   DateTime     @default(now()) @map("created_at") @db.Timestamptz
+model PostRevisionContent {
+  id        String   @id
+  hash      String   @unique
+  data      Json
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  @@map("post_revision_thumbnails")
+  revisionsUsingThisAsFreeContent PostRevision[] @relation("free_content")
+  revisionsUsingThisAsPaidContent PostRevision[] @relation("paid_content")
+
+  @@map("post_revision_contents")
 }
 
-model PostRevisionImage {
+model PostRevisionTag {
   id         String       @id
   revisionId String       @map("revision_id")
   revision   PostRevision @relation(fields: [revisionId], references: [id])
-  imageId    String       @map("image_id")
-  image      Image        @relation(fields: [imageId], references: [id])
+  tagId      String       @map("tag_id")
+  tag        Tag          @relation(fields: [tagId], references: [id])
   createdAt  DateTime     @default(now()) @map("created_at") @db.Timestamptz
 
-  @@unique([revisionId, imageId])
-  @@map("post_revision_images")
-}
-
-model PostTag {
-  id        String   @id
-  postId    String   @map("post_id")
-  post      Post     @relation(fields: [postId], references: [id])
-  tagId     String   @map("tag_id")
-  tag       Tag      @relation(fields: [tagId], references: [id])
-  userId    String   @map("user_id")
-  user      User     @relation(fields: [userId], references: [id])
-  pinned    Boolean  @default(false)
-  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
-
-  @@unique([postId, tagId])
-  @@map("post_tags")
+  @@unique([revisionId, tagId])
+  @@map("post_revision_tags")
 }
 
 model PostView {
@@ -442,12 +415,12 @@ model Tag {
   name      String   @unique
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  wiki      TagWiki?
-  parents   TagHierarchy[] @relation("parents")
-  children  TagHierarchy[] @relation("children")
-  userMutes UserTagMute[]
-  posts     PostTag[]
-  followers TagFollow[]
+  wiki          TagWiki?
+  parents       TagHierarchy[]    @relation("parents")
+  children      TagHierarchy[]    @relation("children")
+  userMutes     UserTagMute[]
+  postRevisions PostRevisionTag[]
+  followers     TagFollow[]
   // spacesUsingThis SpaceTag[]
 
   @@index(createdAt)
@@ -539,7 +512,6 @@ model User {
   spaceBlockedBy           SpaceUserBlock[]
   spaceMasquerades         SpaceMasquerade[]
   postReactions            PostReaction[]
-  postTags                 PostTag[]
   bookmarks                BookmarkGroup[]
 
   @@index([email, state])
@@ -709,6 +681,7 @@ enum PostRevisionKind {
   AUTO_SAVE
   MANUAL_SAVE
   PUBLISHED
+  ARCHIVED
 
   @@map("_post_revision_kind")
 }

--- a/apps/penxle.com/schema.graphql
+++ b/apps/penxle.com/schema.graphql
@@ -198,6 +198,7 @@ type Mutation {
   muteTag(input: MuteTagInput!): Tag!
   prepareFileUpload: PrepareFileUploadResult!
   prepareImageUpload: PrepareImageUploadResult!
+  publishPost(input: PublishPostInput!): Post!
   purchasePoint(input: PurchasePointInput!): PointPurchase!
   purchasePost(input: PurchasePostInput!): Post!
   removeSpaceMember(input: RemoveSpaceMemberInput!): SpaceMember
@@ -281,33 +282,28 @@ type Post {
   bookmarked: Boolean!
   contentFilters: [ContentFilterCategory!]!
   createdAt: DateTime!
+  discloseStats: Boolean!
   draftRevision(revisionId: ID): PostRevision!
+  hasPassword: Boolean!
   id: ID!
   likeCount: Int!
   liked: Boolean!
   member: SpaceMember!
-  option: PostOption!
   permalink: String!
+  publishedAt: DateTime
+  publishedRevision: PostRevision
   purchasedAt: DateTime
-  purchasedRevision: PostRevision!
+  purchasedRevision: PostRevision @deprecated(reason: "Use PostPurchase.revision instead")
   reactions: [PostReaction!]!
-  revision: PostRevision!
-  revisionList: [PostRevision!]!
-  shortlink: String!
-  space: Space!
-  state: PostState!
-  tags: [PostTag!]!
-  unlocked: Boolean!
-  viewCount: Int!
-}
-
-type PostOption {
-  discloseStats: Boolean!
-  hasPassword: Boolean!
-  id: ID!
   receiveFeedback: Boolean!
   receivePatronage: Boolean!
   receiveTagContribution: Boolean!
+  revisions: [PostRevision!]!
+  shortlink: String!
+  space: Space!
+  state: PostState!
+  unlocked: Boolean!
+  viewCount: Int!
   visibility: PostVisibility!
 }
 
@@ -322,12 +318,16 @@ type PostRevision {
   content: JSON!
   contentKind: PostRevisionContentKind!
   createdAt: DateTime!
+  croppedThumbnail: Image
   id: ID!
   kind: PostRevisionKind!
+  originalThumbnail: Image
   previewText: String!
   subtitle: String
-  thumbnail: PostRevisionThumbnail
+  tags: [Tag!]!
+  thumbnailBounds: JSON
   title: String!
+  updatedAt: DateTime!
 }
 
 enum PostRevisionContentKind {
@@ -336,28 +336,16 @@ enum PostRevisionContentKind {
 }
 
 enum PostRevisionKind {
+  ARCHIVED
   AUTO_SAVE
   MANUAL_SAVE
   PUBLISHED
-}
-
-type PostRevisionThumbnail {
-  bounds: JSON!
-  id: ID!
-  origin: Image!
-  thumbnail: Image!
 }
 
 enum PostState {
   DELETED
   DRAFT
   PUBLISHED
-}
-
-type PostTag {
-  id: ID!
-  pinned: Boolean!
-  tag: Tag!
 }
 
 enum PostVisibility {
@@ -389,6 +377,17 @@ type ProvisionedUser {
   name: String
 }
 
+input PublishPostInput {
+  contentFilters: [ContentFilterCategory!]!
+  discloseStats: Boolean!
+  password: String
+  receiveFeedback: Boolean!
+  receivePatronage: Boolean!
+  receiveTagContribution: Boolean!
+  revisionId: ID!
+  visibility: PostVisibility!
+}
+
 input PurchasePointInput {
   paymentMethod: PaymentMethod!
   pointAgreement: Boolean!
@@ -403,7 +402,6 @@ input PurchasePostInput {
 type Query {
   auth(scope: AuthScope!): Void
   authLayoutBackgroundImage: Image
-  draftRevision(revisionId: ID!): PostRevision!
   flash: Flash
   hello(name: String!): String!
   me: User
@@ -436,6 +434,7 @@ input RevisePostInput {
   revisionKind: PostRevisionKind!
   spaceId: ID!
   subtitle: String
+  tags: [String!]! = []
   thumbnailBounds: JSON
   thumbnailId: ID
   title: String!
@@ -580,12 +579,10 @@ input UnsetParentTagInput {
 input UpdatePostOptionsInput {
   contentFilters: [ContentFilterCategory!]
   discloseStats: Boolean
-  password: String
   postId: ID!
   receiveFeedback: Boolean
   receivePatronage: Boolean
   receiveTagContribution: Boolean
-  tags: [String!]
   visibility: PostVisibility
 }
 

--- a/apps/penxle.com/src/lib/components/Feed.svelte
+++ b/apps/penxle.com/src/lib/components/Feed.svelte
@@ -20,29 +20,22 @@
         permalink
         blurred
         purchasedAt
+        publishedAt
 
-        tags {
-          id
-
-          tag {
-            id
-            name
-          }
-        }
-
-        revision {
+        publishedRevision @_required {
           id
           title
           previewText
           createdAt
 
-          thumbnail {
+          croppedThumbnail {
             id
+            ...Image_image
+          }
 
-            thumbnail {
-              id
-              ...Image_image
-            }
+          tags {
+            id
+            name
           }
         }
 
@@ -96,7 +89,7 @@
           {dayjs($post.purchasedAt).formatAsDate()}에 결제된 글 보기
         </Link>
       {:else}
-        <time class="body-13-m text-secondary">{dayjs($post.revision.createdAt).formatAsDate()}</time>
+        <time class="body-13-m text-secondary">{dayjs($post.publishedAt).formatAsDate()}</time>
       {/if}
     </div>
     <button type="button">
@@ -107,7 +100,7 @@
 
 <div class="flex flex-col gap-2 w-full bg-cardprimary sm:(border border-secondary rounded-2xl)">
   <a class="pt-3 px-6 sm:pt-6" href={`/${$post.space.slug}/${$post.permalink}`}>
-    <h2 class="title-20-eb">{$post.revision.title}</h2>
+    <h2 class="title-20-eb">{$post.publishedRevision.title}</h2>
 
     <div class="relative">
       <article
@@ -117,13 +110,13 @@
         )}
       >
         <p class="grow bodylong-16-m text-secondary break-all line-clamp-6 whitespace-pre-line">
-          {$post.revision.previewText}
+          {$post.publishedRevision.previewText}
         </p>
 
-        {#if $post.revision.thumbnail}
+        {#if $post.publishedRevision.croppedThumbnail}
           <Image
             class="h-11.25rem sm:aspect-square object-cover rounded-lg flex-none"
-            $image={$post.revision.thumbnail.thumbnail}
+            $image={$post.publishedRevision.croppedThumbnail}
           />
         {/if}
       </article>
@@ -143,11 +136,11 @@
   </a>
 
   <div class="flex flex-wrap gap-1.5 pb-3 px-6 sm:pb-6">
-    {#each $post.tags.slice(0, 4) as { tag } (tag.id)}
+    {#each $post.publishedRevision.tags.slice(0, 4) as tag (tag.id)}
       <Tag href={`tag/${tag.name}`} size="sm">#{tag.name}</Tag>
     {/each}
-    {#if $post.tags.length > 4}
-      <Tag size="sm">+{$post.tags.length - 4}개의 태그</Tag>
+    {#if $post.publishedRevision.tags.length > 4}
+      <Tag size="sm">+{$post.publishedRevision.tags.length - 4}개의 태그</Tag>
     {/if}
   </div>
 </div>

--- a/apps/penxle.com/src/lib/server/graphql/schemas/bookmark.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/bookmark.ts
@@ -127,9 +127,7 @@ builder.mutationFields((t) => ({
         select: {
           spaceId: true,
           state: true,
-          option: {
-            select: { visibility: true },
-          },
+          visibility: true,
         },
         where: {
           id: input.postId,
@@ -142,7 +140,7 @@ builder.mutationFields((t) => ({
         throw new NotFoundError();
       }
 
-      if (post.option.visibility === 'SPACE') {
+      if (post.visibility === 'SPACE') {
         const meAsMember = await db.spaceMember.exists({
           where: {
             spaceId: post.spaceId,

--- a/apps/penxle.com/src/lib/server/graphql/schemas/space.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/space.ts
@@ -120,11 +120,9 @@ builder.prismaObject('Space', {
             // input.mine이 true인데 meAsMember가 null이면 위에서 return되서 여기까지 안옴
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             memberId: input.mine ? meAsMember!.id : undefined,
-            option: {
-              visibility: meAsMember ? undefined : 'PUBLIC',
-            },
+            visibility: meAsMember ? undefined : 'PUBLIC',
           },
-          orderBy: { createdAt: 'desc' },
+          orderBy: { publishedAt: 'desc' },
         });
       },
     }),

--- a/apps/penxle.com/src/lib/server/graphql/schemas/user.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/user.ts
@@ -152,23 +152,16 @@ builder.prismaObject('User', {
             userId: user.id,
             post: {
               state: 'PUBLISHED',
-              space: { state: 'ACTIVE' },
-              AND: [
+              space: {
+                state: 'ACTIVE',
+                OR: [{ visibility: 'PUBLIC' }, { visibility: 'PRIVATE', members: { some: { userId: user.id } } }],
+              },
+              OR: [
+                { visibility: 'PUBLIC' },
+                { visibility: 'UNLISTED' },
                 {
-                  OR: [
-                    { option: { visibility: 'PUBLIC' } },
-                    { option: { visibility: 'UNLISTED' } },
-                    {
-                      option: { visibility: 'SPACE' },
-                      space: { members: { some: { userId: user.id } } },
-                    },
-                  ],
-                },
-                {
-                  OR: [
-                    { space: { visibility: 'PUBLIC' } },
-                    { space: { visibility: 'PRIVATE', members: { some: { userId: user.id } } } },
-                  ],
+                  visibility: 'SPACE',
+                  space: { members: { some: { userId: user.id } } },
                 },
               ],
             },
@@ -196,23 +189,16 @@ builder.prismaObject('User', {
             userId: user.id,
             post: {
               state: 'PUBLISHED',
-              space: { state: 'ACTIVE' },
-              AND: [
+              space: {
+                state: 'ACTIVE',
+                OR: [{ visibility: 'PUBLIC' }, { visibility: 'PRIVATE', members: { some: { userId: user.id } } }],
+              },
+              OR: [
+                { visibility: 'PUBLIC' },
+                { visibility: 'UNLISTED' },
                 {
-                  OR: [
-                    { option: { visibility: 'PUBLIC' } },
-                    { option: { visibility: 'UNLISTED' } },
-                    {
-                      option: { visibility: 'SPACE' },
-                      space: { members: { some: { userId: user.id } } },
-                    },
-                  ],
-                },
-                {
-                  OR: [
-                    { space: { visibility: 'PUBLIC' } },
-                    { space: { visibility: 'PRIVATE', members: { some: { userId: user.id } } } },
-                  ],
+                  visibility: 'SPACE',
+                  space: { members: { some: { userId: user.id } } },
                 },
               ],
             },

--- a/apps/penxle.com/src/lib/server/rest/routes/shortlink.ts
+++ b/apps/penxle.com/src/lib/server/rest/routes/shortlink.ts
@@ -1,4 +1,5 @@
 import { status } from 'itty-router';
+import { base36To10 } from '$lib/utils';
 import { createRouter } from '../router';
 import type { IRequest } from 'itty-router';
 
@@ -10,9 +11,11 @@ shortlink.get('/shortlink/:shortlink', async (request, { db }) => {
     throw new Error('link is required');
   }
 
+  const permalink = base36To10(shortlink);
+
   const post = await db.post.findUnique({
-    select: { permalink: true, space: { select: { slug: true } } },
-    where: { shortlink },
+    select: { space: { select: { slug: true } } },
+    where: { permalink },
   });
 
   if (!post) {
@@ -21,7 +24,7 @@ shortlink.get('/shortlink/:shortlink', async (request, { db }) => {
 
   return status(307, {
     headers: {
-      Location: `/${post.space.slug}/${post.permalink}`,
+      Location: `/${post.space.slug}/${permalink}`,
     },
   });
 });

--- a/apps/penxle.com/src/lib/tiptap/node-views/access-barrier/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/access-barrier/Component.svelte
@@ -29,7 +29,7 @@
       purchasePost(input: $input) {
         id
 
-        revision {
+        publishedRevision {
           id
           content
         }

--- a/apps/penxle.com/src/lib/utils/number.ts
+++ b/apps/penxle.com/src/lib/utils/number.ts
@@ -1,4 +1,5 @@
 const nf = new Intl.NumberFormat('en-US');
+const base36Characters = '0123456789abcdefghijklmnopqrstuvwxyz';
 
 export const clamp = (value: number, min: number, max: number) => {
   return Math.min(Math.max(value, min), max);
@@ -26,4 +27,13 @@ export const humanizeNumber = (value: number) => {
 
 export const calcurateReadingTime = (characterCount: number) => {
   return comma(Math.ceil(characterCount / 700));
+};
+
+export const base36To10 = (value: string) => {
+  let result = 0n;
+  for (const digit of value) {
+    result = result * 36n + BigInt(base36Characters.indexOf(digit));
+  }
+
+  return result.toString();
 };

--- a/apps/penxle.com/src/lib/validations/post.ts
+++ b/apps/penxle.com/src/lib/validations/post.ts
@@ -1,33 +1,30 @@
 import { z } from 'zod';
 
-export const UpdatePostOptionsInputSchema = z.object({
-  contentFilters: z
-    .array(
-      z.enum([
-        'ADULT',
-        'CRIME',
-        'CRUELTY',
-        'GAMBLING',
-        'GROSSNESS',
-        'HORROR',
-        'INSULT',
-        'OTHER',
-        'PHOBIA',
-        'TRAUMA',
-        'VIOLENCE',
-      ]),
-    )
-    .optional(),
-  discloseStats: z.boolean().optional(),
+export const PublishPostInputSchema = z.object({
+  contentFilters: z.array(
+    z.enum([
+      'ADULT',
+      'CRIME',
+      'CRUELTY',
+      'GAMBLING',
+      'GROSSNESS',
+      'HORROR',
+      'INSULT',
+      'OTHER',
+      'PHOBIA',
+      'TRAUMA',
+      'VIOLENCE',
+    ]),
+  ),
+  discloseStats: z.boolean(),
   password: z
     .union([z.string().regex(/^[!-~]*$/, '영문, 숫자, 키보드 특수문자만 입력할 수 있어요'), z.null()])
     .optional(),
-  postId: z.string(),
-  receiveFeedback: z.boolean().optional(),
-  receivePatronage: z.boolean().optional(),
-  receiveTagContribution: z.boolean().optional(),
-  tags: z.array(z.string()).optional(),
-  visibility: z.enum(['PUBLIC', 'SPACE', 'UNLISTED']).optional(),
+  revisionId: z.string(),
+  receiveFeedback: z.boolean(),
+  receivePatronage: z.boolean(),
+  receiveTagContribution: z.boolean(),
+  visibility: z.enum(['PUBLIC', 'SPACE', 'UNLISTED']),
 });
 
-export type UpdatePostOptionsInput = z.infer<typeof UpdatePostOptionsInputSchema>;
+export type PublishPostInput = z.infer<typeof PublishPostInputSchema>;

--- a/apps/penxle.com/src/routes/(default)/[space]/GalleryPost.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/GalleryPost.svelte
@@ -72,7 +72,7 @@
       purchasePost(input: $input) {
         id
 
-        revision {
+        publishedRevision {
           id
           content
         }

--- a/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
@@ -61,22 +61,8 @@
           unlocked
           contentFilters
           blurred
-
-          option {
-            id
-            hasPassword
-            receiveFeedback
-          }
-
-          tags {
-            id
-            pinned
-
-            tag {
-              id
-              name
-            }
-          }
+          hasPassword
+          receiveFeedback
 
           reactions {
             id
@@ -124,7 +110,7 @@
   $: postRevision = fragment(
     _postRevision,
     graphql(`
-      fragment Post_postRevision on PostRevision {
+      fragment Post_postRevision on PostRevision @_required {
         id
         title
         subtitle
@@ -134,13 +120,14 @@
         contentKind
         previewText
 
-        thumbnail {
+        croppedThumbnail {
           id
+          url
+        }
 
-          thumbnail {
-            id
-            url
-          }
+        tags {
+          id
+          name
         }
       }
     `),
@@ -200,7 +187,7 @@
         id
         unlocked
 
-        revision {
+        publishedRevision {
           id
           content
         }
@@ -280,7 +267,7 @@
 
 <Helmet
   description={$postRevision.previewText}
-  image={$postRevision.thumbnail?.thumbnail.url ?? 'https://pnxl.net/assets/opengraph/default-cover.png'}
+  image={$postRevision.croppedThumbnail?.url ?? 'https://pnxl.net/assets/opengraph/default-cover.png'}
   title={$postRevision.title}
 />
 
@@ -402,7 +389,7 @@
       </div>
     {/if}
 
-    {#if !$query.post.option.hasPassword || $query.post.space.meAsMember || $query.post.unlocked}
+    {#if !$query.post.hasPassword || $query.post.space.meAsMember || $query.post.unlocked}
       <div class="relative">
         {#if $postRevision.contentKind === 'ARTICLE'}
           <article
@@ -495,7 +482,7 @@
     <hr class="w-full border-color-alphagray-10" />
 
     <div class="flex gap-2 flex-wrap">
-      {#each $query.post.tags as { tag } (tag.id)}
+      {#each $postRevision.tags as tag (tag.id)}
         <Tag size="sm">
           #{tag.name}
         </Tag>
@@ -514,11 +501,11 @@
         </button>
       {:else}
         <Tooltip
-          enabled={!$query.post.option.receiveFeedback}
+          enabled={!$query.post.receiveFeedback}
           message="피드백 받기를 설정하지 않은 포스트에요"
           placement="top"
         >
-          <EmojiPicker {$query} disabled={!$query.post.option.receiveFeedback} />
+          <EmojiPicker {$query} disabled={!$query.post.receiveFeedback} />
         </Tooltip>
       {/if}
 

--- a/apps/penxle.com/src/routes/(default)/[space]/Toolbar.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/Toolbar.svelte
@@ -27,16 +27,12 @@
           id
           likeCount
           liked
+          receiveFeedback
 
           reactions {
             id
             emoji
             mine
-          }
-
-          option {
-            id
-            receiveFeedback
           }
         }
 
@@ -146,11 +142,11 @@
         {/if}
 
         <Tooltip
-          enabled={!$query.post.option.receiveFeedback}
+          enabled={!$query.post.receiveFeedback}
           message="피드백 받기를 설정하지 않은 포스트에요"
           placement="top"
         >
-          <EmojiPicker {$query} disabled={!$query.post.option.receiveFeedback} variant="toolbar" />
+          <EmojiPicker {$query} disabled={!$query.post.receiveFeedback} variant="toolbar" />
         </Tooltip>
       </div>
 

--- a/apps/penxle.com/src/routes/(default)/[space]/[post]/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/[post]/+page.svelte
@@ -13,7 +13,7 @@
       post(permalink: $permalink) {
         id
 
-        revision {
+        publishedRevision @_required {
           id
           ...Post_postRevision
         }
@@ -38,4 +38,4 @@
   });
 </script>
 
-<Post $postRevision={$query.post.revision} {$query} />
+<Post $postRevision={$query.post.publishedRevision} {$query} />

--- a/apps/penxle.com/src/routes/(default)/[space]/purchased/[post]/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/purchased/[post]/+page.svelte
@@ -7,7 +7,7 @@
       post(permalink: $permalink) {
         id
 
-        purchasedRevision {
+        purchasedRevision @_required {
           id
           ...Post_postRevision
         }

--- a/apps/penxle.com/src/routes/editor/[permalink]/+page.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/+page.svelte
@@ -23,13 +23,8 @@
           content
           title
           subtitle
-        }
 
-        tags {
-          id
-          pinned
-
-          tag {
+          tags {
             id
             name
           }
@@ -55,7 +50,7 @@
     title = $query.post.draftRevision.title;
     subtitle = $query.post.draftRevision.subtitle ?? null;
     content = $query.post.draftRevision.content;
-    tags = $query.post.tags.map(({ tag }) => tag.name);
+    tags = $query.post.draftRevision.tags.map((tag) => tag.name);
     kind = $query.post.draftRevision.contentKind;
   }
 </script>


### PR DESCRIPTION
# 프론트엔드 변경점!! (중요)
## `Post`
- `publishedAt`이 최초 발행 시간입니다!
- 글 조회 때는 `publishedRevision`, 편집 때는 `draftRevision`(선택 인수로 `revisionId`를 넣을 수 있어요), 버전 목록 볼 때는 `revisions` 조회하세요
- 태그가 리비전으로 이동했습니다!
## `PostRevision`
- 버전 목록에서 편집 시간을 조회할 때는 `updatedAt`을 사용해주세요! (리비전이 재사용되기 때문에 `createdAt`은 부정확할 수 있어요)
- 수정시 썸네일 삭제는 아예 `thumbnailId` 비워두기, 썸네일 그대로는 `thumbnailId`만 채워두고 `thumbnailBounds`만 비워두기, 썸네일 수정은 둘다 채워주세요!
- 비밀번호 역시 그대로 유지는 공백 문자열, 변경은 변경할 비밀번호, 비밀번호 삭제는 `null`입니다!
- `tags`가 이제 `[PostTag]`가 아니라 `[Tag]`를 리턴해요 (여기에선 무조건 작성자가 설정한 태그만 올라가요!)