### PR TITLE
graphql batching request 구현

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/handler.ts
+++ b/apps/penxle.com/src/lib/server/graphql/handler.ts
@@ -9,6 +9,7 @@ export const handler = createYoga<RequestEvent>({
   context: createContext,
   fetchAPI: { Response },
   graphqlEndpoint: '/api/graphql',
+  batching: true,
   maskedErrors: false,
   plugins: [useErrorHandling(), useLogging(), useTelemetry(), useContextFinalizer()],
 });

--- a/packages/glitch/package.json
+++ b/packages/glitch/package.json
@@ -45,6 +45,7 @@
     "@urql/core": "^4.2.0",
     "@urql/devtools": "^2.0.3",
     "@urql/exchange-graphcache": "^6.4.0",
+    "dataloader": "^2.2.2",
     "fast-glob": "^3.3.2",
     "graphql": "^16.8.1",
     "graphql-tag": "^2.12.6",

--- a/packages/glitch/src/client/exchanges/fetch.ts
+++ b/packages/glitch/src/client/exchanges/fetch.ts
@@ -1,0 +1,93 @@
+import { makeErrorResult, makeResult } from '@urql/core';
+import { makeFetchBody } from '@urql/core/internal';
+import DataLoader from 'dataloader';
+import { filter, fromPromise, merge, mergeMap, pipe, tap } from 'wonka';
+import type { Exchange, Operation, OperationResult } from '@urql/core';
+
+export const fetchExchange: Exchange = ({ forward, dispatchDebug }) => {
+  const dataLoader = new DataLoader<Operation, OperationResult>(
+    async (operations) => {
+      const fetch = operations[0].context.fetch ?? globalThis.fetch;
+      const url = operations[0].context.url;
+      const body = JSON.stringify(operations.map((operation) => makeFetchBody(operation)));
+
+      const request: RequestInit = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      };
+
+      for (const operation of operations) {
+        dispatchDebug({
+          type: 'fetchRequest',
+          message: 'A fetch request is being executed.',
+          operation,
+          data: {
+            url,
+            fetchOptions: request,
+          },
+        });
+      }
+
+      let results: OperationResult[];
+      try {
+        const resp = await fetch(url, request);
+        const payload = await resp.json();
+        results = operations.map((operation, i) => makeResult(operation, payload[i]));
+      } catch (err: unknown) {
+        results = operations.map((operation) => makeErrorResult(operation, err as Error));
+      }
+
+      for (const result of results) {
+        const error = result.data ? undefined : result.error;
+
+        dispatchDebug({
+          type: error ? 'fetchError' : 'fetchSuccess',
+          message: `A ${error ? 'failed' : 'successful'} fetch response has been returned.`,
+          operation: result.operation,
+          data: {
+            url,
+            fetchOptions: request,
+            value: error || result,
+          },
+        });
+      }
+
+      return results;
+    },
+    {
+      batchScheduleFn: (cb) => setTimeout(cb, 10),
+      cacheMap: null,
+    },
+  );
+
+  return (ops$) => {
+    const fetch$ = pipe(
+      ops$,
+      filter((operation) => operation.kind !== 'teardown'),
+      tap((operation) =>
+        dispatchDebug({
+          type: 'dataloader',
+          message: 'A fetch request is being queued for later execution.',
+          operation,
+        }),
+      ),
+      mergeMap((operation) => fromPromise(dataLoader.load(operation))),
+      tap(({ operation }) =>
+        dispatchDebug({
+          type: 'dataloader',
+          message: 'Pending fetch requests has been fulfilled.',
+          operation,
+        }),
+      ),
+    );
+
+    const forward$ = pipe(
+      ops$,
+      filter((operation) => operation.kind === 'teardown'),
+      forward,
+    );
+
+    return merge([fetch$, forward$]);
+  };
+};

--- a/packages/glitch/src/client/index.ts
+++ b/packages/glitch/src/client/index.ts
@@ -1,6 +1,7 @@
-import { Client, fetchExchange } from '@urql/core';
+import { Client } from '@urql/core';
 import { devtoolsExchange } from '@urql/devtools';
 import { cacheExchange } from '@urql/exchange-graphcache';
+import { fetchExchange } from './exchanges/fetch';
 import { refetchExchange, signalRefetch } from './exchanges/refetch';
 import type { Exchange } from '@urql/core';
 import type { CacheExchangeOpts } from '@urql/exchange-graphcache';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -612,6 +612,9 @@ importers:
       '@urql/exchange-graphcache':
         specifier: ^6.4.0
         version: 6.4.0(graphql@16.8.1)
+      dataloader:
+        specifier: ^2.2.2
+        version: 2.2.2
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
@@ -6007,27 +6010,6 @@ packages:
       vite: 4.5.0(@types/node@20.10.3)(lightningcss@1.22.1)
     transitivePeerDependencies:
       - rollup
-    dev: false
-
-  /@unocss/vite@0.57.5(vite@4.5.0):
-    resolution: {integrity: sha512-w1F/fR/ooD4KJxqituZLAlHJvwZCXSfosQplVM48XCp4JhXS1rmqybld4Y2IYYL1sAlrE2jAUXoum+rzWKak5Q==}
-    peerDependencies:
-      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@rollup/pluginutils': 5.0.5
-      '@unocss/config': 0.57.5
-      '@unocss/core': 0.57.5
-      '@unocss/inspector': 0.57.5
-      '@unocss/scope': 0.57.5
-      '@unocss/transformer-directives': 0.57.5
-      chokidar: 3.5.3
-      fast-glob: 3.3.2
-      magic-string: 0.30.5
-      vite: 4.5.0(@types/node@20.9.2)(lightningcss@1.22.1)
-    transitivePeerDependencies:
-      - rollup
-    dev: true
 
   /@urql/core@4.2.0(graphql@16.8.1):
     resolution: {integrity: sha512-GRkZ4kECR9UohWAjiSk2UYUetco6/PqSrvyC4AH6g16tyqEShA63M232cfbE1J9XJPaGNjia14Gi+oOqzp144w==}
@@ -7311,6 +7293,10 @@ packages:
       serialize-error: 8.1.0
       shimmer: 1.2.1
       ts-md5: 1.3.1
+    dev: false
+
+  /dataloader@2.2.2:
+    resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
     dev: false
 
   /dayjs@1.11.10:


### PR DESCRIPTION
- urql이 여러 요청을 동시에 보낼 때 먼저 보낸 요청 응답이 오면 이미 진행중인 다른 요청을 캔슬하는 버그가 있음
- 레이아웃 쿼리로 인해 페이지 한번 로드할 때 `/api/graphql` 요청을 2~3개씩 보내는 페이지들이 많음
- 따라서 graphql batching을 구현해 http request 수를 줄임과 동시에 urql 버그를 회피하는 효과를 냄
- 배치 윈도우: 10ms
