### PR TITLE
하단 툴바 UI 아이템을 중앙정렬 및 버튼 텍스트 줄바꿈 없이 고정하기

### DIFF
--- a/apps/penxle.com/src/lib/components/pages/PostManageTable.svelte
+++ b/apps/penxle.com/src/lib/components/pages/PostManageTable.svelte
@@ -341,22 +341,22 @@
 <div
   class={clsx(
     selectedPostCount > 0 ? 'visible opacity-100 translate-y-0' : 'invisible opacity-0 translate-y-1rem',
-    'self-center flex flex-wrap gap-4 items-center px-6 py-2 flex-wrap sticky bottom-1rem bg-white rounded-2xl shadow-[0_0.25rem_1rem_0_rgba(0,0,0,0.15)] transition-all-300',
+    'self-center flex justify-center flex-wrap gap-4 items-center px-6 py-2 flex-wrap sticky bottom-1rem bg-white rounded-2xl shadow-[0_0.25rem_1rem_0_rgba(0,0,0,0.15)] transition-all-300',
   )}
 >
   <span class="body-15-b" aria-live="polite">
     {selectedPostCount}개의 포스트 선택됨
   </span>
   {#if selectedOwnPosts || $spaceMember?.role === 'ADMIN'}
-    <div class="flex gap-4">
+    <div class="flex gap-4 flex-wrap justify-center">
       <Menu class="<sm:hidden" as="div" offset={16} placement="top">
-        <Button slot="value" color="secondary" size="md">공개범위 설정</Button>
+        <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">공개범위 설정</Button>
         <MenuItem on:click={() => updateVisibilities('PUBLIC')}>전체 공개</MenuItem>
         <MenuItem on:click={() => updateVisibilities('UNLISTED')}>링크 공개</MenuItem>
         <MenuItem on:click={() => updateVisibilities('SPACE')}>멤버 공개</MenuItem>
       </Menu>
       <Menu class="<sm:hidden" as="div" offset={16} placement="top">
-        <Button slot="value" color="secondary" size="md">포스트 옵션 설정</Button>
+        <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">포스트 옵션 설정</Button>
         <MenuItem type="div">
           <Switch
             class="flex gap-0.63rem body-14-m items-center justify-between"
@@ -398,10 +398,10 @@
         </MenuItem>
       </Menu>
       <Tooltip message="컬렉션 기능은 아직 준비중이에요">
-        <Button color="secondary" disabled size="md">컬렉션 추가</Button>
+        <Button class="whitespace-nowrap" color="secondary" disabled size="md">컬렉션 추가</Button>
       </Tooltip>
       <Button
-        class="<sm:hidden"
+        class="<sm:hidden whitespace-nowrap"
         color="red"
         size="md"
         on:click={() => {


### PR DESCRIPTION
| 이전 | 이후 |
| :--: | :--: |
| ![스크린샷 2023-12-07 오후 8 54 11](https://github.com/penxle/penxle/assets/5278201/0bcde28e-fd2a-414f-b517-8cb5c64e369a) | <img width="865" alt="스크린샷 2023-12-07 오후 8 15 44" src="https://github.com/penxle/penxle/assets/5278201/583a4acb-4f8d-44e6-bcf0-5b8896df6402"> |


포스트 관리 컨테이너 너비가 좁은 경우 툴바 UI가 깨져서 수정하게 되었습니다.