### PR TITLE
@sentry/cli 버전 2.2.2 로 고정

### DIFF
--- a/apps/penxle.com/package.json
+++ b/apps/penxle.com/package.json
@@ -43,7 +43,7 @@
     "@prisma/client": "^5.6.0",
     "@pulumi/pulumi": "^3.95.0",
     "@resvg/resvg-js": "^2.6.0",
-    "@sentry/cli": "^2.22.2",
+    "@sentry/cli": "2.22.2",
     "@sentry/sveltekit": "^7.84.0",
     "@shopify/draggable": "^1.1.3",
     "@sindresorhus/string-hash": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,7 +333,7 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0
       '@sentry/cli':
-        specifier: ^2.22.2
+        specifier: 2.22.2
         version: 2.22.2
       '@sentry/sveltekit':
         specifier: ^7.84.0

--- a/syncpack.config.cjs
+++ b/syncpack.config.cjs
@@ -1,5 +1,16 @@
 /** @type {import("syncpack").RcFile} */
 module.exports = {
   dependencyTypes: ['prod', 'dev'],
-  semverRange: '^',
+  semverGroups: [
+    {
+      packages: ['**'],
+      dependencies: ['@sentry/cli'],
+      range: '',
+    },
+    {
+      packages: ['**'],
+      dependencies: ['**'],
+      range: '^',
+    },
+  ],
 };


### PR DESCRIPTION
`@sentry/cli` 버전 2.2.3 에서 `@vercel/nft` 통한 배포 이슈가 있음
