### PR TITLE
Post.previewText 에서 whitespace 전부 스페이스 하나로 치환함

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
@@ -482,7 +482,7 @@ builder.prismaObject('PostRevision', {
       select: { freeContent: true },
       resolve: async (revision) => {
         const contentText = await revisionContentToText(revision.freeContent);
-        return contentText.slice(0, 200);
+        return contentText.slice(0, 200).replaceAll(/\s+/g, ' ');
       },
 
       unauthorizedResolver: () => '',


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="701" alt="CleanShot 2023-12-09 at 15 41 56" src="https://github.com/penxle/penxle/assets/337728/43992e75-deda-4125-bf05-4d1727ebda7a">|<img width="789" alt="CleanShot 2023-12-09 at 15 42 43" src="https://github.com/penxle/penxle/assets/337728/67af8e56-2248-420b-94bc-4f030c544656">|
