### PR TITLE
포스트 관리 탭 클릭 시 다른 페이지로 이동하는 오류 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/dashboard/posts/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/dashboard/posts/+layout.svelte
@@ -13,10 +13,8 @@
   <h1 class="title-20-eb">포스트 관리</h1>
   <div>
     <TabHead class="border-none" variant="secondary">
-      <TabHeadItem id={0} href="/{$page.params.slug}/dashboard/posts">포스트</TabHeadItem>
-      <!-- <TabHeadItem id={1} href="/{$query.space.slug}/dashboard/posts/collections">
-        컬렉션
-      </TabHeadItem> -->
+      <TabHeadItem id={0} href="/{$page.params.space}/dashboard/posts">포스트</TabHeadItem>
+      <!-- <TabHeadItem id={1} href="/{$page.params.space}/dashboard/posts/collections">컬렉션</TabHeadItem> -->
     </TabHead>
     <hr class="w-full border-color-alphagray-10" />
   </div>


### PR DESCRIPTION
`page.params.slug` -> `undefined`여서 탭 클릭 시 `undefined/dashboard~`로 이동하는 문제 수정함