### PR TITLE
prisma generate가 turborepo cache에 포함되지 않는 문제 해결

### DIFF
--- a/apps/penxle.com/package.json
+++ b/apps/penxle.com/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "codegen": "svelte-kit sync && glitch generate && prisma generate",
+    "codegen": "svelte-kit sync && glitch generate",
+    "codegen:ephemeral": "prisma generate",
     "db:push": "doppler run -- prisma db push",
     "dev": "doppler run -- vite dev",
     "lint:svelte": "svelte-check --fail-on-warnings",

--- a/turbo.json
+++ b/turbo.json
@@ -6,8 +6,11 @@
       "env": ["PRIVATE_*", "PUBLIC_*"],
       "outputs": [".lambda/**", ".svelte-kit/**", "dist/**"]
     },
+    "codegen:ephemeral": {
+      "cache": false
+    },
     "codegen": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "codegen:ephemeral"],
       "dotEnv": [".env"],
       "outputs": [".svelte-kit/**", ".glitch/**"]
     },


### PR DESCRIPTION
일단 prisma generate 커맨드는 turbo cache에서 제외하도록 함
