### PR TITLE
manual query 구현

### DIFF
--- a/apps/penxle.com/schema.graphql
+++ b/apps/penxle.com/schema.graphql
@@ -382,6 +382,7 @@ type Query {
   authLayoutBackgroundImage: Image
   draftRevision(revisionId: ID!): PostRevision!
   flash: Flash
+  hello(name: String!): String!
   me: User
   pointPurchase(paymentKey: String!): PointPurchase!
   post(permalink: String!): Post!

--- a/apps/penxle.com/src/lib/server/graphql/schemas/playground.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/playground.ts
@@ -8,6 +8,11 @@ import { builder } from '../builder';
  */
 
 builder.queryFields((t) => ({
+  hello: t.string({
+    args: { name: t.arg.string() },
+    resolve: (_, args) => `Hello, ${args.name}`,
+  }),
+
   randomAvatars: t.stringList({
     resolve: async () => {
       const buffers = await Promise.all([...R.range(1, 16)].map(() => createRandomAvatar()));

--- a/apps/penxle.com/src/routes/_playground/manual-query/+page.svelte
+++ b/apps/penxle.com/src/routes/_playground/manual-query/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import Test from './Test.svelte';
+</script>
+
+<Test />

--- a/apps/penxle.com/src/routes/_playground/manual-query/Test.svelte
+++ b/apps/penxle.com/src/routes/_playground/manual-query/Test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { graphql } from '$glitch';
+
+  $: query = graphql(`
+    query PlaygroundManualQueryPage_Query($name: String!) @_manual {
+      hello(name: $name)
+    }
+  `);
+
+  $: console.log($query);
+
+  onMount(() => {
+    console.log('onMount');
+
+    let i = 1;
+    query.refetch({ name: `${i++}` });
+    setInterval(() => {
+      query.refetch({ name: `${i++}` });
+    }, 1000);
+  });
+</script>
+
+{$query?.hello}

--- a/packages/glitch/src/codegen/functions.ts
+++ b/packages/glitch/src/codegen/functions.ts
@@ -18,7 +18,7 @@ export const generateFunctions = (context: GlitchContext): AST.Program => {
     ),
   ]);
 
-  for (const { kind, name, source } of context.artifacts) {
+  for (const { kind, type, name, source } of context.artifacts) {
     switch (kind) {
       case 'query': {
         program.body.push(
@@ -34,7 +34,13 @@ export const generateFunctions = (context: GlitchContext): AST.Program => {
               AST.b.tsTypeAnnotation(
                 AST.b.tsTypeReference(
                   AST.b.identifier('QueryStore'),
-                  AST.b.tsTypeParameterInstantiation([AST.b.tsTypeReference(AST.b.identifier(`types.${name}`))]),
+                  AST.b.tsTypeParameterInstantiation([
+                    AST.b.tsUnionType([
+                      AST.b.tsTypeReference(AST.b.identifier(`types.${name}`)),
+                      ...(type === 'manual' ? [AST.b.tsUndefinedKeyword()] : []),
+                    ]),
+                    AST.b.tsTypeReference(AST.b.identifier(`base.${name}Variables`)),
+                  ]),
                 ),
               ),
             ),

--- a/packages/glitch/src/runtime/index.ts
+++ b/packages/glitch/src/runtime/index.ts
@@ -21,6 +21,6 @@ export const fragment = (ref: unknown) => {
   return createFragmentStore(ref);
 };
 
-export { createQueryStore } from '../store/query';
+export { createManualQueryStore, createQueryStore } from '../store/query';
 export type { FragmentType, MakeRequired } from '../types';
 export type { TypedDocumentNode } from '@graphql-typed-document-node/core';

--- a/packages/glitch/src/types.ts
+++ b/packages/glitch/src/types.ts
@@ -36,6 +36,7 @@ type FragmentArtifact = {
 };
 
 export type Artifact = {
+  type: 'automatic' | 'manual';
   name: string;
   filePath: string;
   source: string;
@@ -62,8 +63,12 @@ export type GlitchClient = {
   onMutationError: (error: Error) => void;
 };
 
-export type QueryStore<D> = Readable<D> & {
-  refetch: () => void;
+export type QueryStore<D, V> = Readable<D> & {
+  refetch: V extends Record<string, never>
+    ? () => Promise<void>
+    : D extends undefined
+      ? (variables: V) => Promise<void>
+      : (variables?: V) => Promise<void>;
 };
 
 export type MutationStore<D, V> = Readable<{

--- a/packages/glitch/src/vite/transform-load.ts
+++ b/packages/glitch/src/vite/transform-load.ts
@@ -15,7 +15,10 @@ export const transformLoadPlugin = (context: GlitchContext): Plugin => {
       }
 
       const queries = context.artifacts.filter(
-        (artifact) => artifact.kind === 'query' && path.dirname(artifact.filePath) === path.dirname(id),
+        (artifact) =>
+          artifact.kind === 'query' &&
+          artifact.type === 'automatic' &&
+          path.dirname(artifact.filePath) === path.dirname(id),
       );
 
       if (queries.length === 0) {


### PR DESCRIPTION
glitch로 선언하는 query에 `@_manual` directive를 붙일 경우 쿼리가 자동으로 SSR되지 않으며 해당 방식으로 선언한 manual query의 경우 `query.refetch({ ... })` 호출을 통해 명시적으로 variable을 바꿔가며 원할 때 호출할 수 있음
