### PR TITLE
opensearch 빌드타임 오류 해결

### DIFF
--- a/apps/penxle.com/src/lib/server/search.ts
+++ b/apps/penxle.com/src/lib/server/search.ts
@@ -1,6 +1,6 @@
 import { Client } from '@opensearch-project/opensearch';
-import { PRIVATE_OPENSEARCH_URL } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 
 export const openSearch = new Client({
-  node: PRIVATE_OPENSEARCH_URL,
+  node: env.PRIVATE_OPENSEARCH_URL || 'http://localhost:9200',
 });


### PR DESCRIPTION
빌드타임에 opensearch url이 비어있을 경우 빌드가 실패하는 이슈가 있어 fallback url을 넣음