### PR TITLE
갤러리 포스트 미리보기 페이지에서 레이아웃 벗어나는 문제 해결

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/GalleryPost.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/GalleryPost.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import 'swiper/css';
 
+  import clsx from 'clsx';
   import { onMount } from 'svelte';
   import { register } from 'swiper/element/bundle';
   import { fragment, graphql } from '$glitch';
@@ -26,6 +27,7 @@
   export { _query as $query };
 
   export let revision: FragmentType<Post_postRevision>;
+  export let mode: 'desktop' | 'mobile' | null = null;
 
   $: query = fragment(
     _query,
@@ -94,19 +96,28 @@
 <div class="max-w-187.5">
   <swiper-container
     bind:this={swiperEl}
-    class="square-[calc(100vw-32px)] max-w-187.5 max-h-187.5 rounded-xl mb-4"
+    class={clsx(
+      'square-[calc(100vw-32px)] max-w-187.5 max-h-187.5 rounded-xl mb-4',
+      mode === 'mobile' && 'max-w-368px! max-h-368px!',
+    )}
     init="false"
   >
     {#each images as node, index (index)}
       {#if node.type !== 'paragraph'}
         <swiper-slide
           bind:this={swiperSlideEl}
-          class="square-[calc(100vw-32px)] max-w-187.5 max-h-187.5 relative [&>button]:hover:opacity-100 rounded-xl"
+          class={clsx(
+            'square-[calc(100vw-32px)] max-w-187.5 max-h-187.5 relative [&>button]:hover:opacity-100 rounded-xl',
+            mode === 'mobile' && 'max-w-368px! max-h-368px!',
+          )}
         >
           {#if node.type === 'image'}
             <div class="relative">
               <Image
-                class="square-[calc(100vw-32px)] max-w-187.5 max-h-187.5 bg-black rounded-xl select-none"
+                class={clsx(
+                  'square-[calc(100vw-32px)] max-w-187.5 max-h-187.5 bg-black rounded-xl select-none',
+                  mode === 'mobile' && 'max-w-368px! max-h-368px!',
+                )}
                 $image={node.attrs.__data}
                 fit="contain"
               />
@@ -120,7 +131,12 @@
               {/if}
             </div>
           {:else if node.type === 'access_barrier' && node.attrs.__data.purchasable}
-            <div class="flex center square-[calc(100vw-32px)] max-w-187.5 max-h-187.5 rounded-xl bg-gray-80 px-10">
+            <div
+              class={clsx(
+                'flex center square-[calc(100vw-32px)] max-w-187.5 max-h-187.5 rounded-xl bg-gray-80 px-10',
+                mode === 'mobile' && 'max-w-368px! max-h-368px!',
+              )}
+            >
               <div class="flex flex-col w-full max-w-100 center space-y-2.5 bg-primary rounded-2xl py-8 px-2.5">
                 <p class="body-15-sb text-secondary">
                   이 뒤에 {node.attrs.__data.counts.images}개의 사진이 더 있어요!

--- a/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
@@ -33,6 +33,7 @@
   $: element = preview ? 'div' : 'a';
 
   export let preview = false;
+  export let mode: 'desktop' | 'mobile' | null = null;
 
   let _class: string | undefined = undefined;
   export { _class as class };
@@ -399,7 +400,7 @@
             <TiptapRenderer class="bodylong-16-m" content={$postRevision.content} bind:editor />
           </article>
         {:else}
-          <GalleryPost {$query} revision={$postRevision} />
+          <GalleryPost {$query} {mode} revision={$postRevision} />
         {/if}
 
         {#if editor && !preview}

--- a/apps/penxle.com/src/routes/(default)/[space]/preview/[post]/+page@.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/preview/[post]/+page@.svelte
@@ -81,6 +81,7 @@
     )}
     $postRevision={$query.post.draftRevision}
     {$query}
+    {mode}
     preview
   />
 </main>


### PR DESCRIPTION
|수정 전|수정 후|
|--|--|
<img width="548" alt="image" src="https://github.com/penxle/penxle/assets/76952602/5265cb3b-2265-4c92-8df7-452a61c4e49f">|<img width="661" alt="image" src="https://github.com/penxle/penxle/assets/76952602/7a0021ca-51f3-49e4-8b5d-2dea7e74791f">
