### PR TITLE
고질적인 pothos 스키마 빌드 오류 해결

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/builder.ts
+++ b/apps/penxle.com/src/lib/server/graphql/builder.ts
@@ -8,16 +8,10 @@ import ValidationPlugin from '@pothos/plugin-validation';
 import { createOpenTelemetryWrapper } from '@pothos/tracing-opentelemetry';
 import { Prisma, PrismaClient } from '@prisma/client';
 import { GraphQLDateTime, GraphQLJSON, GraphQLVoid } from 'graphql-scalars';
-import { dev } from '$app/environment';
 import { PermissionDeniedError } from '$lib/errors';
 import { logger } from '../logging';
 import type PrismaTypes from '@pothos/plugin-prisma/generated';
 import type { Context, UserContext } from '../context';
-
-// 개발환경에서만 강제로 순환 참조 걸어서 ./schemas/**/* 리로드할 때 HMR이 builder까지 리로드하도록 함
-if (dev) {
-  import('./schemas');
-}
 
 const tracer = trace.getTracer('graphql');
 const createSpan = createOpenTelemetryWrapper(tracer, {
@@ -25,54 +19,67 @@ const createSpan = createOpenTelemetryWrapper(tracer, {
   includeSource: true,
 });
 
-export const builder = new SchemaBuilder<{
-  AuthContexts: {
-    user: Context & UserContext;
-  };
-  AuthScopes: {
-    staff: boolean;
-    user: boolean;
-  };
-  Context: Context;
-  DefaultInputFieldRequiredness: true;
-  PrismaTypes: PrismaTypes;
-  Scalars: {
-    DateTime: { Input: Date; Output: Date };
-    ID: { Input: string; Output: string };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    JSON: { Input: any; Output: unknown };
-    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    Void: { Input: never; Output: void };
-  };
-}>({
-  authScopes: (context) => ({
-    staff: false,
-    user: !!context.session,
-  }),
-  defaultInputFieldRequiredness: true,
-  plugins: [TracingPlugin, ScopeAuthPlugin, PrismaPlugin, SimpleObjectsPlugin, ValidationPlugin],
-  prisma: {
-    // spell-checker:disable-next-line
-    dmmf: Prisma.dmmf,
-    client: (ctx) => ctx.db as unknown as PrismaClient,
-    filterConnectionTotalCount: true,
-  },
-  scopeAuthOptions: {
-    treatErrorsAsUnauthorized: true,
-    unauthorizedError: (_, __, ___, result) => {
-      logger.warn(result);
-      return new PermissionDeniedError();
+type Builder = ReturnType<typeof createBuilder>;
+export const createBuilder = () => {
+  const builder = new SchemaBuilder<{
+    AuthContexts: {
+      user: Context & UserContext;
+    };
+    AuthScopes: {
+      staff: boolean;
+      user: boolean;
+    };
+    Context: Context;
+    DefaultInputFieldRequiredness: true;
+    PrismaTypes: PrismaTypes;
+    Scalars: {
+      DateTime: { Input: Date; Output: Date };
+      ID: { Input: string; Output: string };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      JSON: { Input: any; Output: unknown };
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      Void: { Input: never; Output: void };
+    };
+  }>({
+    authScopes: (context) => ({
+      staff: false,
+      user: !!context.session,
+    }),
+    defaultInputFieldRequiredness: true,
+    plugins: [TracingPlugin, ScopeAuthPlugin, PrismaPlugin, SimpleObjectsPlugin, ValidationPlugin],
+    prisma: {
+      // spell-checker:disable-next-line
+      dmmf: Prisma.dmmf,
+      client: (ctx) => ctx.db as unknown as PrismaClient,
+      filterConnectionTotalCount: true,
     },
-  },
-  tracing: {
-    default: (config) => isRootField(config),
-    wrap: (resolver, options) => createSpan(resolver, options),
-  },
-});
+    scopeAuthOptions: {
+      treatErrorsAsUnauthorized: true,
+      unauthorizedError: (_, __, ___, result) => {
+        logger.warn(result);
+        return new PermissionDeniedError();
+      },
+    },
+    tracing: {
+      default: (config) => isRootField(config),
+      wrap: (resolver, options) => createSpan(resolver, options),
+    },
+  });
 
-builder.queryType();
-builder.mutationType();
+  builder.queryType();
+  builder.mutationType();
 
-builder.addScalarType('DateTime', GraphQLDateTime);
-builder.addScalarType('JSON', GraphQLJSON);
-builder.addScalarType('Void', GraphQLVoid);
+  builder.addScalarType('DateTime', GraphQLDateTime);
+  builder.addScalarType('JSON', GraphQLJSON);
+  builder.addScalarType('Void', GraphQLVoid);
+
+  return builder;
+};
+
+export const defineSchema = (fn: (builder: Builder) => void) => fn;
+
+export const addSchema = (builder: Builder, schemas: ((builder: Builder) => void)[]) => {
+  for (const schema of schemas) {
+    schema(builder);
+  }
+};

--- a/apps/penxle.com/src/lib/server/graphql/schemas/bookmark.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/bookmark.ts
@@ -1,235 +1,237 @@
 import { NotFoundError } from '$lib/errors';
 import { createId } from '$lib/utils';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Types
- */
+export const bookmarkSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-builder.prismaObject('BookmarkGroup', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    name: t.exposeString('name'),
-    posts: t.relation('posts'),
-    postCount: t.relationCount('posts', {
-      where: {
-        post: {
-          state: 'PUBLISHED',
-          space: {
-            state: 'ACTIVE',
+  builder.prismaObject('BookmarkGroup', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      name: t.exposeString('name'),
+      posts: t.relation('posts'),
+      postCount: t.relationCount('posts', {
+        where: {
+          post: {
+            state: 'PUBLISHED',
+            space: {
+              state: 'ACTIVE',
+            },
           },
         },
-      },
-    }),
+      }),
 
-    thumbnails: t.prismaField({
-      type: ['Image'],
-      resolve: async (query, bookmarkGroup, _, { db }) => {
-        return db.image.findMany({
-          ...query,
-          where: {
-            postRevisionsUsingThisAsCroppedThumbnail: {
-              some: {
-                kind: 'PUBLISHED',
-                post: {
-                  state: 'PUBLISHED',
-                  space: { state: 'ACTIVE' },
-                  bookmarks: {
-                    some: {
-                      bookmarkGroupId: bookmarkGroup.id,
+      thumbnails: t.prismaField({
+        type: ['Image'],
+        resolve: async (query, bookmarkGroup, _, { db }) => {
+          return db.image.findMany({
+            ...query,
+            where: {
+              postRevisionsUsingThisAsCroppedThumbnail: {
+                some: {
+                  kind: 'PUBLISHED',
+                  post: {
+                    state: 'PUBLISHED',
+                    space: { state: 'ACTIVE' },
+                    bookmarks: {
+                      some: {
+                        bookmarkGroupId: bookmarkGroup.id,
+                      },
                     },
                   },
                 },
               },
             },
-          },
 
-          take: 4,
-        });
-      },
-    }),
-  }),
-});
-
-builder.prismaObject('BookmarkGroupPost', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    post: t.relation('post'),
-    bookmarkGroup: t.relation('bookmarkGroup'),
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-  }),
-});
-
-/**
- * * Inputs
- */
-
-// const CreateBookmarkInput = builder.inputType('CreateBookmarkInput', {
-//   fields: (t) => ({
-//     name: t.string(),
-//   }),
-// });
-
-// const DeleteBookmarkInput = builder.inputType('DeleteBookmarkInput', {
-//   fields: (t) => ({
-//     bookmarkId: t.id(),
-//   }),
-// });
-
-// const UpdateBookmarkInput = builder.inputType('UpdateBookmarkInput', {
-//   fields: (t) => ({
-//     bookmarkId: t.id(),
-//     name: t.string(),
-//   }),
-// });
-
-const BookmarkPostInput = builder.inputType('BookmarkPostInput', {
-  fields: (t) => ({
-    // bookmarkId: t.id(),
-    postId: t.id(),
-  }),
-});
-
-const UnbookmarkPostInput = builder.inputType('UnbookmarkPostInput', {
-  fields: (t) => ({
-    bookmarkId: t.id(),
-    postId: t.id(),
-  }),
-});
-
-/**
- * * Mutations
- */
-
-builder.mutationFields((t) => ({
-  // createBookmark: t.withAuth({ user: true }).prismaField({
-  //   type: 'BookmarkGroup',
-  //   args: { input: t.arg({ type: CreateBookmarkInput }) },
-  //   resolve: async (query, _, { input }, { db, ...context }) => {
-  //     return db.bookmarkGroup.create({
-  //       ...query,
-  //       data: {
-  //         id: createId(),
-  //         name: input.name,
-  //         user: { connect: { id: context.session.userId } },
-  //       },
-  //     });
-  //   },
-  // }),
-
-  // deleteBookmark: t.withAuth({ user: true }).field({
-  //   type: 'Void',
-  //   args: { input: t.arg({ type: DeleteBookmarkInput }) },
-  //   resolve: async (_, { input }, { db, ...context }) => {
-  //     await db.bookmarkGroup.delete({
-  //       where: {
-  //         id: input.bookmarkId,
-  //         userId: context.session.userId,
-  //       },
-  //     });
-  //   },
-  // }),
-
-  // updateBookmark: t.withAuth({ user: true }).prismaField({
-  //   type: 'BookmarkGroup',
-  //   args: { input: t.arg({ type: UpdateBookmarkInput }) },
-  //   resolve: async (query, _, { input }, { db, ...context }) => {
-  //     return db.bookmarkGroup.update({
-  //       ...query,
-  //       where: {
-  //         id: input.bookmarkId,
-  //         userId: context.session.userId,
-  //       },
-  //       data: {
-  //         name: input.name,
-  //       },
-  //     });
-  //   },
-  // }),
-
-  bookmarkPost: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: BookmarkPostInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const post = await db.post.findUnique({
-        where: {
-          id: input.postId,
-          state: 'PUBLISHED',
-          space: { state: 'ACTIVE' },
+            take: 4,
+          });
         },
-      });
+      }),
+    }),
+  });
 
-      if (!post) {
-        throw new NotFoundError();
-      }
+  builder.prismaObject('BookmarkGroupPost', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      post: t.relation('post'),
+      bookmarkGroup: t.relation('bookmarkGroup'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+    }),
+  });
 
-      if (post.visibility === 'SPACE') {
-        const meAsMember = await db.spaceMember.existsUnique({
+  /**
+   * * Inputs
+   */
+
+  // const CreateBookmarkInput = builder.inputType('CreateBookmarkInput', {
+  //   fields: (t) => ({
+  //     name: t.string(),
+  //   }),
+  // });
+
+  // const DeleteBookmarkInput = builder.inputType('DeleteBookmarkInput', {
+  //   fields: (t) => ({
+  //     bookmarkId: t.id(),
+  //   }),
+  // });
+
+  // const UpdateBookmarkInput = builder.inputType('UpdateBookmarkInput', {
+  //   fields: (t) => ({
+  //     bookmarkId: t.id(),
+  //     name: t.string(),
+  //   }),
+  // });
+
+  const BookmarkPostInput = builder.inputType('BookmarkPostInput', {
+    fields: (t) => ({
+      // bookmarkId: t.id(),
+      postId: t.id(),
+    }),
+  });
+
+  const UnbookmarkPostInput = builder.inputType('UnbookmarkPostInput', {
+    fields: (t) => ({
+      bookmarkId: t.id(),
+      postId: t.id(),
+    }),
+  });
+
+  /**
+   * * Mutations
+   */
+
+  builder.mutationFields((t) => ({
+    // createBookmark: t.withAuth({ user: true }).prismaField({
+    //   type: 'BookmarkGroup',
+    //   args: { input: t.arg({ type: CreateBookmarkInput }) },
+    //   resolve: async (query, _, { input }, { db, ...context }) => {
+    //     return db.bookmarkGroup.create({
+    //       ...query,
+    //       data: {
+    //         id: createId(),
+    //         name: input.name,
+    //         user: { connect: { id: context.session.userId } },
+    //       },
+    //     });
+    //   },
+    // }),
+
+    // deleteBookmark: t.withAuth({ user: true }).field({
+    //   type: 'Void',
+    //   args: { input: t.arg({ type: DeleteBookmarkInput }) },
+    //   resolve: async (_, { input }, { db, ...context }) => {
+    //     await db.bookmarkGroup.delete({
+    //       where: {
+    //         id: input.bookmarkId,
+    //         userId: context.session.userId,
+    //       },
+    //     });
+    //   },
+    // }),
+
+    // updateBookmark: t.withAuth({ user: true }).prismaField({
+    //   type: 'BookmarkGroup',
+    //   args: { input: t.arg({ type: UpdateBookmarkInput }) },
+    //   resolve: async (query, _, { input }, { db, ...context }) => {
+    //     return db.bookmarkGroup.update({
+    //       ...query,
+    //       where: {
+    //         id: input.bookmarkId,
+    //         userId: context.session.userId,
+    //       },
+    //       data: {
+    //         name: input.name,
+    //       },
+    //     });
+    //   },
+    // }),
+
+    bookmarkPost: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: BookmarkPostInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const post = await db.post.findUnique({
           where: {
-            spaceId_userId: {
-              spaceId: post.spaceId,
-              userId: context.session.userId,
-            },
-            state: 'ACTIVE',
+            id: input.postId,
+            state: 'PUBLISHED',
+            space: { state: 'ACTIVE' },
           },
         });
 
-        if (!meAsMember) {
+        if (!post) {
           throw new NotFoundError();
         }
-      }
 
-      const defaultBookmarkGroup =
-        (await db.bookmarkGroup.findFirst({
+        if (post.visibility === 'SPACE') {
+          const meAsMember = await db.spaceMember.existsUnique({
+            where: {
+              spaceId_userId: {
+                spaceId: post.spaceId,
+                userId: context.session.userId,
+              },
+              state: 'ACTIVE',
+            },
+          });
+
+          if (!meAsMember) {
+            throw new NotFoundError();
+          }
+        }
+
+        const defaultBookmarkGroup =
+          (await db.bookmarkGroup.findFirst({
+            where: {
+              userId: context.session.userId,
+            },
+          })) ??
+          (await db.bookmarkGroup.create({
+            data: {
+              id: createId(),
+              name: '북마크',
+              userId: context.session.userId,
+            },
+          }));
+
+        const bookmarkGroupPost = await db.bookmarkGroupPost.upsert({
+          include: { post: query },
           where: {
-            userId: context.session.userId,
+            bookmarkGroupId_postId: {
+              bookmarkGroupId: defaultBookmarkGroup.id,
+              postId: input.postId,
+            },
+            bookmarkGroup: { userId: context.session.userId },
           },
-        })) ??
-        (await db.bookmarkGroup.create({
-          data: {
+          create: {
             id: createId(),
-            name: '북마크',
-            userId: context.session.userId,
-          },
-        }));
-
-      const bookmarkGroupPost = await db.bookmarkGroupPost.upsert({
-        include: { post: query },
-        where: {
-          bookmarkGroupId_postId: {
             bookmarkGroupId: defaultBookmarkGroup.id,
             postId: input.postId,
           },
-          bookmarkGroup: { userId: context.session.userId },
-        },
-        create: {
-          id: createId(),
-          bookmarkGroupId: defaultBookmarkGroup.id,
-          postId: input.postId,
-        },
-        update: {},
-      });
+          update: {},
+        });
 
-      return bookmarkGroupPost.post;
-    },
-  }),
+        return bookmarkGroupPost.post;
+      },
+    }),
 
-  unbookmarkPost: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: UnbookmarkPostInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const bookmarkPost = await db.bookmarkGroupPost.delete({
-        include: { post: query },
-        where: {
-          bookmarkGroupId_postId: {
-            bookmarkGroupId: input.bookmarkId,
-            postId: input.postId,
+    unbookmarkPost: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: UnbookmarkPostInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const bookmarkPost = await db.bookmarkGroupPost.delete({
+          include: { post: query },
+          where: {
+            bookmarkGroupId_postId: {
+              bookmarkGroupId: input.bookmarkId,
+              postId: input.postId,
+            },
+            bookmarkGroup: { userId: context.session.userId },
           },
-          bookmarkGroup: { userId: context.session.userId },
-        },
-      });
+        });
 
-      return bookmarkPost.post;
-    },
-  }),
-}));
+        return bookmarkPost.post;
+      },
+    }),
+  }));
+});

--- a/apps/penxle.com/src/lib/server/graphql/schemas/collection.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/collection.ts
@@ -1,214 +1,268 @@
 import { FormValidationError, NotFoundError, PermissionDeniedError } from '$lib/errors';
 import { createId } from '$lib/utils';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Types
- */
+export const collectionSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-builder.prismaObject('SpaceCollection', {
-  select: { id: true },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    name: t.exposeString('name'),
-    thumbnail: t.relation('thumbnail'),
-    count: t.relationCount('posts'),
+  builder.prismaObject('SpaceCollection', {
+    select: { id: true },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      name: t.exposeString('name'),
+      thumbnail: t.relation('thumbnail'),
+      count: t.relationCount('posts'),
 
-    posts: t.prismaField({
-      type: ['Post'],
-      select: { spaceId: true },
-      resolve: async (query, collection, __, { db, ...context }) => {
-        const meAsMember = context.session?.userId
-          ? await db.spaceMember.findFirst({
-              where: {
-                spaceId: collection.spaceId,
-                userId: context.session.userId,
-                state: 'ACTIVE',
+      posts: t.prismaField({
+        type: ['Post'],
+        select: { spaceId: true },
+        resolve: async (query, collection, __, { db, ...context }) => {
+          const meAsMember = context.session?.userId
+            ? await db.spaceMember.findFirst({
+                where: {
+                  spaceId: collection.spaceId,
+                  userId: context.session.userId,
+                  state: 'ACTIVE',
+                },
+              })
+            : null;
+
+          const collectionPosts = await db.spaceCollectionPost.findMany({
+            include: { post: query },
+            where: {
+              collectionId: collection.id,
+              post: {
+                state: 'PUBLISHED',
+                visibility: meAsMember ? undefined : 'PUBLIC',
               },
-            })
-          : null;
-
-        const collectionPosts = await db.spaceCollectionPost.findMany({
-          include: { post: query },
-          where: {
-            collectionId: collection.id,
-            post: {
-              state: 'PUBLISHED',
-              visibility: meAsMember ? undefined : 'PUBLIC',
             },
+            orderBy: { order: 'asc' },
+          });
+
+          return collectionPosts.map((cp) => cp.post);
+        },
+      }),
+    }),
+  });
+
+  builder.prismaObject('SpaceCollectionPost', {
+    select: { id: true },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      post: t.relation('post'),
+      order: t.exposeInt('order'),
+    }),
+  });
+
+  /**
+   * * Inputs
+   */
+
+  const CreateSpaceCollectionInput = builder.inputType('CreateSpaceCollectionInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+      name: t.string(),
+    }),
+  });
+
+  const DeleteSpaceCollectionInput = builder.inputType('DeleteSpaceCollectionInput', {
+    fields: (t) => ({
+      collectionId: t.id(),
+    }),
+  });
+
+  const UpdatePostCollectionInput = builder.inputType('UpdatePostCollectionInput', {
+    fields: (t) => ({
+      collectionId: t.id({ required: false }),
+      postId: t.id(),
+    }),
+  });
+
+  const ReorderSpaceCollectionInput = builder.inputType('ReorderSpaceCollectionInput', {
+    fields: (t) => ({
+      collectionId: t.id(),
+      postId: t.id(),
+      order: t.int(),
+    }),
+  });
+
+  const UpdateCollectionInput = builder.inputType('UpdateCollectionInput', {
+    fields: (t) => ({
+      collectionId: t.id(),
+      name: t.string(),
+      thumbnailId: t.id({ required: false }),
+    }),
+  });
+
+  /**
+   * * Mutations
+   */
+
+  builder.mutationFields((t) => ({
+    createSpaceCollection: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceCollection',
+      args: { input: t.arg({ type: CreateSpaceCollectionInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const meAsMember = await db.spaceMember.findFirst({
+          where: {
+            spaceId: input.spaceId,
+            userId: context.session.userId,
+            state: 'ACTIVE',
           },
-          orderBy: { order: 'asc' },
         });
 
-        return collectionPosts.map((cp) => cp.post);
+        if (!meAsMember) {
+          throw new PermissionDeniedError();
+        }
+
+        return db.spaceCollection.create({
+          ...query,
+          data: {
+            id: createId(),
+            state: 'ACTIVE',
+            name: input.name,
+            spaceId: input.spaceId,
+          },
+        });
       },
     }),
-  }),
-});
 
-builder.prismaObject('SpaceCollectionPost', {
-  select: { id: true },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    post: t.relation('post'),
-    order: t.exposeInt('order'),
-  }),
-});
-
-/**
- * * Inputs
- */
-
-const CreateSpaceCollectionInput = builder.inputType('CreateSpaceCollectionInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-    name: t.string(),
-  }),
-});
-
-const DeleteSpaceCollectionInput = builder.inputType('DeleteSpaceCollectionInput', {
-  fields: (t) => ({
-    collectionId: t.id(),
-  }),
-});
-
-const UpdatePostCollectionInput = builder.inputType('UpdatePostCollectionInput', {
-  fields: (t) => ({
-    collectionId: t.id({ required: false }),
-    postId: t.id(),
-  }),
-});
-
-const ReorderSpaceCollectionInput = builder.inputType('ReorderSpaceCollectionInput', {
-  fields: (t) => ({
-    collectionId: t.id(),
-    postId: t.id(),
-    order: t.int(),
-  }),
-});
-
-const UpdateCollectionInput = builder.inputType('UpdateCollectionInput', {
-  fields: (t) => ({
-    collectionId: t.id(),
-    name: t.string(),
-    thumbnailId: t.id({ required: false }),
-  }),
-});
-
-/**
- * * Mutations
- */
-
-builder.mutationFields((t) => ({
-  createSpaceCollection: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceCollection',
-    args: { input: t.arg({ type: CreateSpaceCollectionInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const meAsMember = await db.spaceMember.findFirst({
-        where: {
-          spaceId: input.spaceId,
-          userId: context.session.userId,
-          state: 'ACTIVE',
-        },
-      });
-
-      if (!meAsMember) {
-        throw new PermissionDeniedError();
-      }
-
-      return db.spaceCollection.create({
-        ...query,
-        data: {
-          id: createId(),
-          state: 'ACTIVE',
-          name: input.name,
-          spaceId: input.spaceId,
-        },
-      });
-    },
-  }),
-
-  deleteSpaceCollection: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceCollection',
-    args: { input: t.arg({ type: DeleteSpaceCollectionInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      return db.spaceCollection.update({
-        ...query,
-        where: {
-          id: input.collectionId,
-          space: {
-            members: {
-              some: {
-                userId: context.session.userId,
-                state: 'ACTIVE',
-              },
-            },
-          },
-        },
-        data: {
-          state: 'INACTIVE',
-        },
-      });
-    },
-  }),
-
-  updatePostCollection: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: UpdatePostCollectionInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const meAsMember = await db.spaceMember.exists({
-        where: {
-          space: {
-            posts: {
-              some: {
-                id: input.postId,
-              },
-            },
-            collections: input.collectionId
-              ? {
-                  some: {
-                    id: input.collectionId,
-                  },
-                }
-              : undefined,
-          },
-          userId: context.session.userId,
-          state: 'ACTIVE',
-        },
-      });
-
-      if (!meAsMember) {
-        throw new PermissionDeniedError();
-      }
-
-      const post = await db.post.findUniqueOrThrow({
-        select: { id: true, collectionPost: true },
-        where: { id: input.postId },
-      });
-
-      const deleteCollectionPost = async (id: string) => {
-        const deletedCollectionPost = await db.spaceCollectionPost.delete({
-          select: { collectionId: true, order: true },
-          where: { id },
-        });
-
-        await db.spaceCollectionPost.updateMany({
+    deleteSpaceCollection: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceCollection',
+      args: { input: t.arg({ type: DeleteSpaceCollectionInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        return db.spaceCollection.update({
+          ...query,
           where: {
-            collectionId: deletedCollectionPost.collectionId,
-            order: { gt: deletedCollectionPost.order },
+            id: input.collectionId,
+            space: {
+              members: {
+                some: {
+                  userId: context.session.userId,
+                  state: 'ACTIVE',
+                },
+              },
+            },
           },
           data: {
-            order: { decrement: 1 },
+            state: 'INACTIVE',
           },
         });
-      };
+      },
+    }),
 
-      if (input.collectionId) {
-        if (post.collectionPost) {
+    updatePostCollection: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: UpdatePostCollectionInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const meAsMember = await db.spaceMember.exists({
+          where: {
+            space: {
+              posts: {
+                some: {
+                  id: input.postId,
+                },
+              },
+              collections: input.collectionId
+                ? {
+                    some: {
+                      id: input.collectionId,
+                    },
+                  }
+                : undefined,
+            },
+            userId: context.session.userId,
+            state: 'ACTIVE',
+          },
+        });
+
+        if (!meAsMember) {
+          throw new PermissionDeniedError();
+        }
+
+        const post = await db.post.findUniqueOrThrow({
+          select: { id: true, collectionPost: true },
+          where: { id: input.postId },
+        });
+
+        const deleteCollectionPost = async (id: string) => {
+          const deletedCollectionPost = await db.spaceCollectionPost.delete({
+            select: { collectionId: true, order: true },
+            where: { id },
+          });
+
+          await db.spaceCollectionPost.updateMany({
+            where: {
+              collectionId: deletedCollectionPost.collectionId,
+              order: { gt: deletedCollectionPost.order },
+            },
+            data: {
+              order: { decrement: 1 },
+            },
+          });
+        };
+
+        if (input.collectionId) {
+          if (post.collectionPost) {
+            await deleteCollectionPost(post.collectionPost.id);
+          }
+
+          const lastOrder = await db.spaceCollectionPost.findFirst({
+            select: { order: true },
+            where: {
+              collectionId: input.collectionId,
+            },
+            orderBy: { order: 'desc' },
+          });
+
+          await db.spaceCollectionPost.create({
+            data: {
+              id: createId(),
+              collectionId: input.collectionId,
+              postId: input.postId,
+              order: lastOrder ? lastOrder.order + 1 : 0,
+            },
+          });
+        } else {
+          if (!post.collectionPost) {
+            throw new NotFoundError();
+          }
+
           await deleteCollectionPost(post.collectionPost.id);
         }
 
-        const lastOrder = await db.spaceCollectionPost.findFirst({
+        return db.post.findUniqueOrThrow({
+          ...query,
+          where: { id: post.id },
+        });
+      },
+    }),
+
+    reorderSpaceCollection: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceCollection',
+      args: { input: t.arg({ type: ReorderSpaceCollectionInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const meAsMember = await db.spaceMember.exists({
+          where: {
+            space: {
+              collections: {
+                some: {
+                  id: input.collectionId,
+                },
+              },
+            },
+            userId: context.session.userId,
+            state: 'ACTIVE',
+          },
+        });
+
+        if (!meAsMember) {
+          throw new PermissionDeniedError();
+        }
+
+        const lastOrder = await db.spaceCollectionPost.findFirstOrThrow({
           select: { order: true },
           where: {
             collectionId: input.collectionId,
@@ -216,151 +270,99 @@ builder.mutationFields((t) => ({
           orderBy: { order: 'desc' },
         });
 
-        await db.spaceCollectionPost.create({
-          data: {
-            id: createId(),
-            collectionId: input.collectionId,
-            postId: input.postId,
-            order: lastOrder ? lastOrder.order + 1 : 0,
-          },
-        });
-      } else {
-        if (!post.collectionPost) {
-          throw new NotFoundError();
+        if (lastOrder.order < input.order) {
+          throw new FormValidationError('order', '잘못된 순서에요');
         }
 
-        await deleteCollectionPost(post.collectionPost.id);
-      }
-
-      return db.post.findUniqueOrThrow({
-        ...query,
-        where: { id: post.id },
-      });
-    },
-  }),
-
-  reorderSpaceCollection: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceCollection',
-    args: { input: t.arg({ type: ReorderSpaceCollectionInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const meAsMember = await db.spaceMember.exists({
-        where: {
-          space: {
-            collections: {
-              some: {
-                id: input.collectionId,
-              },
-            },
-          },
-          userId: context.session.userId,
-          state: 'ACTIVE',
-        },
-      });
-
-      if (!meAsMember) {
-        throw new PermissionDeniedError();
-      }
-
-      const lastOrder = await db.spaceCollectionPost.findFirstOrThrow({
-        select: { order: true },
-        where: {
-          collectionId: input.collectionId,
-        },
-        orderBy: { order: 'desc' },
-      });
-
-      if (lastOrder.order < input.order) {
-        throw new FormValidationError('order', '잘못된 순서에요');
-      }
-
-      const originalOrder = await db.spaceCollectionPost.findFirstOrThrow({
-        select: { order: true },
-        where: {
-          postId: input.postId,
-        },
-      });
-
-      await db.spaceCollectionPost.update({
-        where: {
-          postId: input.postId,
-        },
-        data: {
-          order: lastOrder.order + 1,
-        },
-      });
-
-      if (originalOrder.order > input.order) {
-        await db.spaceCollectionPost.updateMany({
+        const originalOrder = await db.spaceCollectionPost.findFirstOrThrow({
+          select: { order: true },
           where: {
-            collectionId: input.collectionId,
-            order: { lt: originalOrder.order, gte: input.order },
-          },
-          data: {
-            order: { increment: 1 },
+            postId: input.postId,
           },
         });
-      } else if (originalOrder.order < input.order) {
-        await db.spaceCollectionPost.updateMany({
+
+        await db.spaceCollectionPost.update({
           where: {
-            collectionId: input.collectionId,
-            order: { gt: originalOrder.order, lte: input.order },
+            postId: input.postId,
           },
           data: {
-            order: { decrement: 1 },
+            order: lastOrder.order + 1,
           },
         });
-      }
 
-      await db.spaceCollectionPost.update({
-        where: {
-          postId: input.postId,
-        },
-        data: {
-          order: input.order,
-        },
-      });
+        if (originalOrder.order > input.order) {
+          await db.spaceCollectionPost.updateMany({
+            where: {
+              collectionId: input.collectionId,
+              order: { lt: originalOrder.order, gte: input.order },
+            },
+            data: {
+              order: { increment: 1 },
+            },
+          });
+        } else if (originalOrder.order < input.order) {
+          await db.spaceCollectionPost.updateMany({
+            where: {
+              collectionId: input.collectionId,
+              order: { gt: originalOrder.order, lte: input.order },
+            },
+            data: {
+              order: { decrement: 1 },
+            },
+          });
+        }
 
-      return db.spaceCollection.findUniqueOrThrow({
-        ...query,
-        where: {
-          id: input.collectionId,
-        },
-      });
-    },
-  }),
+        await db.spaceCollectionPost.update({
+          where: {
+            postId: input.postId,
+          },
+          data: {
+            order: input.order,
+          },
+        });
 
-  updateSpaceCollection: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceCollection',
-    args: { input: t.arg({ type: UpdateCollectionInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const meAsMember = await db.spaceMember.exists({
-        where: {
-          space: {
-            collections: {
-              some: {
-                id: input.collectionId,
+        return db.spaceCollection.findUniqueOrThrow({
+          ...query,
+          where: {
+            id: input.collectionId,
+          },
+        });
+      },
+    }),
+
+    updateSpaceCollection: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceCollection',
+      args: { input: t.arg({ type: UpdateCollectionInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const meAsMember = await db.spaceMember.exists({
+          where: {
+            space: {
+              collections: {
+                some: {
+                  id: input.collectionId,
+                },
               },
             },
+            userId: context.session.userId,
+            state: 'ACTIVE',
           },
-          userId: context.session.userId,
-          state: 'ACTIVE',
-        },
-      });
+        });
 
-      if (!meAsMember) {
-        throw new PermissionDeniedError();
-      }
+        if (!meAsMember) {
+          throw new PermissionDeniedError();
+        }
 
-      return db.spaceCollection.update({
-        ...query,
-        where: {
-          id: input.collectionId,
-        },
-        data: {
-          name: input.name,
-          thumbnailId: input.thumbnailId,
-        },
-      });
-    },
-  }),
-}));
+        return db.spaceCollection.update({
+          ...query,
+          where: {
+            id: input.collectionId,
+          },
+          data: {
+            name: input.name,
+            thumbnailId: input.thumbnailId,
+          },
+        });
+      },
+    }),
+  }));
+});

--- a/apps/penxle.com/src/lib/server/graphql/schemas/enums.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/enums.ts
@@ -1,11 +1,13 @@
 import { $Enums } from '@prisma/client';
 import * as enums from '$lib/server/enums';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Enums
- */
+export const enumsSchema = defineSchema((builder) => {
+  /**
+   * * Enums
+   */
 
-for (const [name, e] of Object.entries({ ...$Enums, ...enums })) {
-  builder.enumType(e, { name });
-}
+  for (const [name, e] of Object.entries({ ...$Enums, ...enums })) {
+    builder.enumType(e, { name });
+  }
+});

--- a/apps/penxle.com/src/lib/server/graphql/schemas/feed.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/feed.ts
@@ -1,179 +1,221 @@
 import dayjs from 'dayjs';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Queries
- */
+export const feedSchema = defineSchema((builder) => {
+  /**
+   * * Queries
+   */
 
-builder.queryFields((t) => ({
-  recommendFeed: t.prismaField({
-    type: ['Post'],
-    resolve: async (query, _, __, { db, ...context }) => {
-      // const identity = context.session ? await db.userPersonalIdentity.findUniqueOrThrow({
-      //   where: { userId: context.session.userId },
-      // }) : null;
+  builder.queryFields((t) => ({
+    recommendFeed: t.prismaField({
+      type: ['Post'],
+      resolve: async (query, _, __, { db, ...context }) => {
+        // const identity = context.session ? await db.userPersonalIdentity.findUniqueOrThrow({
+        //   where: { userId: context.session.userId },
+        // }) : null;
 
-      return db.post.findMany({
-        ...query,
-        where: {
-          state: 'PUBLISHED',
-          visibility: 'PUBLIC',
-          password: null,
-          //NOT: isAdulthood(identity?.birthday) ? undefined : { contentFilters: { has: 'ADULT' } },
-          space: {
-            state: 'ACTIVE',
-            userMutes: context.session
+        return db.post.findMany({
+          ...query,
+          where: {
+            state: 'PUBLISHED',
+            visibility: 'PUBLIC',
+            password: null,
+            //NOT: isAdulthood(identity?.birthday) ? undefined : { contentFilters: { has: 'ADULT' } },
+            space: {
+              state: 'ACTIVE',
+              userMutes: context.session
+                ? {
+                    none: { userId: context.session.userId },
+                  }
+                : undefined,
+            },
+            publishedRevision: context.session
               ? {
-                  none: { userId: context.session.userId },
+                  tags: {
+                    none: {
+                      tag: {
+                        userMutes: { some: { userId: context.session.userId } },
+                      },
+                    },
+                  },
                 }
               : undefined,
           },
-          publishedRevision: context.session
-            ? {
-                tags: {
-                  none: {
-                    tag: {
-                      userMutes: { some: { userId: context.session.userId } },
+
+          orderBy: { views: { _count: 'desc' } },
+          take: 20,
+        });
+      },
+    }),
+
+    tagFeed: t.withAuth({ user: true }).prismaField({
+      type: ['Post'],
+      args: { dateBefore: t.arg.string({ required: false }) },
+      resolve: async (query, _, input, { db, ...context }) => {
+        const dateBefore = input.dateBefore ? dayjs(input.dateBefore) : undefined;
+
+        return db.post.findMany({
+          ...query,
+          where: {
+            state: 'PUBLISHED',
+            createdAt: dateBefore?.isValid() ? { lt: dateBefore.toDate() } : undefined,
+            visibility: 'PUBLIC',
+            password: null,
+            publishedRevision: {
+              tags: {
+                some: {
+                  tag: {
+                    followers: {
+                      some: { userId: context.session.userId },
                     },
                   },
                 },
-              }
-            : undefined,
-        },
-
-        orderBy: { views: { _count: 'desc' } },
-        take: 20,
-      });
-    },
-  }),
-
-  tagFeed: t.withAuth({ user: true }).prismaField({
-    type: ['Post'],
-    args: { dateBefore: t.arg.string({ required: false }) },
-    resolve: async (query, _, input, { db, ...context }) => {
-      const dateBefore = input.dateBefore ? dayjs(input.dateBefore) : undefined;
-
-      return db.post.findMany({
-        ...query,
-        where: {
-          state: 'PUBLISHED',
-          createdAt: dateBefore?.isValid() ? { lt: dateBefore.toDate() } : undefined,
-          visibility: 'PUBLIC',
-          password: null,
-          publishedRevision: {
-            tags: {
-              some: {
-                tag: {
-                  followers: {
-                    some: { userId: context.session.userId },
+                none: {
+                  tag: {
+                    userMutes: { some: { userId: context.session.userId } },
                   },
                 },
               },
-              none: {
-                tag: {
-                  userMutes: { some: { userId: context.session.userId } },
-                },
+            },
+            space: {
+              state: 'ACTIVE',
+              userMutes: {
+                none: { userId: context.session.userId },
               },
             },
           },
-          space: {
-            state: 'ACTIVE',
-            userMutes: {
-              none: { userId: context.session.userId },
-            },
-          },
-        },
 
-        orderBy: { publishedAt: 'desc' },
-        take: 20,
-      });
-    },
-  }),
+          orderBy: { publishedAt: 'desc' },
+          take: 20,
+        });
+      },
+    }),
 
-  spaceFeed: t.withAuth({ user: true }).prismaField({
-    type: ['Post'],
-    args: { dateBefore: t.arg.string({ required: false }) },
-    resolve: async (query, _, input, { db, ...context }) => {
-      const dateBefore = input.dateBefore ? dayjs(input.dateBefore) : undefined;
+    spaceFeed: t.withAuth({ user: true }).prismaField({
+      type: ['Post'],
+      args: { dateBefore: t.arg.string({ required: false }) },
+      resolve: async (query, _, input, { db, ...context }) => {
+        const dateBefore = input.dateBefore ? dayjs(input.dateBefore) : undefined;
 
-      return db.post.findMany({
-        ...query,
-        where: {
-          state: 'PUBLISHED',
-          createdAt: dateBefore?.isValid() ? { lt: dateBefore.toDate() } : undefined,
-          visibility: 'PUBLIC',
-          password: null,
-          publishedRevision: {
-            tags: {
-              none: {
-                tag: {
-                  userMutes: { some: { userId: context.session.userId } },
+        return db.post.findMany({
+          ...query,
+          where: {
+            state: 'PUBLISHED',
+            createdAt: dateBefore?.isValid() ? { lt: dateBefore.toDate() } : undefined,
+            visibility: 'PUBLIC',
+            password: null,
+            publishedRevision: {
+              tags: {
+                none: {
+                  tag: {
+                    userMutes: { some: { userId: context.session.userId } },
+                  },
                 },
               },
             },
-          },
-          space: {
-            state: 'ACTIVE',
-            userMutes: {
-              none: { userId: context.session.userId },
+            space: {
+              state: 'ACTIVE',
+              userMutes: {
+                none: { userId: context.session.userId },
+              },
+              followers: {
+                some: { userId: context.session.userId },
+              },
             },
-            followers: {
-              some: { userId: context.session.userId },
+          },
+
+          orderBy: { publishedAt: 'desc' },
+          take: 20,
+        });
+      },
+    }),
+
+    recentlyCreatedTags: t.prismaField({
+      type: ['Tag'],
+      resolve: async (query, _, __, { db, ...context }) => {
+        return db.tag.findMany({
+          ...query,
+          where: {
+            userMutes: context.session ? { none: { userId: context.session.userId } } : undefined,
+          },
+
+          orderBy: { createdAt: 'desc' },
+          take: 20,
+        });
+      },
+    }),
+
+    recentlyUsedTags: t.prismaField({
+      type: ['Tag'],
+      resolve: async (query, _, __, { db, ...context }) => {
+        const postTags = await db.postRevisionTag.findMany({
+          include: { tag: query },
+          where: {
+            tag: context.session
+              ? {
+                  userMutes: { none: { userId: context.session.userId } },
+                }
+              : undefined,
+            revision: { kind: 'PUBLISHED' },
+          },
+
+          distinct: ['tagId'],
+          orderBy: { createdAt: 'desc' },
+          take: 20,
+        });
+
+        return postTags.map(({ tag }) => tag);
+      },
+    }),
+
+    recentlyPurchasedPosts: t.prismaField({
+      type: ['Post'],
+      resolve: async (query, _, __, { db, ...context }) => {
+        const postPurchases = await db.postPurchase.findMany({
+          include: { post: query },
+          where: {
+            post: {
+              state: 'PUBLISHED',
+              visibility: 'PUBLIC',
+              password: null,
+              publishedRevision: {
+                tags: context.session
+                  ? {
+                      none: {
+                        tag: {
+                          userMutes: { some: { userId: context.session.userId } },
+                        },
+                      },
+                    }
+                  : undefined,
+              },
+              space: {
+                state: 'ACTIVE',
+                visibility: 'PUBLIC',
+                userMutes: context.session
+                  ? {
+                      none: { userId: context.session.userId },
+                    }
+                  : undefined,
+              },
             },
           },
-        },
 
-        orderBy: { publishedAt: 'desc' },
-        take: 20,
-      });
-    },
-  }),
+          distinct: ['postId'],
+          orderBy: { createdAt: 'desc' },
+          take: 10,
+        });
 
-  recentlyCreatedTags: t.prismaField({
-    type: ['Tag'],
-    resolve: async (query, _, __, { db, ...context }) => {
-      return db.tag.findMany({
-        ...query,
-        where: {
-          userMutes: context.session ? { none: { userId: context.session.userId } } : undefined,
-        },
+        return postPurchases.map(({ post }) => post);
+      },
+    }),
 
-        orderBy: { createdAt: 'desc' },
-        take: 20,
-      });
-    },
-  }),
-
-  recentlyUsedTags: t.prismaField({
-    type: ['Tag'],
-    resolve: async (query, _, __, { db, ...context }) => {
-      const postTags = await db.postRevisionTag.findMany({
-        include: { tag: query },
-        where: {
-          tag: context.session
-            ? {
-                userMutes: { none: { userId: context.session.userId } },
-              }
-            : undefined,
-          revision: { kind: 'PUBLISHED' },
-        },
-
-        distinct: ['tagId'],
-        orderBy: { createdAt: 'desc' },
-        take: 20,
-      });
-
-      return postTags.map(({ tag }) => tag);
-    },
-  }),
-
-  recentlyPurchasedPosts: t.prismaField({
-    type: ['Post'],
-    resolve: async (query, _, __, { db, ...context }) => {
-      const postPurchases = await db.postPurchase.findMany({
-        include: { post: query },
-        where: {
-          post: {
+    recentlyPublishedSpaces: t.prismaField({
+      type: ['Space'],
+      resolve: async (query, _, __, { db, ...context }) => {
+        const posts = await db.post.findMany({
+          include: { space: query },
+          where: {
             state: 'PUBLISHED',
             visibility: 'PUBLIC',
             password: null,
@@ -198,54 +240,14 @@ builder.queryFields((t) => ({
                 : undefined,
             },
           },
-        },
 
-        distinct: ['postId'],
-        orderBy: { createdAt: 'desc' },
-        take: 10,
-      });
+          take: 5,
+          distinct: ['spaceId'],
+          orderBy: { publishedAt: 'desc' },
+        });
 
-      return postPurchases.map(({ post }) => post);
-    },
-  }),
-
-  recentlyPublishedSpaces: t.prismaField({
-    type: ['Space'],
-    resolve: async (query, _, __, { db, ...context }) => {
-      const posts = await db.post.findMany({
-        include: { space: query },
-        where: {
-          state: 'PUBLISHED',
-          visibility: 'PUBLIC',
-          password: null,
-          publishedRevision: {
-            tags: context.session
-              ? {
-                  none: {
-                    tag: {
-                      userMutes: { some: { userId: context.session.userId } },
-                    },
-                  },
-                }
-              : undefined,
-          },
-          space: {
-            state: 'ACTIVE',
-            visibility: 'PUBLIC',
-            userMutes: context.session
-              ? {
-                  none: { userId: context.session.userId },
-                }
-              : undefined,
-          },
-        },
-
-        take: 5,
-        distinct: ['spaceId'],
-        orderBy: { publishedAt: 'desc' },
-      });
-
-      return posts.map(({ space }) => space);
-    },
-  }),
-}));
+        return posts.map(({ space }) => space);
+      },
+    }),
+  }));
+});

--- a/apps/penxle.com/src/lib/server/graphql/schemas/file.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/file.ts
@@ -3,119 +3,121 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import * as mrmime from 'mrmime';
 import { aws } from '$lib/server/external-api';
 import { createId } from '$lib/utils';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Types
- */
+export const fileSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-builder.prismaObject('File', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    name: t.exposeString('name'),
-    size: t.exposeInt('size'),
+  builder.prismaObject('File', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      name: t.exposeString('name'),
+      size: t.exposeInt('size'),
 
-    url: t.field({
-      type: 'String',
-      resolve: (parent) => `https://pnxl.net/${parent.path}`,
+      url: t.field({
+        type: 'String',
+        resolve: (parent) => `https://pnxl.net/${parent.path}`,
+      }),
     }),
-  }),
+  });
+
+  const PrepareFileUploadResult = builder.simpleObject('PrepareFileUploadResult', {
+    fields: (t) => ({
+      key: t.string(),
+      presignedUrl: t.string(),
+    }),
+  });
+
+  /**
+   * * Inputs
+   */
+
+  const FinalizeFileUploadInput = builder.inputType('FinalizeFileUploadInput', {
+    fields: (t) => ({
+      key: t.string(),
+      name: t.string(),
+    }),
+  });
+
+  /**
+   * * Queries
+   */
+
+  // builder.queryFields((t) => ({
+  // }));
+
+  /**
+   * * Mutations
+   */
+
+  builder.mutationFields((t) => ({
+    prepareFileUpload: t.withAuth({ user: true }).field({
+      type: PrepareFileUploadResult,
+      resolve: async () => {
+        const key = aws.createS3ObjectKey('files');
+
+        const presignedUrl = await getSignedUrl(
+          aws.s3,
+          new PutObjectCommand({
+            Bucket: 'penxle-uploads',
+            Key: key,
+          }),
+          { expiresIn: 60 * 60 }, // 1 hour
+        );
+
+        return { key, presignedUrl };
+      },
+    }),
+
+    finalizeFileUpload: t.withAuth({ user: true }).prismaField({
+      type: 'File',
+      args: { input: t.arg({ type: FinalizeFileUploadInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const object = await aws.s3.send(
+          new GetObjectCommand({
+            Bucket: 'penxle-uploads',
+            Key: input.key,
+          }),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const buffer = await object.Body!.transformToByteArray();
+
+        const key = aws.createS3ObjectKey('files');
+        const ext = input.name.split('.').pop() ?? 'unk';
+        const path = `${key}.${ext}`;
+
+        await aws.s3.send(
+          new PutObjectCommand({
+            Bucket: 'penxle-data',
+            Key: path,
+            Body: buffer,
+            ContentType: object.ContentType,
+            ContentDisposition: `attachment; filename="${encodeURIComponent(input.name)}"`,
+          }),
+        );
+
+        await aws.s3.send(
+          new DeleteObjectCommand({
+            Bucket: 'penxle-uploads',
+            Key: input.key,
+          }),
+        );
+
+        return await db.file.create({
+          ...query,
+          data: {
+            id: createId(),
+            userId: context.session.userId,
+            name: input.name,
+            format: mrmime.lookup(input.name) ?? 'application/octet-stream',
+            size: buffer.byteLength,
+            path,
+          },
+        });
+      },
+    }),
+  }));
 });
-
-const PrepareFileUploadResult = builder.simpleObject('PrepareFileUploadResult', {
-  fields: (t) => ({
-    key: t.string(),
-    presignedUrl: t.string(),
-  }),
-});
-
-/**
- * * Inputs
- */
-
-const FinalizeFileUploadInput = builder.inputType('FinalizeFileUploadInput', {
-  fields: (t) => ({
-    key: t.string(),
-    name: t.string(),
-  }),
-});
-
-/**
- * * Queries
- */
-
-// builder.queryFields((t) => ({
-// }));
-
-/**
- * * Mutations
- */
-
-builder.mutationFields((t) => ({
-  prepareFileUpload: t.withAuth({ user: true }).field({
-    type: PrepareFileUploadResult,
-    resolve: async () => {
-      const key = aws.createS3ObjectKey('files');
-
-      const presignedUrl = await getSignedUrl(
-        aws.s3,
-        new PutObjectCommand({
-          Bucket: 'penxle-uploads',
-          Key: key,
-        }),
-        { expiresIn: 60 * 60 }, // 1 hour
-      );
-
-      return { key, presignedUrl };
-    },
-  }),
-
-  finalizeFileUpload: t.withAuth({ user: true }).prismaField({
-    type: 'File',
-    args: { input: t.arg({ type: FinalizeFileUploadInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const object = await aws.s3.send(
-        new GetObjectCommand({
-          Bucket: 'penxle-uploads',
-          Key: input.key,
-        }),
-      );
-
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const buffer = await object.Body!.transformToByteArray();
-
-      const key = aws.createS3ObjectKey('files');
-      const ext = input.name.split('.').pop() ?? 'unk';
-      const path = `${key}.${ext}`;
-
-      await aws.s3.send(
-        new PutObjectCommand({
-          Bucket: 'penxle-data',
-          Key: path,
-          Body: buffer,
-          ContentType: object.ContentType,
-          ContentDisposition: `attachment; filename="${encodeURIComponent(input.name)}"`,
-        }),
-      );
-
-      await aws.s3.send(
-        new DeleteObjectCommand({
-          Bucket: 'penxle-uploads',
-          Key: input.key,
-        }),
-      );
-
-      return await db.file.create({
-        ...query,
-        data: {
-          id: createId(),
-          userId: context.session.userId,
-          name: input.name,
-          format: mrmime.lookup(input.name) ?? 'application/octet-stream',
-          size: buffer.byteLength,
-          path,
-        },
-      });
-    },
-  }),
-}));

--- a/apps/penxle.com/src/lib/server/graphql/schemas/image.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/image.ts
@@ -4,142 +4,144 @@ import * as R from 'radash';
 import { aws } from '$lib/server/external-api';
 import { finalizeImage } from '$lib/server/utils';
 import { createId } from '$lib/utils';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 import type { ImageBounds } from '$lib/utils';
 
-/**
- * * Types
- */
+export const imageSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-builder.prismaObject('Image', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    width: t.exposeInt('width'),
-    height: t.exposeInt('height'),
-    placeholder: t.exposeString('placeholder'),
+  builder.prismaObject('Image', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      width: t.exposeInt('width'),
+      height: t.exposeInt('height'),
+      placeholder: t.exposeString('placeholder'),
 
-    url: t.field({
-      type: 'String',
-      resolve: (parent) => `https://pnxl.net/${parent.path}`,
+      url: t.field({
+        type: 'String',
+        resolve: (parent) => `https://pnxl.net/${parent.path}`,
+      }),
     }),
-  }),
+  });
+
+  const PrepareImageUploadResult = builder.simpleObject('PrepareImageUploadResult', {
+    fields: (t) => ({
+      key: t.string(),
+      presignedUrl: t.string(),
+    }),
+  });
+
+  /**
+   * * Inputs
+   */
+
+  const FinalizeImageUploadInput = builder.inputType('FinalizeImageUploadInput', {
+    fields: (t) => ({
+      key: t.string(),
+      name: t.string(),
+      bounds: t.field({ type: 'JSON', required: false }),
+    }),
+  });
+
+  /**
+   * * Queries
+   */
+
+  builder.queryFields((t) => ({
+    authLayoutBackgroundImage: t.prismaField({
+      type: 'Image',
+      nullable: true,
+      resolve: async (query, _, __, { db }) => {
+        return await db.image.findFirst({
+          ...query,
+          where: { name: { startsWith: 'sample' } },
+          skip: R.random(0, 99),
+          orderBy: { id: 'asc' },
+        });
+      },
+    }),
+  }));
+
+  /**
+   * * Mutations
+   */
+
+  builder.mutationFields((t) => ({
+    prepareImageUpload: t.withAuth({ user: true }).field({
+      type: PrepareImageUploadResult,
+      resolve: async () => {
+        const key = aws.createS3ObjectKey('images');
+
+        const presignedUrl = await getSignedUrl(
+          aws.s3,
+          new PutObjectCommand({
+            Bucket: 'penxle-uploads',
+            Key: key,
+          }),
+          { expiresIn: 60 * 60 }, // 1 hour
+        );
+
+        return {
+          key,
+          presignedUrl,
+        };
+      },
+    }),
+
+    finalizeImageUpload: t.withAuth({ user: true }).prismaField({
+      type: 'Image',
+      args: { input: t.arg({ type: FinalizeImageUploadInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const object = await aws.s3.send(
+          new GetObjectCommand({
+            Bucket: 'penxle-uploads',
+            Key: input.key,
+          }),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const source = await object.Body!.transformToByteArray();
+        const res = await finalizeImage(source, input.bounds as ImageBounds);
+
+        const key = aws.createS3ObjectKey('images');
+        const ext = input.name.split('.').pop() ?? 'unk';
+        const path = `${key}.${ext}`;
+
+        await aws.s3.send(
+          new PutObjectCommand({
+            Bucket: 'penxle-data',
+            Key: path,
+            Body: res.buffer,
+            ContentType: object.ContentType ?? `image/${res.format}`,
+          }),
+        );
+
+        await aws.s3.send(
+          new DeleteObjectCommand({
+            Bucket: 'penxle-uploads',
+            Key: input.key,
+          }),
+        );
+
+        return await db.image.create({
+          ...query,
+          data: {
+            id: createId(),
+            userId: context.session.userId,
+            name: input.name,
+            format: `image/${res.format}`,
+            size: res.size,
+            width: res.width,
+            height: res.height,
+            path,
+            color: res.color,
+            placeholder: res.placeholder,
+            hash: res.hash,
+          },
+        });
+      },
+    }),
+  }));
 });
-
-const PrepareImageUploadResult = builder.simpleObject('PrepareImageUploadResult', {
-  fields: (t) => ({
-    key: t.string(),
-    presignedUrl: t.string(),
-  }),
-});
-
-/**
- * * Inputs
- */
-
-const FinalizeImageUploadInput = builder.inputType('FinalizeImageUploadInput', {
-  fields: (t) => ({
-    key: t.string(),
-    name: t.string(),
-    bounds: t.field({ type: 'JSON', required: false }),
-  }),
-});
-
-/**
- * * Queries
- */
-
-builder.queryFields((t) => ({
-  authLayoutBackgroundImage: t.prismaField({
-    type: 'Image',
-    nullable: true,
-    resolve: async (query, _, __, { db }) => {
-      return await db.image.findFirst({
-        ...query,
-        where: { name: { startsWith: 'sample' } },
-        skip: R.random(0, 99),
-        orderBy: { id: 'asc' },
-      });
-    },
-  }),
-}));
-
-/**
- * * Mutations
- */
-
-builder.mutationFields((t) => ({
-  prepareImageUpload: t.withAuth({ user: true }).field({
-    type: PrepareImageUploadResult,
-    resolve: async () => {
-      const key = aws.createS3ObjectKey('images');
-
-      const presignedUrl = await getSignedUrl(
-        aws.s3,
-        new PutObjectCommand({
-          Bucket: 'penxle-uploads',
-          Key: key,
-        }),
-        { expiresIn: 60 * 60 }, // 1 hour
-      );
-
-      return {
-        key,
-        presignedUrl,
-      };
-    },
-  }),
-
-  finalizeImageUpload: t.withAuth({ user: true }).prismaField({
-    type: 'Image',
-    args: { input: t.arg({ type: FinalizeImageUploadInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const object = await aws.s3.send(
-        new GetObjectCommand({
-          Bucket: 'penxle-uploads',
-          Key: input.key,
-        }),
-      );
-
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const source = await object.Body!.transformToByteArray();
-      const res = await finalizeImage(source, input.bounds as ImageBounds);
-
-      const key = aws.createS3ObjectKey('images');
-      const ext = input.name.split('.').pop() ?? 'unk';
-      const path = `${key}.${ext}`;
-
-      await aws.s3.send(
-        new PutObjectCommand({
-          Bucket: 'penxle-data',
-          Key: path,
-          Body: res.buffer,
-          ContentType: object.ContentType ?? `image/${res.format}`,
-        }),
-      );
-
-      await aws.s3.send(
-        new DeleteObjectCommand({
-          Bucket: 'penxle-uploads',
-          Key: input.key,
-        }),
-      );
-
-      return await db.image.create({
-        ...query,
-        data: {
-          id: createId(),
-          userId: context.session.userId,
-          name: input.name,
-          format: `image/${res.format}`,
-          size: res.size,
-          width: res.width,
-          height: res.height,
-          path,
-          color: res.color,
-          placeholder: res.placeholder,
-          hash: res.hash,
-        },
-      });
-    },
-  }),
-}));

--- a/apps/penxle.com/src/lib/server/graphql/schemas/index.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/index.ts
@@ -1,20 +1,37 @@
-import './bookmark';
-import './collection';
-import './enums';
-import './feed';
-import './file';
-import './image';
-import './internal';
-import './playground';
-import './point';
-import './post';
-import './search';
-import './space';
-import './tag';
-import './user';
-
 import { dev } from '$app/environment';
-import { builder } from '../builder';
+import { addSchema, createBuilder } from '../builder';
+import { bookmarkSchema } from './bookmark';
+import { collectionSchema } from './collection';
+import { enumsSchema } from './enums';
+import { feedSchema } from './feed';
+import { fileSchema } from './file';
+import { imageSchema } from './image';
+import { internalSchema } from './internal';
+import { playgroundSchema } from './playground';
+import { pointSchema } from './point';
+import { postSchema } from './post';
+import { searchSchema } from './search';
+import { spaceSchema } from './space';
+import { tagSchema } from './tag';
+import { userSchema } from './user';
+
+const builder = createBuilder();
+addSchema(builder, [
+  bookmarkSchema,
+  collectionSchema,
+  enumsSchema,
+  feedSchema,
+  fileSchema,
+  imageSchema,
+  internalSchema,
+  playgroundSchema,
+  pointSchema,
+  postSchema,
+  searchSchema,
+  spaceSchema,
+  tagSchema,
+  userSchema,
+]);
 
 export const schema = builder.toSchema();
 

--- a/apps/penxle.com/src/lib/server/graphql/schemas/internal.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/internal.ts
@@ -1,32 +1,34 @@
 import { redis } from '$lib/server/cache';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Types
- */
+export const internalSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-const Flash = builder.simpleObject('Flash', {
-  fields: (t) => ({
-    type: t.string(),
-    message: t.string(),
-  }),
+  const Flash = builder.simpleObject('Flash', {
+    fields: (t) => ({
+      type: t.string(),
+      message: t.string(),
+    }),
+  });
+
+  /**
+   * * Queries
+   */
+
+  builder.queryFields((t) => ({
+    flash: t.field({
+      type: Flash,
+      nullable: true,
+      resolve: async (_, __, context) => {
+        const payload = await redis.getdel(`flash:${context.deviceId}`);
+        if (!payload) {
+          return null;
+        }
+
+        return JSON.parse(payload);
+      },
+    }),
+  }));
 });
-
-/**
- * * Queries
- */
-
-builder.queryFields((t) => ({
-  flash: t.field({
-    type: Flash,
-    nullable: true,
-    resolve: async (_, __, context) => {
-      const payload = await redis.getdel(`flash:${context.deviceId}`);
-      if (!payload) {
-        return null;
-      }
-
-      return JSON.parse(payload);
-    },
-  }),
-}));

--- a/apps/penxle.com/src/lib/server/graphql/schemas/playground.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/playground.ts
@@ -1,53 +1,55 @@
 import * as R from 'radash';
 import { createRandomAvatar } from '$lib/server/utils/avatar';
 import { createRandomIcon } from '$lib/server/utils/icon';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Queries
- */
+export const playgroundSchema = defineSchema((builder) => {
+  /**
+   * * Queries
+   */
 
-builder.queryFields((t) => ({
-  hello: t.string({
-    args: { name: t.arg.string() },
-    resolve: (_, args) => `Hello, ${args.name}`,
-  }),
+  builder.queryFields((t) => ({
+    hello: t.string({
+      args: { name: t.arg.string() },
+      resolve: (_, args) => `Hello, ${args.name}`,
+    }),
 
-  randomAvatars: t.stringList({
-    resolve: async () => {
-      const buffers = await Promise.all([...R.range(1, 16)].map(() => createRandomAvatar()));
-      return buffers.map((buffer) => buffer.toString('base64'));
-    },
-  }),
+    randomAvatars: t.stringList({
+      resolve: async () => {
+        const buffers = await Promise.all([...R.range(1, 16)].map(() => createRandomAvatar()));
+        return buffers.map((buffer) => buffer.toString('base64'));
+      },
+    }),
 
-  randomIcons: t.stringList({
-    resolve: async () => {
-      const buffers = await Promise.all([...R.range(1, 16)].map(() => createRandomIcon()));
-      return buffers.map((buffer) => buffer.toString('base64'));
-    },
-  }),
+    randomIcons: t.stringList({
+      resolve: async () => {
+        const buffers = await Promise.all([...R.range(1, 16)].map(() => createRandomIcon()));
+        return buffers.map((buffer) => buffer.toString('base64'));
+      },
+    }),
 
-  sampleImage: t.prismaField({
-    type: 'Image',
-    resolve: async (query, _, __, { db }) => {
-      return await db.image.findFirstOrThrow({
-        ...query,
-        where: { name: { startsWith: 'sample' } },
-        skip: R.random(0, 99),
-        orderBy: { id: 'asc' },
-      });
-    },
-  }),
-
-  sampleImages: t.prismaField({
-    type: ['Image'],
-    resolve: async (query, _, __, { db }) => {
-      return R.shuffle(
-        await db.image.findMany({
+    sampleImage: t.prismaField({
+      type: 'Image',
+      resolve: async (query, _, __, { db }) => {
+        return await db.image.findFirstOrThrow({
           ...query,
           where: { name: { startsWith: 'sample' } },
-        }),
-      );
-    },
-  }),
-}));
+          skip: R.random(0, 99),
+          orderBy: { id: 'asc' },
+        });
+      },
+    }),
+
+    sampleImages: t.prismaField({
+      type: ['Image'],
+      resolve: async (query, _, __, { db }) => {
+        return R.shuffle(
+          await db.image.findMany({
+            ...query,
+            where: { name: { startsWith: 'sample' } },
+          }),
+        );
+      },
+    }),
+  }));
+});

--- a/apps/penxle.com/src/lib/server/graphql/schemas/point.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/point.ts
@@ -5,121 +5,123 @@ import numeral from 'numeral';
 import { match } from 'ts-pattern';
 import { exim, portone } from '$lib/server/external-api';
 import { createId } from '$lib/utils';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Types
- */
+export const pointSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-builder.prismaObject('PointPurchase', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    pointAmount: t.exposeInt('pointAmount'),
-    paymentAmount: t.exposeInt('paymentAmount'),
-    paymentMethod: t.expose('paymentMethod', { type: PaymentMethod }),
-    paymentData: t.expose('paymentData', { type: 'JSON' }),
-    paymentResult: t.expose('paymentResult', { type: 'JSON', nullable: true }),
-    state: t.expose('state', { type: PointPurchaseState }),
-    expiresAt: t.expose('expiresAt', { type: 'DateTime' }),
-  }),
+  builder.prismaObject('PointPurchase', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      pointAmount: t.exposeInt('pointAmount'),
+      paymentAmount: t.exposeInt('paymentAmount'),
+      paymentMethod: t.expose('paymentMethod', { type: PaymentMethod }),
+      paymentData: t.expose('paymentData', { type: 'JSON' }),
+      paymentResult: t.expose('paymentResult', { type: 'JSON', nullable: true }),
+      state: t.expose('state', { type: PointPurchaseState }),
+      expiresAt: t.expose('expiresAt', { type: 'DateTime' }),
+    }),
+  });
+
+  /**
+   * * Inputs
+   */
+
+  const PurchasePointInput = builder.inputType('PurchasePointInput', {
+    fields: (t) => ({
+      paymentMethod: t.field({ type: PaymentMethod }),
+      pointAmount: t.int(),
+      pointAgreement: t.boolean(),
+    }),
+  });
+
+  /**
+   * * Queries
+   */
+
+  builder.queryFields((t) => ({
+    pointPurchase: t.withAuth({ user: true }).prismaField({
+      type: 'PointPurchase',
+      args: { paymentKey: t.arg.string() },
+      resolve: (query, _, args, { db, ...context }) => {
+        return db.pointPurchase.findUniqueOrThrow({
+          ...query,
+          where: {
+            paymentKey: args.paymentKey,
+            userId: context.session.userId,
+          },
+        });
+      },
+    }),
+  }));
+
+  /**
+   * * Mutations
+   */
+
+  builder.mutationFields((t) => ({
+    purchasePoint: t.withAuth({ user: true }).prismaField({
+      type: 'PointPurchase',
+      args: { input: t.arg({ type: PurchasePointInput }) },
+      resolve: async (query, __, { input }, { db, ...context }) => {
+        const user = await db.user.findUniqueOrThrow({
+          where: { id: context.session.userId },
+        });
+
+        const paymentKey = `PX${input.pointAmount}${customAlphabet('ABCDEFGHIJKLMNOPQRSTUVWXYZ')(8)}`;
+        const paymentAmount = input.pointAmount * 1.1;
+        const expiresAt = dayjs().add(1, 'hour');
+
+        const pgData = await match(input.paymentMethod)
+          .with('CREDIT_CARD', () => ({ pg: 'tosspayments', pay_method: 'card' }))
+          .with('BANK_ACCOUNT', () => ({ pg: 'tosspayments', pay_method: 'trans' }))
+          .with('VIRTUAL_BANK_ACCOUNT', () => ({
+            pg: 'tosspayments',
+            pay_method: 'vbank',
+            vbank_due: expiresAt.kst().format('YYYY-MM-DD HH:mm:ss'),
+          }))
+          .with('PHONE_BILL', () => ({ pg: 'tosspayments', pay_method: 'phone' }))
+          .with('GIFTCARD_CULTURELAND', () => ({ pg: 'tosspayments', pay_method: 'cultureland' }))
+          .with('GIFTCARD_SMARTCULTURE', () => ({ pg: 'tosspayments', pay_method: 'smartculture' }))
+          .with('GIFTCARD_BOOKNLIFE', () => ({ pg: 'tosspayments', pay_method: 'booknlife' }))
+          .with('PAYPAL', async () => ({
+            pg: 'paypal_v2',
+            pay_method: 'paypal',
+            amount: numeral(paymentAmount / (await exim.getUSDExchangeRate())).format('0.00'),
+          }))
+          .exhaustive();
+
+        const paymentData = {
+          merchant_uid: paymentKey,
+          name: `펜슬 ${input.pointAmount} P`,
+          amount: paymentAmount,
+          buyer_email: user.email,
+
+          notice_url: `${context.url.origin}/api/payment/webhook`,
+          m_redirect_url: `${context.url.origin}/api/payment/callback`,
+
+          ...pgData,
+        };
+
+        await portone.registerPaymentAmount({ paymentKey, paymentAmount: paymentData.amount });
+
+        return await db.pointPurchase.create({
+          ...query,
+          data: {
+            id: createId(),
+            userId: context.session.userId,
+            pointAmount: input.pointAmount,
+            paymentAmount,
+            paymentMethod: input.paymentMethod,
+            paymentKey,
+            paymentData,
+            state: 'PENDING',
+            expiresAt: expiresAt.toDate(),
+          },
+        });
+      },
+    }),
+  }));
 });
-
-/**
- * * Inputs
- */
-
-const PurchasePointInput = builder.inputType('PurchasePointInput', {
-  fields: (t) => ({
-    paymentMethod: t.field({ type: PaymentMethod }),
-    pointAmount: t.int(),
-    pointAgreement: t.boolean(),
-  }),
-});
-
-/**
- * * Queries
- */
-
-builder.queryFields((t) => ({
-  pointPurchase: t.withAuth({ user: true }).prismaField({
-    type: 'PointPurchase',
-    args: { paymentKey: t.arg.string() },
-    resolve: (query, _, args, { db, ...context }) => {
-      return db.pointPurchase.findUniqueOrThrow({
-        ...query,
-        where: {
-          paymentKey: args.paymentKey,
-          userId: context.session.userId,
-        },
-      });
-    },
-  }),
-}));
-
-/**
- * * Mutations
- */
-
-builder.mutationFields((t) => ({
-  purchasePoint: t.withAuth({ user: true }).prismaField({
-    type: 'PointPurchase',
-    args: { input: t.arg({ type: PurchasePointInput }) },
-    resolve: async (query, __, { input }, { db, ...context }) => {
-      const user = await db.user.findUniqueOrThrow({
-        where: { id: context.session.userId },
-      });
-
-      const paymentKey = `PX${input.pointAmount}${customAlphabet('ABCDEFGHIJKLMNOPQRSTUVWXYZ')(8)}`;
-      const paymentAmount = input.pointAmount * 1.1;
-      const expiresAt = dayjs().add(1, 'hour');
-
-      const pgData = await match(input.paymentMethod)
-        .with('CREDIT_CARD', () => ({ pg: 'tosspayments', pay_method: 'card' }))
-        .with('BANK_ACCOUNT', () => ({ pg: 'tosspayments', pay_method: 'trans' }))
-        .with('VIRTUAL_BANK_ACCOUNT', () => ({
-          pg: 'tosspayments',
-          pay_method: 'vbank',
-          vbank_due: expiresAt.kst().format('YYYY-MM-DD HH:mm:ss'),
-        }))
-        .with('PHONE_BILL', () => ({ pg: 'tosspayments', pay_method: 'phone' }))
-        .with('GIFTCARD_CULTURELAND', () => ({ pg: 'tosspayments', pay_method: 'cultureland' }))
-        .with('GIFTCARD_SMARTCULTURE', () => ({ pg: 'tosspayments', pay_method: 'smartculture' }))
-        .with('GIFTCARD_BOOKNLIFE', () => ({ pg: 'tosspayments', pay_method: 'booknlife' }))
-        .with('PAYPAL', async () => ({
-          pg: 'paypal_v2',
-          pay_method: 'paypal',
-          amount: numeral(paymentAmount / (await exim.getUSDExchangeRate())).format('0.00'),
-        }))
-        .exhaustive();
-
-      const paymentData = {
-        merchant_uid: paymentKey,
-        name: `펜슬 ${input.pointAmount} P`,
-        amount: paymentAmount,
-        buyer_email: user.email,
-
-        notice_url: `${context.url.origin}/api/payment/webhook`,
-        m_redirect_url: `${context.url.origin}/api/payment/callback`,
-
-        ...pgData,
-      };
-
-      await portone.registerPaymentAmount({ paymentKey, paymentAmount: paymentData.amount });
-
-      return await db.pointPurchase.create({
-        ...query,
-        data: {
-          id: createId(),
-          userId: context.session.userId,
-          pointAmount: input.pointAmount,
-          paymentAmount,
-          paymentMethod: input.paymentMethod,
-          paymentKey,
-          paymentData,
-          state: 'PENDING',
-          expiresAt: expiresAt.toDate(),
-        },
-      });
-    },
-  }),
-}));

--- a/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
@@ -19,994 +19,1081 @@ import { s3 } from '$lib/server/external-api/aws';
 import { deductUserPoint, directUploadImage, getUserPoint, indexPost, indexTags, isAdulthood } from '$lib/server/utils';
 import { decorateContent, revisionContentToText, sanitizeContent } from '$lib/server/utils/tiptap';
 import { base36To10, createId, createTiptapDocument, createTiptapNode } from '$lib/utils';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 import type { JSONContent } from '@tiptap/core';
 import type { ImageBounds } from '$lib/utils';
 
-/**
- * * Types
- */
+export const postSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-builder.prismaObject('Post', {
-  grantScopes: async (post, { db, ...context }) => {
-    // 글 관리 권한이 있는지 체크
-    if (context.session?.userId === post.userId) {
-      return ['$post:view', '$post:edit'];
-    }
-
-    const member = context.session
-      ? await db.spaceMember.findUnique({
-          where: {
-            spaceId_userId: {
-              spaceId: post.spaceId,
-              userId: context.session.userId,
-            },
-            state: 'ACTIVE',
-          },
-        })
-      : null;
-
-    if (member?.role === 'ADMIN') {
-      return ['$post:view', '$post:edit'];
-    }
-
-    // 이 이하부터 글 관리 권한 없음
-    // 글을 볼 권한이 없는지 체크
-
-    if (post.state !== 'PUBLISHED' || (post.visibility === 'SPACE' && member?.role !== 'MEMBER')) {
-      return [];
-    }
-
-    if (post.password) {
-      const unlock = await redis.hget(`Post:${post.id}:passwordUnlock`, context.deviceId);
-      if (!unlock || dayjs().isAfter(dayjs(unlock))) {
-        return [];
-      }
-    }
-
-    return ['$post:view'];
-  },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    state: t.expose('state', { type: PostState }),
-
-    permalink: t.exposeString('permalink'),
-    shortlink: t.field({
-      type: 'String',
-      resolve: ({ permalink }) => BigInt(permalink).toString(36),
-    }),
-
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-    publishedAt: t.expose('publishedAt', { type: 'DateTime', nullable: true }),
-
-    member: t.relation('member'),
-    space: t.relation('space'),
-    likeCount: t.relationCount('likes'),
-    viewCount: t.relationCount('views'),
-
-    visibility: t.expose('visibility', { type: PostVisibility }),
-    discloseStats: t.exposeBoolean('discloseStats'),
-    receiveFeedback: t.exposeBoolean('receiveFeedback'),
-    receivePatronage: t.exposeBoolean('receivePatronage'),
-    receiveTagContribution: t.exposeBoolean('receiveTagContribution'),
-
-    hasPassword: t.boolean({
-      resolve: (post) => !!post.password,
-    }),
-
-    unlocked: t.boolean({
-      resolve: async (post, _, context) => {
-        if (!post.password) {
-          return true;
-        }
-
-        const unlock = await redis.hget(`Post:${post.id}:passwordUnlock`, context.deviceId);
-        return !!unlock && dayjs(unlock).isAfter(dayjs());
-      },
-    }),
-
-    contentFilters: t.expose('contentFilters', { type: [ContentFilterCategory] }),
-    blurred: t.boolean({
-      resolve: async (post, _, { db, ...context }) => {
-        if (!context.session) {
-          return post.contentFilters.length > 0;
-        }
-
-        const myFilters = R.objectify(
-          // await db.userContentFilterPreference.findMany({
-          //   where: { userId: context.session.userId },
-          // }),
-          await db.user
-            .findUniqueOrThrow({
-              where: { id: context.session.userId },
-            })
-            .contentFilterPreferences(),
-          (filter) => filter.category,
-          (filter) => filter.action,
-        );
-
-        return post.contentFilters.some((filter) => myFilters[filter] !== 'EXPOSE');
-      },
-    }),
-
-    publishedRevision: t.relation('publishedRevision', {
-      authScopes: { $granted: '$post:view' },
-      nullable: true,
-      unauthorizedResolver: () => null,
-    }),
-
-    revisions: t.relation('revisions', {
-      authScopes: { $granted: '$post:edit' },
-      query: {
-        orderBy: { createdAt: 'desc' },
-      },
-    }),
-
-    draftRevision: t.prismaField({
-      type: 'PostRevision',
-      authScopes: { $granted: '$post:edit' },
-      args: { revisionId: t.arg.id({ required: false }) },
-      select: ({ revisionId }, __, nestedSelection) => ({
-        revisions: nestedSelection({
-          where: { id: revisionId },
-          orderBy: { createdAt: 'desc' },
-          take: 1,
-        }),
-      }),
-      resolve: (_, { revisions }) => revisions[0],
-    }),
-
-    liked: t.boolean({
-      resolve: async (post, _, { db, ...context }) => {
-        if (!context.session) {
-          return false;
-        }
-
-        return await db.postLike.existsUnique({
-          where: {
-            postId_userId: {
-              postId: post.id,
-              userId: context.session.userId,
-            },
-          },
-        });
-      },
-    }),
-
-    reactions: t.prismaField({
-      type: ['PostReaction'],
-      resolve: async (query, post, _, { db, ...context }) => {
-        if (!post.receiveFeedback) {
-          return [];
-        }
-
-        if (!context.session) {
-          return db.postReaction.findMany({
-            ...query,
-            where: { postId: post.id },
-          });
-        }
-
-        return [
-          ...(await db.postReaction.findMany({
-            ...query,
-            where: {
-              postId: post.id,
-              userId: context.session.userId,
-            },
-            orderBy: { createdAt: 'desc' },
-          })),
-          ...(await db.postReaction.findMany({
-            ...query,
-            where: {
-              postId: post.id,
-              userId: { not: context.session.userId },
-            },
-            orderBy: { createdAt: 'desc' },
-          })),
-        ];
-      },
-    }),
-
-    bookmarked: t.boolean({
-      deprecationReason: 'Use bookmarkGroups instead',
-      select: (_, { ...context }) => {
-        if (!context.session) {
-          return {};
-        }
-
-        return {
-          bookmarks: {
-            where: {
-              bookmarkGroup: { userId: context.session?.userId },
-            },
-          },
-        };
-      },
-
-      resolve: (post) => {
-        return post.bookmarks?.length > 0;
-      },
-    }),
-
-    bookmarkGroups: t.prismaField({
-      type: ['BookmarkGroup'],
-      resolve: (query, post, __, { db, ...context }) => {
-        if (!context.session) {
-          return [];
-        }
-
-        return db.bookmarkGroup.findMany({
-          ...query,
-          where: {
-            userId: context.session.userId,
-            posts: {
-              some: {
-                postId: post.id,
-              },
-            },
-          },
-        });
-      },
-
-      unauthorizedResolver: () => [],
-    }),
-
-    purchasedAt: t.field({
-      type: 'DateTime',
-      nullable: true,
-      select: (_, context) => ({
-        purchases: context.session
-          ? {
-              where: {
-                userId: context.session?.userId,
-              },
-              take: 1,
-            }
-          : undefined,
-      }),
-
-      resolve: ({ purchases }, _, context) => {
-        if (!context.session) {
-          return null;
-        }
-
-        return purchases[0]?.createdAt ?? null;
-      },
-    }),
-
-    //// deprecated
-
-    purchasedRevision: t.withAuth({ user: true }).prismaField({
-      type: 'PostRevision',
-      deprecationReason: 'Use PostPurchase.revision instead',
-      nullable: true,
-      select: (_, context, nestedSelection) => ({
-        revisions: nestedSelection({
-          where: {
-            purchases: {
-              some: { userId: context.session.userId },
-            },
-          },
-          take: 1,
-        }),
-      }),
-
-      resolve: (_, { revisions }) => revisions[0],
-    }),
-  }),
-});
-
-builder.prismaObject('PostRevision', {
-  grantScopes: async (revision, { db, ...context }) => {
-    const post = await db.post.findUniqueOrThrow({
-      where: { id: revision.postId },
-    });
-
-    if (post.contentFilters.includes('ADULT')) {
-      if (!context.session) {
-        return [];
+  builder.prismaObject('Post', {
+    grantScopes: async (post, { db, ...context }) => {
+      // 글 관리 권한이 있는지 체크
+      if (context.session?.userId === post.userId) {
+        return ['$post:view', '$post:edit'];
       }
 
-      const identity = await db.userPersonalIdentity.findUnique({
-        where: { userId: context.session.userId },
-      });
-
-      if (!identity || !isAdulthood(identity.birthday)) {
-        return [];
-      }
-    }
-
-    return ['$postRevision:view'];
-  },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    kind: t.expose('kind', { type: PostRevisionKind }),
-    title: t.exposeString('title'),
-    subtitle: t.exposeString('subtitle', { nullable: true }),
-    price: t.exposeInt('price', { nullable: true }),
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-    updatedAt: t.expose('updatedAt', { type: 'DateTime' }),
-
-    originalThumbnail: t.relation('originalThumbnail', {
-      nullable: true,
-      authScopes: { $granted: '$postRevision:view' },
-      unauthorizedResolver: () => null,
-    }),
-
-    croppedThumbnail: t.relation('croppedThumbnail', {
-      nullable: true,
-      authScopes: { $granted: '$postRevision:view' },
-      unauthorizedResolver: () => null,
-    }),
-
-    thumbnailBounds: t.expose('thumbnailBounds', {
-      type: 'JSON',
-      nullable: true,
-      authScopes: { $granted: '$postRevision:view' },
-      unauthorizedResolver: () => null,
-    }),
-
-    tags: t.prismaField({
-      type: ['Tag'],
-      select: (_, __, nestedSelection) => ({
-        tags: {
-          include: { tag: nestedSelection() },
-        },
-      }),
-
-      resolve: (_, { tags }) => tags.map(({ tag }) => tag),
-    }),
-
-    contentKind: t.expose('contentKind', { type: PostRevisionContentKind }),
-
-    content: t.field({
-      type: 'JSON',
-      authScopes: { $granted: '$postRevision:view' },
-      select: { post: true, freeContent: true, paidContent: true },
-      resolve: async (revision, _, { db, ...context }) => {
-        const freeContent = await decorateContent(db, revision.freeContent.data as JSONContent[]);
-        const paidContent = revision.paidContent
-          ? await decorateContent(db, revision.paidContent.data as JSONContent[])
-          : null;
-
-        if (!paidContent) {
-          return createTiptapDocument(freeContent);
-        }
-
-        if (context.session) {
-          const purchase = await db.postPurchase.findUnique({
-            where: {
-              postId_userId: {
-                postId: revision.post.id,
-                userId: context.session.userId,
-              },
-            },
-          });
-
-          if (purchase) {
-            return createTiptapDocument([
-              ...freeContent,
-              createTiptapNode({
-                type: 'access_barrier',
-                attrs: {
-                  price: revision.price,
-                  __data: {
-                    purchasable: false,
-                    purchasedAt: dayjs(purchase.createdAt).toISOString(),
-                  },
-                },
-              }),
-              ...paidContent,
-            ]);
-          }
-
-          const isMember = await db.spaceMember.existsUnique({
+      const member = context.session
+        ? await db.spaceMember.findUnique({
             where: {
               spaceId_userId: {
-                spaceId: revision.post.spaceId,
+                spaceId: post.spaceId,
+                userId: context.session.userId,
+              },
+              state: 'ACTIVE',
+            },
+          })
+        : null;
+
+      if (member?.role === 'ADMIN') {
+        return ['$post:view', '$post:edit'];
+      }
+
+      // 이 이하부터 글 관리 권한 없음
+      // 글을 볼 권한이 없는지 체크
+
+      if (post.state !== 'PUBLISHED' || (post.visibility === 'SPACE' && member?.role !== 'MEMBER')) {
+        return [];
+      }
+
+      if (post.password) {
+        const unlock = await redis.hget(`Post:${post.id}:passwordUnlock`, context.deviceId);
+        if (!unlock || dayjs().isAfter(dayjs(unlock))) {
+          return [];
+        }
+      }
+
+      return ['$post:view'];
+    },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      state: t.expose('state', { type: PostState }),
+
+      permalink: t.exposeString('permalink'),
+      shortlink: t.field({
+        type: 'String',
+        resolve: ({ permalink }) => BigInt(permalink).toString(36),
+      }),
+
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+      publishedAt: t.expose('publishedAt', { type: 'DateTime', nullable: true }),
+
+      member: t.relation('member'),
+      space: t.relation('space'),
+      likeCount: t.relationCount('likes'),
+      viewCount: t.relationCount('views'),
+
+      visibility: t.expose('visibility', { type: PostVisibility }),
+      discloseStats: t.exposeBoolean('discloseStats'),
+      receiveFeedback: t.exposeBoolean('receiveFeedback'),
+      receivePatronage: t.exposeBoolean('receivePatronage'),
+      receiveTagContribution: t.exposeBoolean('receiveTagContribution'),
+
+      hasPassword: t.boolean({
+        resolve: (post) => !!post.password,
+      }),
+
+      unlocked: t.boolean({
+        resolve: async (post, _, context) => {
+          if (!post.password) {
+            return true;
+          }
+
+          const unlock = await redis.hget(`Post:${post.id}:passwordUnlock`, context.deviceId);
+          return !!unlock && dayjs(unlock).isAfter(dayjs());
+        },
+      }),
+
+      contentFilters: t.expose('contentFilters', { type: [ContentFilterCategory] }),
+      blurred: t.boolean({
+        resolve: async (post, _, { db, ...context }) => {
+          if (!context.session) {
+            return post.contentFilters.length > 0;
+          }
+
+          const myFilters = R.objectify(
+            // await db.userContentFilterPreference.findMany({
+            //   where: { userId: context.session.userId },
+            // }),
+            await db.user
+              .findUniqueOrThrow({
+                where: { id: context.session.userId },
+              })
+              .contentFilterPreferences(),
+            (filter) => filter.category,
+            (filter) => filter.action,
+          );
+
+          return post.contentFilters.some((filter) => myFilters[filter] !== 'EXPOSE');
+        },
+      }),
+
+      publishedRevision: t.relation('publishedRevision', {
+        authScopes: { $granted: '$post:view' },
+        nullable: true,
+        unauthorizedResolver: () => null,
+      }),
+
+      revisions: t.relation('revisions', {
+        authScopes: { $granted: '$post:edit' },
+        query: {
+          orderBy: { createdAt: 'desc' },
+        },
+      }),
+
+      draftRevision: t.prismaField({
+        type: 'PostRevision',
+        authScopes: { $granted: '$post:edit' },
+        args: { revisionId: t.arg.id({ required: false }) },
+        select: ({ revisionId }, __, nestedSelection) => ({
+          revisions: nestedSelection({
+            where: { id: revisionId },
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+          }),
+        }),
+        resolve: (_, { revisions }) => revisions[0],
+      }),
+
+      liked: t.boolean({
+        resolve: async (post, _, { db, ...context }) => {
+          if (!context.session) {
+            return false;
+          }
+
+          return await db.postLike.existsUnique({
+            where: {
+              postId_userId: {
+                postId: post.id,
                 userId: context.session.userId,
               },
             },
           });
-
-          if (isMember) {
-            return createTiptapDocument([
-              ...freeContent,
-              createTiptapNode({
-                type: 'access_barrier',
-                attrs: {
-                  price: revision.price,
-                  __data: { purchasable: false },
-                },
-              }),
-              ...paidContent,
-            ]);
-          }
-        }
-
-        const paidContentText = await revisionContentToText(revision.paidContent);
-
-        let paidContentImageCount = 0,
-          paidContentFileCount = 0;
-        for (const node of paidContent) {
-          if (node.type === 'image') {
-            paidContentImageCount++;
-          } else if (node.type === 'file') {
-            paidContentFileCount++;
-          }
-        }
-
-        return createTiptapDocument([
-          ...freeContent,
-          createTiptapNode({
-            type: 'access_barrier',
-            attrs: {
-              price: revision.price,
-              __data: {
-                purchasable: true,
-
-                point: context.session ? await getUserPoint({ db, userId: context.session.userId }) : null,
-
-                postId: revision.post.id,
-                revisionId: revision.id,
-
-                counts: {
-                  characters: paidContentText.length,
-                  images: paidContentImageCount,
-                  files: paidContentFileCount,
-                },
-              },
-            },
-          }),
-        ]);
-      },
-
-      unauthorizedResolver: () => createTiptapDocument([]),
-    }),
-
-    characterCount: t.field({
-      type: 'Int',
-      authScopes: { $granted: '$postRevision:view' },
-      select: { freeContent: true, paidContent: true },
-      resolve: async (revision) => {
-        const contentText = await revisionContentToText(revision.freeContent);
-        const paidContentText = revision.paidContent ? await revisionContentToText(revision.paidContent) : '';
-        return contentText.length + paidContentText.length;
-      },
-
-      unauthorizedResolver: () => 0,
-    }),
-
-    previewText: t.field({
-      type: 'String',
-      select: { freeContent: true },
-      resolve: async (revision) => {
-        const contentText = await revisionContentToText(revision.freeContent);
-        return contentText.slice(0, 200).replaceAll(/\s+/g, ' ');
-      },
-
-      unauthorizedResolver: () => '',
-    }),
-  }),
-});
-
-builder.prismaObject('PostReaction', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    emoji: t.exposeString('emoji'),
-
-    mine: t.boolean({
-      resolve: async (reaction, _, { ...context }) => {
-        if (!context.session) {
-          return false;
-        }
-
-        return reaction.userId === context.session.userId;
-      },
-    }),
-  }),
-});
-
-/**
- * * Inputs
- */
-
-const RevisePostInput = builder.inputType('RevisePostInput', {
-  fields: (t) => ({
-    revisionKind: t.field({ type: PostRevisionKind }),
-    contentKind: t.field({ type: PostRevisionContentKind, defaultValue: 'ARTICLE' }),
-
-    postId: t.id({ required: false }),
-    spaceId: t.id(),
-
-    title: t.string(),
-    subtitle: t.string({ required: false }),
-    content: t.field({ type: 'JSON' }),
-
-    thumbnailId: t.id({ required: false }),
-    thumbnailBounds: t.field({ type: 'JSON', required: false }),
-    tags: t.stringList({ defaultValue: [] }),
-  }),
-});
-
-const PublishPostInput = builder.inputType('PublishPostInput', {
-  fields: (t) => ({
-    revisionId: t.id(),
-    visibility: t.field({ type: PostVisibility }),
-    discloseStats: t.boolean(),
-    receiveFeedback: t.boolean(),
-    receivePatronage: t.boolean(),
-    receiveTagContribution: t.boolean(),
-    contentFilters: t.field({ type: [ContentFilterCategory] }),
-    password: t.string({ required: false }),
-  }),
-});
-
-const UpdatePostOptionsInput = builder.inputType('UpdatePostOptionsInput', {
-  fields: (t) => ({
-    postId: t.id(),
-    visibility: t.field({ type: PostVisibility, required: false }),
-    discloseStats: t.boolean({ required: false }),
-    receiveFeedback: t.boolean({ required: false }),
-    receivePatronage: t.boolean({ required: false }),
-    receiveTagContribution: t.boolean({ required: false }),
-  }),
-});
-
-const DeletePostInput = builder.inputType('DeletePostInput', {
-  fields: (t) => ({
-    postId: t.id(),
-  }),
-});
-
-const LikePostInput = builder.inputType('LikePostInput', {
-  fields: (t) => ({
-    postId: t.id(),
-  }),
-});
-
-const UnlikePostInput = builder.inputType('UnlikePostInput', {
-  fields: (t) => ({
-    postId: t.id(),
-  }),
-});
-
-const PurchasePostInput = builder.inputType('PurchasePostInput', {
-  fields: (t) => ({
-    postId: t.id(),
-    revisionId: t.id(),
-  }),
-});
-
-const UpdatePostViewInput = builder.inputType('UpdatePostViewInput', {
-  fields: (t) => ({
-    postId: t.id(),
-  }),
-});
-
-const CreatePostReactionInput = builder.inputType('CreatePostReactionInput', {
-  fields: (t) => ({
-    postId: t.id(),
-    emoji: t.string(),
-  }),
-});
-
-const DeletePostReactionInput = builder.inputType('DeletePostReactionInput', {
-  fields: (t) => ({
-    postId: t.id(),
-    emoji: t.string(),
-  }),
-});
-
-const UnlockPasswordedPostInput = builder.inputType('UnlockPasswordedPostInput', {
-  fields: (t) => ({
-    postId: t.id(),
-    password: t.string(),
-  }),
-});
-
-/**
- * * Queries
- */
-
-builder.queryFields((t) => ({
-  post: t.prismaField({
-    type: 'Post',
-    args: { permalink: t.arg.string() },
-    resolve: async (query, _, args, { db, ...context }) => {
-      const post = await db.post.findUnique({
-        include: { space: true },
-        where: {
-          permalink: args.permalink,
-          state: { not: 'DELETED' },
-          space: {
-            state: 'ACTIVE',
-          },
         },
-      });
+      }),
 
-      if (!post) {
-        throw new NotFoundError();
-      }
+      reactions: t.prismaField({
+        type: ['PostReaction'],
+        resolve: async (query, post, _, { db, ...context }) => {
+          if (!post.receiveFeedback) {
+            return [];
+          }
 
-      if (post.space.visibility === 'PRIVATE' || post.state === 'DRAFT' || post.visibility === 'SPACE') {
-        const member = context.session
-          ? await db.spaceMember.findUnique({
+          if (!context.session) {
+            return db.postReaction.findMany({
+              ...query,
+              where: { postId: post.id },
+            });
+          }
+
+          return [
+            ...(await db.postReaction.findMany({
+              ...query,
               where: {
-                spaceId_userId: {
-                  spaceId: post.space.id,
-                  userId: context.session.userId,
-                },
-                state: 'ACTIVE',
+                postId: post.id,
+                userId: context.session.userId,
               },
-            })
-          : null;
-
-        if (!member || (post.state === 'DRAFT' && member.role !== 'ADMIN' && post.userId !== context.session?.userId)) {
-          throw new PermissionDeniedError();
-        }
-      }
-
-      return await db.post.findUniqueOrThrow({
-        ...query,
-        where: { id: post.id },
-      });
-    },
-  }),
-
-  // draftRevision: t.withAuth({ user: true }).prismaField({
-  //   type: 'PostRevision',
-  //   args: { revisionId: t.arg.id() },
-  //   resolve: async (query, _, args, { db, ...context }) =>
-  //     // TODO: 어드민도 접근할 수 있게 권한 체크 추가
-  //     db.postRevision.findUniqueOrThrow({
-  //       ...query,
-  //       where: {
-  //         id: args.revisionId,
-  //         userId: context.session.userId,
-  //       },
-  //     }),
-  // }),
-}));
-
-/**
- * * Mutations
- */
-
-builder.mutationFields((t) => ({
-  revisePost: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: RevisePostInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const meAsMember = await db.spaceMember.findUniqueOrThrow({
-        where: {
-          spaceId_userId: {
-            spaceId: input.spaceId,
-            userId: context.session.userId,
-          },
-        },
-      });
-
-      if (input.postId) {
-        const post = await db.post.findUniqueOrThrow({
-          where: { id: input.postId },
-        });
-
-        if (post.userId !== context.session.userId && (post.spaceId !== input.spaceId || meAsMember.role !== 'ADMIN')) {
-          throw new NotFoundError();
-        }
-
-        if (post.state === 'PUBLISHED' && post.spaceId !== input.spaceId) {
-          throw new IntentionalError('이미 다른 스페이스에 게시된 글이에요.');
-        }
-      }
-
-      let document = (input.content as JSONContent).content;
-      if (!document) {
-        throw new FormValidationError('content', '잘못된 내용이에요');
-      }
-
-      const lastRevision = input.postId
-        ? await db.postRevision.findFirst({
-            where: { postId: input.postId },
-            orderBy: { createdAt: 'desc' },
-          })
-        : undefined;
-
-      document = await sanitizeContent(document);
-
-      let croppedImageId: string | undefined;
-      if (input.thumbnailId) {
-        if (input.thumbnailBounds) {
-          const originalImageData = await db.image.findUniqueOrThrow({
-            where: {
-              id: input.thumbnailId,
-              userId: context.session.userId,
-            },
-          });
-
-          const originalImageRequest = await s3.send(
-            new GetObjectCommand({
-              Bucket: 'penxle-data',
-              Key: originalImageData.path,
-            }),
-          );
-
-          croppedImageId = await directUploadImage({
-            db,
-            userId: context.session.userId,
-            name: originalImageData.name,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            source: await originalImageRequest.Body!.transformToByteArray(),
-            bounds: input.thumbnailBounds as ImageBounds,
-          });
-        } else {
-          croppedImageId = lastRevision?.croppedThumbnailId ?? undefined;
-        }
-      }
-
-      const accessBarrierPosition = document.findIndex((node) => node.type === 'access_barrier');
-      const accessBarrier = accessBarrierPosition === -1 ? undefined : document[accessBarrierPosition];
-      const freeContentData = accessBarrierPosition === -1 ? document : document.slice(0, accessBarrierPosition);
-      const paidContentData = accessBarrierPosition === -1 ? undefined : document.slice(accessBarrierPosition + 1);
-      const freeContentHash = Buffer.from(
-        await webcrypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(freeContentData))),
-      ).toString('hex');
-      const paidContentHash = paidContentData
-        ? Buffer.from(
-            await webcrypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(paidContentData))),
-          ).toString('hex')
-        : undefined;
-
-      const freeContent = await db.postRevisionContent.upsert({
-        where: { hash: freeContentHash },
-        create: {
-          id: createId(),
-          hash: freeContentHash,
-          data: freeContentData,
-        },
-        update: {},
-      });
-
-      const paidContent = paidContentData
-        ? await db.postRevisionContent.upsert({
-            where: { hash: paidContentHash },
-            create: {
-              id: createId(),
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              hash: paidContentHash!,
-              data: paidContentData,
-            },
-            update: {},
-          })
-        : undefined;
-
-      const price: number | undefined = accessBarrier?.attrs?.price;
-
-      const postId = input.postId ?? createId();
-
-      const postTags = await Promise.all(
-        (input.tags ?? []).map((tagName) =>
-          db.tag.upsert({
-            where: { name: tagName },
-            create: {
-              id: createId(),
-              name: tagName,
-            },
-            update: {},
-          }),
-        ),
-      );
-
-      const revisionData = {
-        userId: context.session.userId,
-        kind: input.revisionKind,
-        contentKind: input.contentKind,
-        title: input.title,
-        subtitle: input.subtitle?.length ? input.subtitle : undefined,
-        freeContentId: freeContent.id,
-        paidContentId: paidContent?.id,
-        tags: {
-          createMany: {
-            data: postTags.map((tag) => ({
-              id: createId(),
-              tagId: tag.id,
+              orderBy: { createdAt: 'desc' },
             })),
-          },
+            ...(await db.postReaction.findMany({
+              ...query,
+              where: {
+                postId: post.id,
+                userId: { not: context.session.userId },
+              },
+              orderBy: { createdAt: 'desc' },
+            })),
+          ];
         },
-        price,
-        originalThumbnailId: input.thumbnailId,
-        croppedThumbnailId: croppedImageId,
-        thumbnailBounds: input.thumbnailBounds,
-      };
+      }),
 
-      /// 여기까지 데이터 가공 단계
-      /// 여기부터 포스트 생성/수정 단계
+      bookmarked: t.boolean({
+        deprecationReason: 'Use bookmarkGroups instead',
+        select: (_, { ...context }) => {
+          if (!context.session) {
+            return {};
+          }
 
-      // 1. 일단 포스트가 없었다면 생성
-      if (!input.postId) {
-        await db.post.create({
-          data: {
-            id: postId,
-            permalink: base36To10(cuid({ length: 6 })()),
-            spaceId: input.spaceId,
-            memberId: meAsMember.id,
-            userId: context.session.userId,
-            state: 'DRAFT',
-            visibility: 'SPACE',
-            discloseStats: true,
-            receiveFeedback: true,
-            receivePatronage: true,
-            receiveTagContribution: true,
-            contentFilters: [],
-          },
-        });
-      }
-
-      // 2. 리비전 생성/재사용
-
-      let revisionId = createId();
-
-      if (
-        lastRevision &&
-        lastRevision.kind === 'AUTO_SAVE' &&
-        dayjs(lastRevision.createdAt).add(5, 'minutes').isAfter(dayjs())
-      ) {
-        await db.postRevision.update({
-          where: { id: lastRevision.id },
-          data: {
-            ...revisionData,
-            tags: {
-              deleteMany: {},
-              createMany: revisionData.tags.createMany,
+          return {
+            bookmarks: {
+              where: {
+                bookmarkGroup: { userId: context.session?.userId },
+              },
             },
-            updatedAt: new Date(),
-          },
-        });
-        revisionId = lastRevision.id;
-      } else {
-        await db.postRevision.create({
-          data: {
-            id: revisionId,
-            postId,
-            ...revisionData,
-          },
-        });
-      }
-
-      /// 여기까지 포스트 생성/수정 단계
-
-      return await db.post.findUniqueOrThrow({
-        ...query,
-        where: { id: postId },
-      });
-    },
-  }),
-
-  publishPost: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: PublishPostInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const revision = await db.postRevision.update({
-        include: { post: true, tags: { include: { tag: true } } },
-        where: {
-          id: input.revisionId,
-          post: {
-            state: { not: 'DELETED' },
-          },
+          };
         },
-        data: { kind: 'PUBLISHED' },
-      });
 
-      if (revision.userId !== context.session.userId) {
-        const meAsMember = await db.spaceMember.findUniqueOrThrow({
-          where: {
-            spaceId_userId: {
-              spaceId: revision.post.id,
+        resolve: (post) => {
+          return post.bookmarks?.length > 0;
+        },
+      }),
+
+      bookmarkGroups: t.prismaField({
+        type: ['BookmarkGroup'],
+        resolve: (query, post, __, { db, ...context }) => {
+          if (!context.session) {
+            return [];
+          }
+
+          return db.bookmarkGroup.findMany({
+            ...query,
+            where: {
               userId: context.session.userId,
+              posts: {
+                some: {
+                  postId: post.id,
+                },
+              },
             },
-            state: 'ACTIVE',
-          },
-        });
+          });
+        },
 
-        if (meAsMember.role !== 'ADMIN') {
-          throw new PermissionDeniedError();
+        unauthorizedResolver: () => [],
+      }),
+
+      purchasedAt: t.field({
+        type: 'DateTime',
+        nullable: true,
+        select: (_, context) => ({
+          purchases: context.session
+            ? {
+                where: {
+                  userId: context.session?.userId,
+                },
+                take: 1,
+              }
+            : undefined,
+        }),
+
+        resolve: ({ purchases }, _, context) => {
+          if (!context.session) {
+            return null;
+          }
+
+          return purchases[0]?.createdAt ?? null;
+        },
+      }),
+
+      //// deprecated
+
+      purchasedRevision: t.withAuth({ user: true }).prismaField({
+        type: 'PostRevision',
+        deprecationReason: 'Use PostPurchase.revision instead',
+        nullable: true,
+        select: (_, context, nestedSelection) => ({
+          revisions: nestedSelection({
+            where: {
+              purchases: {
+                some: { userId: context.session.userId },
+              },
+            },
+            take: 1,
+          }),
+        }),
+
+        resolve: (_, { revisions }) => revisions[0],
+      }),
+    }),
+  });
+
+  builder.prismaObject('PostRevision', {
+    grantScopes: async (revision, { db, ...context }) => {
+      const post = await db.post.findUniqueOrThrow({
+        where: { id: revision.postId },
+      });
+
+      if (post.contentFilters.includes('ADULT')) {
+        if (!context.session) {
+          return [];
         }
-      }
 
-      if (input.contentFilters.includes('ADULT')) {
         const identity = await db.userPersonalIdentity.findUnique({
           where: { userId: context.session.userId },
         });
 
         if (!identity || !isAdulthood(identity.birthday)) {
-          throw new IntentionalError('성인인증을 하지 않으면 성인 컨텐츠를 게시할 수 없어요');
+          return [];
         }
       }
 
-      const password = await match(input.password)
-        .with('', () => revision.post.password)
-        .with(P.string, (password) => hash(password))
-        .with(P.nullish, () => null)
-        .exhaustive();
-
-      await db.postRevision.updateMany({
-        where: {
-          postId: revision.post.id,
-          kind: 'PUBLISHED',
-          id: { not: revision.id },
-        },
-        data: { kind: 'ARCHIVED' },
-      });
-
-      const post = await db.post.update({
-        ...query,
-        where: { id: revision.post.id },
-        data: {
-          state: 'PUBLISHED',
-          publishedAt: revision.post.publishedAt ?? new Date(),
-          publishedRevisionId: revision.id,
-          visibility: input.visibility,
-          discloseStats: input.discloseStats,
-          receiveFeedback: input.receiveFeedback,
-          receivePatronage: input.receivePatronage,
-          receiveTagContribution: input.receiveTagContribution,
-          contentFilters: input.contentFilters,
-          password,
-        },
-      });
-
-      await indexPost({ db, postId: revision.post.id });
-      await indexTags({ tags: revision.tags.map(({ tag }) => tag) });
-      return post;
+      return ['$postRevision:view'];
     },
-  }),
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      kind: t.expose('kind', { type: PostRevisionKind }),
+      title: t.exposeString('title'),
+      subtitle: t.exposeString('subtitle', { nullable: true }),
+      price: t.exposeInt('price', { nullable: true }),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+      updatedAt: t.expose('updatedAt', { type: 'DateTime' }),
 
-  updatePostOptions: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: UpdatePostOptionsInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const post = await db.post.update({
-        select: { id: true, password: true },
-        where: {
-          id: input.postId,
-          OR: [
-            { userId: context.session.userId },
-            { space: { members: { some: { userId: context.session.userId, role: 'ADMIN', state: 'ACTIVE' } } } },
-          ],
+      originalThumbnail: t.relation('originalThumbnail', {
+        nullable: true,
+        authScopes: { $granted: '$postRevision:view' },
+        unauthorizedResolver: () => null,
+      }),
+
+      croppedThumbnail: t.relation('croppedThumbnail', {
+        nullable: true,
+        authScopes: { $granted: '$postRevision:view' },
+        unauthorizedResolver: () => null,
+      }),
+
+      thumbnailBounds: t.expose('thumbnailBounds', {
+        type: 'JSON',
+        nullable: true,
+        authScopes: { $granted: '$postRevision:view' },
+        unauthorizedResolver: () => null,
+      }),
+
+      tags: t.prismaField({
+        type: ['Tag'],
+        select: (_, __, nestedSelection) => ({
+          tags: {
+            include: { tag: nestedSelection() },
+          },
+        }),
+
+        resolve: (_, { tags }) => tags.map(({ tag }) => tag),
+      }),
+
+      contentKind: t.expose('contentKind', { type: PostRevisionContentKind }),
+
+      content: t.field({
+        type: 'JSON',
+        authScopes: { $granted: '$postRevision:view' },
+        select: { post: true, freeContent: true, paidContent: true },
+        resolve: async (revision, _, { db, ...context }) => {
+          const freeContent = await decorateContent(db, revision.freeContent.data as JSONContent[]);
+          const paidContent = revision.paidContent
+            ? await decorateContent(db, revision.paidContent.data as JSONContent[])
+            : null;
+
+          if (!paidContent) {
+            return createTiptapDocument(freeContent);
+          }
+
+          if (context.session) {
+            const purchase = await db.postPurchase.findUnique({
+              where: {
+                postId_userId: {
+                  postId: revision.post.id,
+                  userId: context.session.userId,
+                },
+              },
+            });
+
+            if (purchase) {
+              return createTiptapDocument([
+                ...freeContent,
+                createTiptapNode({
+                  type: 'access_barrier',
+                  attrs: {
+                    price: revision.price,
+                    __data: {
+                      purchasable: false,
+                      purchasedAt: dayjs(purchase.createdAt).toISOString(),
+                    },
+                  },
+                }),
+                ...paidContent,
+              ]);
+            }
+
+            const isMember = await db.spaceMember.existsUnique({
+              where: {
+                spaceId_userId: {
+                  spaceId: revision.post.spaceId,
+                  userId: context.session.userId,
+                },
+              },
+            });
+
+            if (isMember) {
+              return createTiptapDocument([
+                ...freeContent,
+                createTiptapNode({
+                  type: 'access_barrier',
+                  attrs: {
+                    price: revision.price,
+                    __data: { purchasable: false },
+                  },
+                }),
+                ...paidContent,
+              ]);
+            }
+          }
+
+          const paidContentText = await revisionContentToText(revision.paidContent);
+
+          let paidContentImageCount = 0,
+            paidContentFileCount = 0;
+          for (const node of paidContent) {
+            if (node.type === 'image') {
+              paidContentImageCount++;
+            } else if (node.type === 'file') {
+              paidContentFileCount++;
+            }
+          }
+
+          return createTiptapDocument([
+            ...freeContent,
+            createTiptapNode({
+              type: 'access_barrier',
+              attrs: {
+                price: revision.price,
+                __data: {
+                  purchasable: true,
+
+                  point: context.session ? await getUserPoint({ db, userId: context.session.userId }) : null,
+
+                  postId: revision.post.id,
+                  revisionId: revision.id,
+
+                  counts: {
+                    characters: paidContentText.length,
+                    images: paidContentImageCount,
+                    files: paidContentFileCount,
+                  },
+                },
+              },
+            }),
+          ]);
         },
 
-        data: {
-          visibility: input.visibility ?? undefined,
-          discloseStats: input.discloseStats ?? undefined,
-          receiveFeedback: input.receiveFeedback ?? undefined,
-          receivePatronage: input.receivePatronage ?? undefined,
-          receiveTagContribution: input.receiveTagContribution ?? undefined,
+        unauthorizedResolver: () => createTiptapDocument([]),
+      }),
+
+      characterCount: t.field({
+        type: 'Int',
+        authScopes: { $granted: '$postRevision:view' },
+        select: { freeContent: true, paidContent: true },
+        resolve: async (revision) => {
+          const contentText = await revisionContentToText(revision.freeContent);
+          const paidContentText = revision.paidContent ? await revisionContentToText(revision.paidContent) : '';
+          return contentText.length + paidContentText.length;
         },
-      });
 
-      if (input.visibility) {
-        await indexPost({ db, postId: post.id });
-      }
+        unauthorizedResolver: () => 0,
+      }),
 
-      return db.post.findUniqueOrThrow({
-        ...query,
-        where: { id: post.id },
-      });
-    },
-  }),
+      previewText: t.field({
+        type: 'String',
+        select: { freeContent: true },
+        resolve: async (revision) => {
+          const contentText = await revisionContentToText(revision.freeContent);
+          return contentText.slice(0, 200).replaceAll(/\s+/g, ' ');
+        },
 
-  deletePost: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: DeletePostInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const post = await db.post.findUniqueOrThrow({
-        where: { id: input.postId },
-      });
+        unauthorizedResolver: () => '',
+      }),
+    }),
+  });
 
-      if (post.userId !== context.session.userId) {
+  builder.prismaObject('PostReaction', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      emoji: t.exposeString('emoji'),
+
+      mine: t.boolean({
+        resolve: async (reaction, _, { ...context }) => {
+          if (!context.session) {
+            return false;
+          }
+
+          return reaction.userId === context.session.userId;
+        },
+      }),
+    }),
+  });
+
+  /**
+   * * Inputs
+   */
+
+  const RevisePostInput = builder.inputType('RevisePostInput', {
+    fields: (t) => ({
+      revisionKind: t.field({ type: PostRevisionKind }),
+      contentKind: t.field({ type: PostRevisionContentKind, defaultValue: 'ARTICLE' }),
+
+      postId: t.id({ required: false }),
+      spaceId: t.id(),
+
+      title: t.string(),
+      subtitle: t.string({ required: false }),
+      content: t.field({ type: 'JSON' }),
+
+      thumbnailId: t.id({ required: false }),
+      thumbnailBounds: t.field({ type: 'JSON', required: false }),
+      tags: t.stringList({ defaultValue: [] }),
+    }),
+  });
+
+  const PublishPostInput = builder.inputType('PublishPostInput', {
+    fields: (t) => ({
+      revisionId: t.id(),
+      visibility: t.field({ type: PostVisibility }),
+      discloseStats: t.boolean(),
+      receiveFeedback: t.boolean(),
+      receivePatronage: t.boolean(),
+      receiveTagContribution: t.boolean(),
+      contentFilters: t.field({ type: [ContentFilterCategory] }),
+      password: t.string({ required: false }),
+    }),
+  });
+
+  const UpdatePostOptionsInput = builder.inputType('UpdatePostOptionsInput', {
+    fields: (t) => ({
+      postId: t.id(),
+      visibility: t.field({ type: PostVisibility, required: false }),
+      discloseStats: t.boolean({ required: false }),
+      receiveFeedback: t.boolean({ required: false }),
+      receivePatronage: t.boolean({ required: false }),
+      receiveTagContribution: t.boolean({ required: false }),
+    }),
+  });
+
+  const DeletePostInput = builder.inputType('DeletePostInput', {
+    fields: (t) => ({
+      postId: t.id(),
+    }),
+  });
+
+  const LikePostInput = builder.inputType('LikePostInput', {
+    fields: (t) => ({
+      postId: t.id(),
+    }),
+  });
+
+  const UnlikePostInput = builder.inputType('UnlikePostInput', {
+    fields: (t) => ({
+      postId: t.id(),
+    }),
+  });
+
+  const PurchasePostInput = builder.inputType('PurchasePostInput', {
+    fields: (t) => ({
+      postId: t.id(),
+      revisionId: t.id(),
+    }),
+  });
+
+  const UpdatePostViewInput = builder.inputType('UpdatePostViewInput', {
+    fields: (t) => ({
+      postId: t.id(),
+    }),
+  });
+
+  const CreatePostReactionInput = builder.inputType('CreatePostReactionInput', {
+    fields: (t) => ({
+      postId: t.id(),
+      emoji: t.string(),
+    }),
+  });
+
+  const DeletePostReactionInput = builder.inputType('DeletePostReactionInput', {
+    fields: (t) => ({
+      postId: t.id(),
+      emoji: t.string(),
+    }),
+  });
+
+  const UnlockPasswordedPostInput = builder.inputType('UnlockPasswordedPostInput', {
+    fields: (t) => ({
+      postId: t.id(),
+      password: t.string(),
+    }),
+  });
+
+  /**
+   * * Queries
+   */
+
+  builder.queryFields((t) => ({
+    post: t.prismaField({
+      type: 'Post',
+      args: { permalink: t.arg.string() },
+      resolve: async (query, _, args, { db, ...context }) => {
+        const post = await db.post.findUnique({
+          include: { space: true },
+          where: {
+            permalink: args.permalink,
+            state: { not: 'DELETED' },
+            space: {
+              state: 'ACTIVE',
+            },
+          },
+        });
+
+        if (!post) {
+          throw new NotFoundError();
+        }
+
+        if (post.space.visibility === 'PRIVATE' || post.state === 'DRAFT' || post.visibility === 'SPACE') {
+          const member = context.session
+            ? await db.spaceMember.findUnique({
+                where: {
+                  spaceId_userId: {
+                    spaceId: post.space.id,
+                    userId: context.session.userId,
+                  },
+                  state: 'ACTIVE',
+                },
+              })
+            : null;
+
+          if (
+            !member ||
+            (post.state === 'DRAFT' && member.role !== 'ADMIN' && post.userId !== context.session?.userId)
+          ) {
+            throw new PermissionDeniedError();
+          }
+        }
+
+        return await db.post.findUniqueOrThrow({
+          ...query,
+          where: { id: post.id },
+        });
+      },
+    }),
+
+    // draftRevision: t.withAuth({ user: true }).prismaField({
+    //   type: 'PostRevision',
+    //   args: { revisionId: t.arg.id() },
+    //   resolve: async (query, _, args, { db, ...context }) =>
+    //     // TODO: 어드민도 접근할 수 있게 권한 체크 추가
+    //     db.postRevision.findUniqueOrThrow({
+    //       ...query,
+    //       where: {
+    //         id: args.revisionId,
+    //         userId: context.session.userId,
+    //       },
+    //     }),
+    // }),
+  }));
+
+  /**
+   * * Mutations
+   */
+
+  builder.mutationFields((t) => ({
+    revisePost: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: RevisePostInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
         const meAsMember = await db.spaceMember.findUniqueOrThrow({
+          where: {
+            spaceId_userId: {
+              spaceId: input.spaceId,
+              userId: context.session.userId,
+            },
+          },
+        });
+
+        if (input.postId) {
+          const post = await db.post.findUniqueOrThrow({
+            where: { id: input.postId },
+          });
+
+          if (
+            post.userId !== context.session.userId &&
+            (post.spaceId !== input.spaceId || meAsMember.role !== 'ADMIN')
+          ) {
+            throw new NotFoundError();
+          }
+
+          if (post.state === 'PUBLISHED' && post.spaceId !== input.spaceId) {
+            throw new IntentionalError('이미 다른 스페이스에 게시된 글이에요.');
+          }
+        }
+
+        let document = (input.content as JSONContent).content;
+        if (!document) {
+          throw new FormValidationError('content', '잘못된 내용이에요');
+        }
+
+        const lastRevision = input.postId
+          ? await db.postRevision.findFirst({
+              where: { postId: input.postId },
+              orderBy: { createdAt: 'desc' },
+            })
+          : undefined;
+
+        document = await sanitizeContent(document);
+
+        let croppedImageId: string | undefined;
+        if (input.thumbnailId) {
+          if (input.thumbnailBounds) {
+            const originalImageData = await db.image.findUniqueOrThrow({
+              where: {
+                id: input.thumbnailId,
+                userId: context.session.userId,
+              },
+            });
+
+            const originalImageRequest = await s3.send(
+              new GetObjectCommand({
+                Bucket: 'penxle-data',
+                Key: originalImageData.path,
+              }),
+            );
+
+            croppedImageId = await directUploadImage({
+              db,
+              userId: context.session.userId,
+              name: originalImageData.name,
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              source: await originalImageRequest.Body!.transformToByteArray(),
+              bounds: input.thumbnailBounds as ImageBounds,
+            });
+          } else {
+            croppedImageId = lastRevision?.croppedThumbnailId ?? undefined;
+          }
+        }
+
+        const accessBarrierPosition = document.findIndex((node) => node.type === 'access_barrier');
+        const accessBarrier = accessBarrierPosition === -1 ? undefined : document[accessBarrierPosition];
+        const freeContentData = accessBarrierPosition === -1 ? document : document.slice(0, accessBarrierPosition);
+        const paidContentData = accessBarrierPosition === -1 ? undefined : document.slice(accessBarrierPosition + 1);
+        const freeContentHash = Buffer.from(
+          await webcrypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(freeContentData))),
+        ).toString('hex');
+        const paidContentHash = paidContentData
+          ? Buffer.from(
+              await webcrypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(paidContentData))),
+            ).toString('hex')
+          : undefined;
+
+        const freeContent = await db.postRevisionContent.upsert({
+          where: { hash: freeContentHash },
+          create: {
+            id: createId(),
+            hash: freeContentHash,
+            data: freeContentData,
+          },
+          update: {},
+        });
+
+        const paidContent = paidContentData
+          ? await db.postRevisionContent.upsert({
+              where: { hash: paidContentHash },
+              create: {
+                id: createId(),
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                hash: paidContentHash!,
+                data: paidContentData,
+              },
+              update: {},
+            })
+          : undefined;
+
+        const price: number | undefined = accessBarrier?.attrs?.price;
+
+        const postId = input.postId ?? createId();
+
+        const postTags = await Promise.all(
+          (input.tags ?? []).map((tagName) =>
+            db.tag.upsert({
+              where: { name: tagName },
+              create: {
+                id: createId(),
+                name: tagName,
+              },
+              update: {},
+            }),
+          ),
+        );
+
+        const revisionData = {
+          userId: context.session.userId,
+          kind: input.revisionKind,
+          contentKind: input.contentKind,
+          title: input.title,
+          subtitle: input.subtitle?.length ? input.subtitle : undefined,
+          freeContentId: freeContent.id,
+          paidContentId: paidContent?.id,
+          tags: {
+            createMany: {
+              data: postTags.map((tag) => ({
+                id: createId(),
+                tagId: tag.id,
+              })),
+            },
+          },
+          price,
+          originalThumbnailId: input.thumbnailId,
+          croppedThumbnailId: croppedImageId,
+          thumbnailBounds: input.thumbnailBounds,
+        };
+
+        /// 여기까지 데이터 가공 단계
+        /// 여기부터 포스트 생성/수정 단계
+
+        // 1. 일단 포스트가 없었다면 생성
+        if (!input.postId) {
+          await db.post.create({
+            data: {
+              id: postId,
+              permalink: base36To10(cuid({ length: 6 })()),
+              spaceId: input.spaceId,
+              memberId: meAsMember.id,
+              userId: context.session.userId,
+              state: 'DRAFT',
+              visibility: 'SPACE',
+              discloseStats: true,
+              receiveFeedback: true,
+              receivePatronage: true,
+              receiveTagContribution: true,
+              contentFilters: [],
+            },
+          });
+        }
+
+        // 2. 리비전 생성/재사용
+
+        let revisionId = createId();
+
+        if (
+          lastRevision &&
+          lastRevision.kind === 'AUTO_SAVE' &&
+          dayjs(lastRevision.createdAt).add(5, 'minutes').isAfter(dayjs())
+        ) {
+          await db.postRevision.update({
+            where: { id: lastRevision.id },
+            data: {
+              ...revisionData,
+              tags: {
+                deleteMany: {},
+                createMany: revisionData.tags.createMany,
+              },
+              updatedAt: new Date(),
+            },
+          });
+          revisionId = lastRevision.id;
+        } else {
+          await db.postRevision.create({
+            data: {
+              id: revisionId,
+              postId,
+              ...revisionData,
+            },
+          });
+        }
+
+        /// 여기까지 포스트 생성/수정 단계
+
+        return await db.post.findUniqueOrThrow({
+          ...query,
+          where: { id: postId },
+        });
+      },
+    }),
+
+    publishPost: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: PublishPostInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const revision = await db.postRevision.update({
+          include: { post: true, tags: { include: { tag: true } } },
+          where: {
+            id: input.revisionId,
+            post: {
+              state: { not: 'DELETED' },
+            },
+          },
+          data: { kind: 'PUBLISHED' },
+        });
+
+        if (revision.userId !== context.session.userId) {
+          const meAsMember = await db.spaceMember.findUniqueOrThrow({
+            where: {
+              spaceId_userId: {
+                spaceId: revision.post.id,
+                userId: context.session.userId,
+              },
+              state: 'ACTIVE',
+            },
+          });
+
+          if (meAsMember.role !== 'ADMIN') {
+            throw new PermissionDeniedError();
+          }
+        }
+
+        if (input.contentFilters.includes('ADULT')) {
+          const identity = await db.userPersonalIdentity.findUnique({
+            where: { userId: context.session.userId },
+          });
+
+          if (!identity || !isAdulthood(identity.birthday)) {
+            throw new IntentionalError('성인인증을 하지 않으면 성인 컨텐츠를 게시할 수 없어요');
+          }
+        }
+
+        const password = await match(input.password)
+          .with('', () => revision.post.password)
+          .with(P.string, (password) => hash(password))
+          .with(P.nullish, () => null)
+          .exhaustive();
+
+        await db.postRevision.updateMany({
+          where: {
+            postId: revision.post.id,
+            kind: 'PUBLISHED',
+            id: { not: revision.id },
+          },
+          data: { kind: 'ARCHIVED' },
+        });
+
+        const post = await db.post.update({
+          ...query,
+          where: { id: revision.post.id },
+          data: {
+            state: 'PUBLISHED',
+            publishedAt: revision.post.publishedAt ?? new Date(),
+            publishedRevisionId: revision.id,
+            visibility: input.visibility,
+            discloseStats: input.discloseStats,
+            receiveFeedback: input.receiveFeedback,
+            receivePatronage: input.receivePatronage,
+            receiveTagContribution: input.receiveTagContribution,
+            contentFilters: input.contentFilters,
+            password,
+          },
+        });
+
+        await indexPost({ db, postId: revision.post.id });
+        await indexTags({ tags: revision.tags.map(({ tag }) => tag) });
+        return post;
+      },
+    }),
+
+    updatePostOptions: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: UpdatePostOptionsInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const post = await db.post.update({
+          select: { id: true, password: true },
+          where: {
+            id: input.postId,
+            OR: [
+              { userId: context.session.userId },
+              { space: { members: { some: { userId: context.session.userId, role: 'ADMIN', state: 'ACTIVE' } } } },
+            ],
+          },
+
+          data: {
+            visibility: input.visibility ?? undefined,
+            discloseStats: input.discloseStats ?? undefined,
+            receiveFeedback: input.receiveFeedback ?? undefined,
+            receivePatronage: input.receivePatronage ?? undefined,
+            receiveTagContribution: input.receiveTagContribution ?? undefined,
+          },
+        });
+
+        if (input.visibility) {
+          await indexPost({ db, postId: post.id });
+        }
+
+        return db.post.findUniqueOrThrow({
+          ...query,
+          where: { id: post.id },
+        });
+      },
+    }),
+
+    deletePost: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: DeletePostInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const post = await db.post.findUniqueOrThrow({
+          where: { id: input.postId },
+        });
+
+        if (post.userId !== context.session.userId) {
+          const meAsMember = await db.spaceMember.findUniqueOrThrow({
+            where: {
+              spaceId_userId: {
+                spaceId: post.spaceId,
+                userId: context.session.userId,
+              },
+            },
+          });
+
+          if (meAsMember.role !== 'ADMIN') {
+            throw new PermissionDeniedError();
+          }
+        }
+
+        return await db.post.update({
+          ...query,
+          where: { id: post.id },
+          data: {
+            state: 'DELETED',
+            publishedRevision: { update: { kind: 'ARCHIVED' } },
+          },
+        });
+      },
+    }),
+
+    likePost: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: LikePostInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        return db.post.update({
+          ...query,
+          where: { id: input.postId },
+          data: {
+            likes: {
+              upsert: {
+                where: {
+                  postId_userId: {
+                    postId: input.postId,
+                    userId: context.session.userId,
+                  },
+                },
+                create: {
+                  id: createId(),
+                  userId: context.session.userId,
+                },
+                update: {},
+              },
+            },
+          },
+        });
+      },
+    }),
+
+    unlikePost: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: UnlikePostInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        return db.post.update({
+          ...query,
+          where: { id: input.postId },
+          data: {
+            likes: {
+              deleteMany: {
+                userId: context.session.userId,
+              },
+            },
+          },
+        });
+      },
+    }),
+
+    purchasePost: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: PurchasePostInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const post = await db.post.findUniqueOrThrow({
+          include: { publishedRevision: true },
+          where: { id: input.postId },
+        });
+
+        const isMember = await db.spaceMember.existsUnique({
           where: {
             spaceId_userId: {
               spaceId: post.spaceId,
@@ -1015,240 +1102,161 @@ builder.mutationFields((t) => ({
           },
         });
 
-        if (meAsMember.role !== 'ADMIN') {
-          throw new PermissionDeniedError();
+        if (isMember || !post.publishedRevision?.price) {
+          throw new IntentionalError('구매할 수 없는 포스트예요');
         }
-      }
 
-      return await db.post.update({
-        ...query,
-        where: { id: post.id },
-        data: {
-          state: 'DELETED',
-          publishedRevision: { update: { kind: 'ARCHIVED' } },
-        },
-      });
-    },
-  }),
-
-  likePost: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: LikePostInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      return db.post.update({
-        ...query,
-        where: { id: input.postId },
-        data: {
-          likes: {
-            upsert: {
-              where: {
-                postId_userId: {
-                  postId: input.postId,
-                  userId: context.session.userId,
-                },
-              },
-              create: {
-                id: createId(),
-                userId: context.session.userId,
-              },
-              update: {},
-            },
-          },
-        },
-      });
-    },
-  }),
-
-  unlikePost: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: UnlikePostInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      return db.post.update({
-        ...query,
-        where: { id: input.postId },
-        data: {
-          likes: {
-            deleteMany: {
+        const purchased = await db.postPurchase.existsUnique({
+          where: {
+            postId_userId: {
+              postId: input.postId,
               userId: context.session.userId,
             },
           },
-        },
-      });
-    },
-  }),
-
-  purchasePost: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: PurchasePostInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const post = await db.post.findUniqueOrThrow({
-        include: { publishedRevision: true },
-        where: { id: input.postId },
-      });
-
-      const isMember = await db.spaceMember.existsUnique({
-        where: {
-          spaceId_userId: {
-            spaceId: post.spaceId,
-            userId: context.session.userId,
-          },
-        },
-      });
-
-      if (isMember || !post.publishedRevision?.price) {
-        throw new IntentionalError('구매할 수 없는 포스트예요');
-      }
-
-      const purchased = await db.postPurchase.existsUnique({
-        where: {
-          postId_userId: {
-            postId: input.postId,
-            userId: context.session.userId,
-          },
-        },
-      });
-
-      if (purchased) {
-        throw new IntentionalError('이미 구매한 포스트예요');
-      }
-
-      if (post.publishedRevision.id !== input.revisionId) {
-        throw new IntentionalError('포스트 내용이 변경되었어요. 다시 시도해 주세요');
-      }
-
-      const purchase = await db.postPurchase.create({
-        data: {
-          id: createId(),
-          userId: context.session.userId,
-          postId: input.postId,
-          revisionId: post.publishedRevision.id,
-        },
-      });
-
-      await deductUserPoint({
-        db,
-        userId: context.session.userId,
-        amount: post.publishedRevision.price,
-        targetId: purchase.id,
-        cause: 'UNLOCK_CONTENT',
-      });
-
-      return await db.post.findUniqueOrThrow({
-        ...query,
-        where: { id: input.postId },
-      });
-    },
-  }),
-
-  updatePostView: t.prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: UpdatePostViewInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const view = await db.postView.findFirst({
-        where: {
-          postId: input.postId,
-          userId: context.session ? context.session.userId : undefined,
-          deviceId: context.session ? undefined : context.deviceId,
-        },
-      });
-
-      if (view) {
-        await db.postView.update({
-          where: { id: view.id },
-          data: {
-            deviceId: context.deviceId,
-            viewedAt: new Date(),
-          },
         });
-      } else {
-        await db.postView.create({
-          data: {
-            id: createId(),
-            postId: input.postId,
-            userId: context.session?.userId,
-            deviceId: context.deviceId,
-          },
-        });
-      }
 
-      return db.post.findUniqueOrThrow({
-        ...query,
-        where: { id: input.postId },
-      });
-    },
-  }),
-
-  createPostReaction: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: CreatePostReactionInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      if (!emojiData.emojis[input.emoji]) {
-        throw new IntentionalError('잘못된 이모지예요');
-      }
-
-      const post = await db.post.findUniqueOrThrow({
-        where: { id: input.postId },
-      });
-
-      if (!post.receiveFeedback) {
-        throw new IntentionalError('피드백을 받지 않는 포스트예요');
-      }
-
-      await db.postReaction.create({
-        data: {
-          id: createId(),
-          userId: context.session.userId,
-          postId: input.postId,
-          emoji: input.emoji,
-        },
-      });
-
-      return db.post.findUniqueOrThrow({
-        ...query,
-        where: { id: input.postId },
-      });
-    },
-  }),
-
-  deletePostReaction: t.withAuth({ user: true }).prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: DeletePostReactionInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      await db.postReaction.deleteMany({
-        where: {
-          postId: input.postId,
-          userId: context.session.userId,
-          emoji: input.emoji,
-        },
-      });
-      return db.post.findUniqueOrThrow({
-        ...query,
-        where: { id: input.postId },
-      });
-    },
-  }),
-
-  unlockPasswordedPost: t.prismaField({
-    type: 'Post',
-    args: { input: t.arg({ type: UnlockPasswordedPostInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const post = await db.post.findUniqueOrThrow({
-        where: { id: input.postId },
-      });
-
-      if (post.password) {
-        if (!(await verify(post.password, input.password))) {
-          throw new FormValidationError('password', '잘못된 비밀번호예요');
+        if (purchased) {
+          throw new IntentionalError('이미 구매한 포스트예요');
         }
 
-        await redis.hset(`Post:${post.id}:passwordUnlock`, context.deviceId, dayjs().add(1, 'hour').toISOString());
-        await redis.expire(`Post:${post.id}:passwordUnlock`, 60 * 60);
-      }
+        if (post.publishedRevision.id !== input.revisionId) {
+          throw new IntentionalError('포스트 내용이 변경되었어요. 다시 시도해 주세요');
+        }
 
-      return db.post.findUniqueOrThrow({
-        ...query,
-        where: { id: post.id },
-      });
-    },
-  }),
-}));
+        const purchase = await db.postPurchase.create({
+          data: {
+            id: createId(),
+            userId: context.session.userId,
+            postId: input.postId,
+            revisionId: post.publishedRevision.id,
+          },
+        });
+
+        await deductUserPoint({
+          db,
+          userId: context.session.userId,
+          amount: post.publishedRevision.price,
+          targetId: purchase.id,
+          cause: 'UNLOCK_CONTENT',
+        });
+
+        return await db.post.findUniqueOrThrow({
+          ...query,
+          where: { id: input.postId },
+        });
+      },
+    }),
+
+    updatePostView: t.prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: UpdatePostViewInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const view = await db.postView.findFirst({
+          where: {
+            postId: input.postId,
+            userId: context.session ? context.session.userId : undefined,
+            deviceId: context.session ? undefined : context.deviceId,
+          },
+        });
+
+        if (view) {
+          await db.postView.update({
+            where: { id: view.id },
+            data: {
+              deviceId: context.deviceId,
+              viewedAt: new Date(),
+            },
+          });
+        } else {
+          await db.postView.create({
+            data: {
+              id: createId(),
+              postId: input.postId,
+              userId: context.session?.userId,
+              deviceId: context.deviceId,
+            },
+          });
+        }
+
+        return db.post.findUniqueOrThrow({
+          ...query,
+          where: { id: input.postId },
+        });
+      },
+    }),
+
+    createPostReaction: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: CreatePostReactionInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        if (!emojiData.emojis[input.emoji]) {
+          throw new IntentionalError('잘못된 이모지예요');
+        }
+
+        const post = await db.post.findUniqueOrThrow({
+          where: { id: input.postId },
+        });
+
+        if (!post.receiveFeedback) {
+          throw new IntentionalError('피드백을 받지 않는 포스트예요');
+        }
+
+        await db.postReaction.create({
+          data: {
+            id: createId(),
+            userId: context.session.userId,
+            postId: input.postId,
+            emoji: input.emoji,
+          },
+        });
+
+        return db.post.findUniqueOrThrow({
+          ...query,
+          where: { id: input.postId },
+        });
+      },
+    }),
+
+    deletePostReaction: t.withAuth({ user: true }).prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: DeletePostReactionInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        await db.postReaction.deleteMany({
+          where: {
+            postId: input.postId,
+            userId: context.session.userId,
+            emoji: input.emoji,
+          },
+        });
+        return db.post.findUniqueOrThrow({
+          ...query,
+          where: { id: input.postId },
+        });
+      },
+    }),
+
+    unlockPasswordedPost: t.prismaField({
+      type: 'Post',
+      args: { input: t.arg({ type: UnlockPasswordedPostInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const post = await db.post.findUniqueOrThrow({
+          where: { id: input.postId },
+        });
+
+        if (post.password) {
+          if (!(await verify(post.password, input.password))) {
+            throw new FormValidationError('password', '잘못된 비밀번호예요');
+          }
+
+          await redis.hset(`Post:${post.id}:passwordUnlock`, context.deviceId, dayjs().add(1, 'hour').toISOString());
+          await redis.expire(`Post:${post.id}:passwordUnlock`, 60 * 60);
+        }
+
+        return db.post.findUniqueOrThrow({
+          ...query,
+          where: { id: post.id },
+        });
+      },
+    }),
+  }));
+});

--- a/apps/penxle.com/src/lib/server/graphql/schemas/search.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/search.ts
@@ -1,188 +1,190 @@
 import * as R from 'radash';
 import { openSearch } from '$lib/server/search';
 import { disassembleHangulString } from '$lib/utils';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-type SearchHits = {
-  _id: string;
-  _score: number;
-  _source: {
-    id: string;
-    title: string;
-    subtitle?: string;
-    spaceId: string;
-    tags: string[];
+export const searchSchema = defineSchema((builder) => {
+  type SearchHits = {
+    _id: string;
+    _score: number;
+    _source: {
+      id: string;
+      title: string;
+      subtitle?: string;
+      spaceId: string;
+      tags: string[];
+    };
   };
-};
 
-/**
- * * Queries
- */
+  /**
+   * * Queries
+   */
 
-builder.queryFields((t) => ({
-  searchPosts: t.prismaField({
-    type: ['Post'],
-    args: {
-      query: t.arg.string(),
-    },
-    resolve: async (query, _, args, { db, ...context }) => {
-      const mutedTags = context.session
-        ? await db.userTagMute.findMany({
-            where: { userId: context.session.userId },
-          })
-        : [];
+  builder.queryFields((t) => ({
+    searchPosts: t.prismaField({
+      type: ['Post'],
+      args: {
+        query: t.arg.string(),
+      },
+      resolve: async (query, _, args, { db, ...context }) => {
+        const mutedTags = context.session
+          ? await db.userTagMute.findMany({
+              where: { userId: context.session.userId },
+            })
+          : [];
 
-      const mutedSpaces = context.session
-        ? await db.userSpaceMute.findMany({
-            where: { userId: context.session.userId },
-          })
-        : [];
+        const mutedSpaces = context.session
+          ? await db.userSpaceMute.findMany({
+              where: { userId: context.session.userId },
+            })
+          : [];
 
-      const searchResult = await openSearch.search({
-        index: 'posts',
-        body: {
-          query: {
-            bool: {
-              should: [
-                { match_phrase: { title: args.query } },
-                { match_phrase: { subtitle: args.query } },
-                { match: { tags: args.query } },
-              ],
-              must: [
-                {
-                  multi_match: {
-                    query: args.query,
-                    fields: ['title', 'subtitle', 'tags'],
+        const searchResult = await openSearch.search({
+          index: 'posts',
+          body: {
+            query: {
+              bool: {
+                should: [
+                  { match_phrase: { title: args.query } },
+                  { match_phrase: { subtitle: args.query } },
+                  { match: { tags: args.query } },
+                ],
+                must: [
+                  {
+                    multi_match: {
+                      query: args.query,
+                      fields: ['title', 'subtitle', 'tags'],
+                    },
                   },
-                },
-              ],
-              must_not: R.sift([
-                mutedTags.length > 0
-                  ? {
-                      terms: { ['tags.id']: mutedTags.map(({ tagId }) => tagId) },
-                    }
-                  : undefined,
-                mutedSpaces.length > 0
-                  ? {
-                      terms: { spaceId: mutedSpaces.map(({ spaceId }) => spaceId) },
-                    }
-                  : undefined,
-              ]),
+                ],
+                must_not: R.sift([
+                  mutedTags.length > 0
+                    ? {
+                        terms: { ['tags.id']: mutedTags.map(({ tagId }) => tagId) },
+                      }
+                    : undefined,
+                  mutedSpaces.length > 0
+                    ? {
+                        terms: { spaceId: mutedSpaces.map(({ spaceId }) => spaceId) },
+                      }
+                    : undefined,
+                ]),
+              },
             },
           },
-        },
-      });
+        });
 
-      const hits: SearchHits[] = searchResult.body.hits.hits;
-      const resultIds = hits.map((hit) => hit._id);
-      const posts = R.objectify(
-        await db.post.findMany({
-          ...query,
-          where: {
-            id: { in: resultIds },
-            state: 'PUBLISHED',
-            space: {
-              state: 'ACTIVE',
-              visibility: 'PUBLIC',
+        const hits: SearchHits[] = searchResult.body.hits.hits;
+        const resultIds = hits.map((hit) => hit._id);
+        const posts = R.objectify(
+          await db.post.findMany({
+            ...query,
+            where: {
+              id: { in: resultIds },
+              state: 'PUBLISHED',
+              space: {
+                state: 'ACTIVE',
+                visibility: 'PUBLIC',
+              },
             },
-          },
-        }),
-        (post) => post.id,
-      );
+          }),
+          (post) => post.id,
+        );
 
-      return R.sift(hits.map((hit) => posts[hit._id]));
-    },
-  }),
+        return R.sift(hits.map((hit) => posts[hit._id]));
+      },
+    }),
 
-  searchSpaces: t.prismaField({
-    type: ['Space'],
-    args: {
-      query: t.arg.string(),
-    },
-    resolve: async (query, _, args, { db, ...context }) => {
-      const mutedSpaces = context.session
-        ? await db.userSpaceMute.findMany({
-            where: { userId: context.session.userId },
-          })
-        : [];
+    searchSpaces: t.prismaField({
+      type: ['Space'],
+      args: {
+        query: t.arg.string(),
+      },
+      resolve: async (query, _, args, { db, ...context }) => {
+        const mutedSpaces = context.session
+          ? await db.userSpaceMute.findMany({
+              where: { userId: context.session.userId },
+            })
+          : [];
 
-      const searchResult = await openSearch.search({
-        index: 'spaces',
-        body: {
-          query: {
-            bool: {
-              should: [{ match_phrase: { name: args.query } }],
-              must: [
-                {
-                  multi_match: {
-                    query: args.query,
-                    fields: ['name'],
+        const searchResult = await openSearch.search({
+          index: 'spaces',
+          body: {
+            query: {
+              bool: {
+                should: [{ match_phrase: { name: args.query } }],
+                must: [
+                  {
+                    multi_match: {
+                      query: args.query,
+                      fields: ['name'],
+                    },
                   },
-                },
-              ],
-              must_not: R.sift([
-                mutedSpaces.length > 0
-                  ? {
-                      ids: { values: mutedSpaces.map(({ spaceId }) => spaceId) },
-                    }
-                  : undefined,
-              ]),
+                ],
+                must_not: R.sift([
+                  mutedSpaces.length > 0
+                    ? {
+                        ids: { values: mutedSpaces.map(({ spaceId }) => spaceId) },
+                      }
+                    : undefined,
+                ]),
+              },
             },
           },
-        },
-      });
+        });
 
-      const hits: SearchHits[] = searchResult.body.hits.hits;
-      const resultIds = hits.map((hit) => hit._id);
-      const spaces = R.objectify(
-        await db.space.findMany({
-          ...query,
-          where: {
-            id: { in: resultIds },
-          },
-        }),
-        (space) => space.id,
-      );
+        const hits: SearchHits[] = searchResult.body.hits.hits;
+        const resultIds = hits.map((hit) => hit._id);
+        const spaces = R.objectify(
+          await db.space.findMany({
+            ...query,
+            where: {
+              id: { in: resultIds },
+            },
+          }),
+          (space) => space.id,
+        );
 
-      return R.sift(hits.map((hit) => spaces[hit._id]));
-    },
-  }),
+        return R.sift(hits.map((hit) => spaces[hit._id]));
+      },
+    }),
 
-  searchTags: t.prismaField({
-    type: ['Tag'],
-    args: { query: t.arg.string() },
-    resolve: async (query, _, args, { db }) => {
-      const searchResult = await openSearch.search({
-        index: 'tags',
-        body: {
-          query: {
-            bool: {
-              should: [
-                { match_phrase: { 'name.raw': args.query } },
-                {
-                  match_phrase: /^[ㄱ-ㅎ]+$/.test(args.query)
-                    ? { 'name.initial': args.query }
-                    : { 'name.disassembled': disassembleHangulString(args.query) },
-                },
-              ],
+    searchTags: t.prismaField({
+      type: ['Tag'],
+      args: { query: t.arg.string() },
+      resolve: async (query, _, args, { db }) => {
+        const searchResult = await openSearch.search({
+          index: 'tags',
+          body: {
+            query: {
+              bool: {
+                should: [
+                  { match_phrase: { 'name.raw': args.query } },
+                  {
+                    match_phrase: /^[ㄱ-ㅎ]+$/.test(args.query)
+                      ? { 'name.initial': args.query }
+                      : { 'name.disassembled': disassembleHangulString(args.query) },
+                  },
+                ],
+              },
             },
           },
-        },
-      });
+        });
 
-      const hits: SearchHits[] = searchResult.body.hits.hits;
-      const resultIds = hits.map((hit) => hit._id);
-      const tags = R.objectify(
-        await db.tag.findMany({
-          ...query,
-          where: {
-            id: { in: resultIds },
-          },
-        }),
-        (tag) => tag.id,
-      );
+        const hits: SearchHits[] = searchResult.body.hits.hits;
+        const resultIds = hits.map((hit) => hit._id);
+        const tags = R.objectify(
+          await db.tag.findMany({
+            ...query,
+            where: {
+              id: { in: resultIds },
+            },
+          }),
+          (tag) => tag.id,
+        );
 
-      return R.sift(hits.map((hit) => tags[hit._id]));
-    },
-  }),
-}));
+        return R.sift(hits.map((hit) => tags[hit._id]));
+      },
+    }),
+  }));
+});

--- a/apps/penxle.com/src/lib/server/graphql/schemas/space.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/space.ts
@@ -10,1026 +10,1028 @@ import {
   CreateSpaceSchema,
   UpdateSpaceSchema,
 } from '$lib/validations';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Types
- */
+export const spaceSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-builder.prismaObject('Space', {
-  grantScopes: async (space, { db, ...context }) => {
-    if (!context.session) {
-      return [];
-    }
+  builder.prismaObject('Space', {
+    grantScopes: async (space, { db, ...context }) => {
+      if (!context.session) {
+        return [];
+      }
 
-    const member = await db.spaceMember.findUnique({
-      where: {
-        spaceId_userId: {
-          spaceId: space.id,
-          userId: context.session.userId,
-        },
-        state: 'ACTIVE',
-      },
-    });
-
-    if (!member) {
-      return [];
-    }
-
-    return R.sift(['$space:member', member.role === 'ADMIN' && '$space:admin']);
-  },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    slug: t.exposeString('slug'),
-    name: t.exposeString('name'),
-    description: t.exposeString('description', { nullable: true }),
-    icon: t.relation('icon'),
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-
-    followed: t.boolean({
-      resolve: async (space, _, { db, ...context }) => {
-        if (!context.session) {
-          return false;
-        }
-
-        return await db.spaceFollow.existsUnique({
-          where: {
-            userId_spaceId: {
-              userId: context.session.userId,
-              spaceId: space.id,
-            },
-          },
-        });
-      },
-    }),
-
-    meAsMember: t.prismaField({
-      type: 'SpaceMember',
-      nullable: true,
-      resolve: async (query, space, __, { db, ...context }) => {
-        if (!context.session) {
-          return null;
-        }
-
-        return await db.spaceMember.findUnique({
-          ...query,
-          where: {
-            spaceId_userId: {
-              spaceId: space.id,
-              userId: context.session.userId,
-            },
-            state: 'ACTIVE',
-          },
-        });
-      },
-    }),
-
-    members: t.relation('members', {
-      query: { where: { state: 'ACTIVE' } },
-    }),
-
-    invitations: t.relation('invitations', {
-      authScopes: { $granted: '$space:admin' },
-      // @ts-expect-error pothos-prisma가 unauthorizedResolver 리턴값 타입 추론을 잘못하는듯
-      unauthorizedResolver: () => [],
-      grantScopes: ['$space.member.invitation'],
-    }),
-
-    posts: t.prismaField({
-      type: ['Post'],
-      args: { mine: t.arg.boolean({ defaultValue: false }) },
-      resolve: async (query, space, input, { db, ...context }) => {
-        const meAsMember = context.session
-          ? await db.spaceMember.findUnique({
-              where: {
-                spaceId_userId: {
-                  spaceId: space.id,
-                  userId: context.session.userId,
-                },
-              },
-            })
-          : null;
-        if (input.mine && !meAsMember) {
-          return [];
-        }
-        return await db.post.findMany({
-          ...query,
-          where: {
+      const member = await db.spaceMember.findUnique({
+        where: {
+          spaceId_userId: {
             spaceId: space.id,
-            state: 'PUBLISHED',
-            // input.mine이 true인데 meAsMember가 null이면 위에서 return되서 여기까지 안옴
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            memberId: input.mine ? meAsMember!.id : undefined,
-            visibility: meAsMember ? undefined : 'PUBLIC',
+            userId: context.session.userId,
           },
-          orderBy: { publishedAt: 'desc' },
-        });
-      },
-    }),
-
-    visibility: t.expose('visibility', { type: SpaceVisibility }),
-    externalLinks: t.relation('externalLinks'),
-
-    muted: t.field({
-      type: 'Boolean',
-      resolve: async (space, _, { db, ...context }) => {
-        if (!context.session) {
-          return false;
-        }
-
-        return db.userSpaceMute.existsUnique({
-          where: {
-            userId_spaceId: {
-              userId: context.session.userId,
-              spaceId: space.id,
-            },
-          },
-        });
-      },
-    }),
-
-    collections: t.relation('collections', {
-      query: { where: { state: 'ACTIVE' } },
-    }),
-
-    postCount: t.relationCount('posts', { where: { state: 'PUBLISHED' } }),
-    followerCount: t.relationCount('followers', { where: { user: { state: 'ACTIVE' } } }),
-  }),
-});
-
-builder.prismaObject('SpaceMember', {
-  grantScopes: async (member, { db, ...context }) => {
-    if (!context.session) {
-      return [];
-    }
-
-    const meAsMember = await db.spaceMember.findUnique({
-      where: {
-        spaceId_userId: {
-          spaceId: member.spaceId,
-          userId: context.session.userId,
-        },
-        state: 'ACTIVE',
-      },
-    });
-
-    if (!meAsMember) {
-      return [];
-    }
-
-    return R.sift(['$space:member', meAsMember.role === 'ADMIN' && '$space:admin']);
-  },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    role: t.expose('role', { type: SpaceMemberRole }),
-    profile: t.relation('profile'),
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-    email: t.string({
-      authScopes: { $granted: '$space:member' },
-      resolve: async (member, _, { db }) => {
-        const user = await db.user.findUniqueOrThrow({
-          where: { id: member.userId },
-        });
-
-        return user?.email;
-      },
-    }),
-  }),
-});
-
-builder.prismaObject('SpaceMemberInvitation', {
-  authScopes: { $granted: '$space.member.invitation' },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    receivedEmail: t.exposeString('receivedEmail'),
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-    state: t.field({
-      type: SpaceMemberInvitationState,
-      authScopes: { $granted: '$space.member.invitation.state' },
-      resolve: (invitation) => invitation.state,
-      unauthorizedResolver: (invitation) =>
-        ['PENDING', 'ACCEPTED'].includes(invitation.state) ? invitation.state : 'PENDING',
-    }),
-    space: t.relation('space'),
-    respondedAt: t.expose('respondedAt', {
-      type: 'DateTime',
-      nullable: true,
-    }),
-  }),
-});
-
-builder.prismaObject('SpaceExternalLink', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    url: t.exposeString('url'),
-  }),
-});
-
-/**
- * * Inputs
- */
-
-const CreateSpaceInput = builder.inputType('CreateSpaceInput', {
-  fields: (t) => ({
-    name: t.string(),
-    slug: t.string(),
-    iconId: t.id({ required: false }),
-    profileName: t.string({ required: false }),
-    profileAvatarId: t.id({ required: false }),
-    isPublic: t.boolean({ defaultValue: true }),
-  }),
-  validate: { schema: CreateSpaceSchema },
-});
-
-const DeleteSpaceInput = builder.inputType('DeleteSpaceInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-  }),
-});
-
-const UpdateSpaceInput = builder.inputType('UpdateSpaceInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-    name: t.string({ required: false }),
-    slug: t.string({ required: false }),
-    iconId: t.id({ required: false }),
-    description: t.string({ required: false }),
-    externalLinks: t.stringList({ required: false }),
-    isPublic: t.boolean({ required: false }),
-  }),
-  validate: { schema: UpdateSpaceSchema },
-});
-
-const UpdateSpaceProfileInput = builder.inputType('UpdateSpaceProfileInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-    profileName: t.string(),
-    profileAvatarId: t.id(),
-  }),
-});
-
-const DeleteSpaceProfileInput = builder.inputType('DeleteSpaceProfileInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-  }),
-});
-
-const CreateSpaceMemberInvitationInput = builder.inputType('CreateSpaceMemberInvitationInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-    email: t.string(),
-    role: t.field({ type: SpaceMemberRole }),
-  }),
-  validate: { schema: CreateSpaceMemberInvitationSchema },
-});
-
-const AcceptSpaceMemberInvitationInput = builder.inputType('AcceptSpaceMemberInvitationInput', {
-  fields: (t) => ({
-    invitationId: t.id(),
-    profileName: t.string({ required: false }),
-    profileAvatarId: t.id({ required: false }),
-  }),
-  validate: { schema: AcceptSpaceMemberInvitationSchema },
-});
-
-const IgnoreSpaceMemberInvitationInput = builder.inputType('IgnoreSpaceMemberInvitationInput', {
-  fields: (t) => ({
-    invitationId: t.id(),
-  }),
-});
-
-const LeaveSpaceInput = builder.inputType('LeaveSpaceInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-  }),
-});
-
-const RemoveSpaceMemberInput = builder.inputType('RemoveSpaceMemberInput', {
-  fields: (t) => ({
-    spaceMemberId: t.id(),
-  }),
-});
-
-const FollowSpaceInput = builder.inputType('FollowSpaceInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-  }),
-});
-
-const UnfollowSpaceInput = builder.inputType('UnfollowSpaceInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-  }),
-});
-
-const MuteSpaceInput = builder.inputType('MuteSpaceInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-  }),
-});
-
-const UnmuteSpaceInput = builder.inputType('UnmuteSpaceInput', {
-  fields: (t) => ({
-    spaceId: t.id(),
-  }),
-});
-
-const UpdateSpaceMemberRoleInput = builder.inputType('UpdateSpaceMemberRoleInput', {
-  fields: (t) => ({
-    spaceMemberId: t.id(),
-    role: t.field({ type: SpaceMemberRole }),
-  }),
-});
-
-/**
- * * Queries
- */
-
-builder.queryFields((t) => ({
-  space: t.prismaField({
-    type: 'Space',
-    args: { slug: t.arg.string() },
-    resolve: async (query, _, args, { db, ...context }) => {
-      const space = await db.space.findFirst({
-        where: { slug: args.slug, state: 'ACTIVE' },
-      });
-
-      if (!space) {
-        throw new NotFoundError();
-      }
-
-      if (space.visibility === 'PRIVATE') {
-        if (!context.session) {
-          throw new PermissionDeniedError();
-        }
-
-        const isMember = await db.spaceMember.existsUnique({
-          where: {
-            spaceId_userId: {
-              spaceId: space.id,
-              userId: context.session.userId,
-            },
-            state: 'ACTIVE',
-          },
-        });
-
-        if (!isMember) {
-          throw new PermissionDeniedError();
-        }
-      }
-
-      return db.space.findUniqueOrThrow({
-        ...query,
-        where: { id: space.id },
-      });
-    },
-  }),
-}));
-
-/**
- * * Mutations
- */
-
-builder.mutationFields((t) => ({
-  createSpace: t.withAuth({ user: true }).prismaField({
-    type: 'Space',
-    args: { input: t.arg({ type: CreateSpaceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const isSlugUsed = await db.space.exists({
-        where: { slug: input.slug, state: 'ACTIVE' },
-      });
-
-      if (isSlugUsed) {
-        throw new FormValidationError('slug', '이미 사용중인 URL이에요.');
-      }
-
-      let profileId: string;
-      if (input.profileName && input.profileAvatarId) {
-        const profile = await db.profile.create({
-          data: {
-            id: createId(),
-            name: input.profileName,
-            avatarId: input.profileAvatarId,
-          },
-        });
-
-        profileId = profile.id;
-      } else {
-        const user = await db.user.findUniqueOrThrow({
-          where: { id: context.session.userId },
-        });
-
-        profileId = user.profileId;
-      }
-
-      let iconId = input.iconId;
-      if (!iconId) {
-        iconId = await directUploadImage({
-          db,
-          userId: context.session.userId,
-          name: 'icon',
-          source: await createRandomIcon(),
-        });
-      }
-
-      const spaceId = createId();
-      const space = await db.space.create({
-        ...query,
-        data: {
-          id: spaceId,
-          name: input.name,
-          slug: input.slug,
           state: 'ACTIVE',
-          visibility: input.isPublic ? 'PUBLIC' : 'PRIVATE',
-          iconId,
-          members: {
-            create: {
-              id: createId(),
-              userId: context.session.userId,
-              profileId,
-              role: 'ADMIN',
+        },
+      });
+
+      if (!member) {
+        return [];
+      }
+
+      return R.sift(['$space:member', member.role === 'ADMIN' && '$space:admin']);
+    },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      slug: t.exposeString('slug'),
+      name: t.exposeString('name'),
+      description: t.exposeString('description', { nullable: true }),
+      icon: t.relation('icon'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+
+      followed: t.boolean({
+        resolve: async (space, _, { db, ...context }) => {
+          if (!context.session) {
+            return false;
+          }
+
+          return await db.spaceFollow.existsUnique({
+            where: {
+              userId_spaceId: {
+                userId: context.session.userId,
+                spaceId: space.id,
+              },
+            },
+          });
+        },
+      }),
+
+      meAsMember: t.prismaField({
+        type: 'SpaceMember',
+        nullable: true,
+        resolve: async (query, space, __, { db, ...context }) => {
+          if (!context.session) {
+            return null;
+          }
+
+          return await db.spaceMember.findUnique({
+            ...query,
+            where: {
+              spaceId_userId: {
+                spaceId: space.id,
+                userId: context.session.userId,
+              },
               state: 'ACTIVE',
             },
-          },
+          });
         },
-      });
+      }),
 
-      await indexSpace({ db, spaceId });
-      return space;
-    },
-  }),
+      members: t.relation('members', {
+        query: { where: { state: 'ACTIVE' } },
+      }),
 
-  deleteSpace: t.withAuth({ user: true }).prismaField({
-    type: 'Space',
-    args: { input: t.arg({ type: DeleteSpaceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const space = await db.space.update({
-        ...query,
-        where: {
-          id: input.spaceId,
-          state: 'ACTIVE',
-          members: { some: { userId: context.session.userId, role: 'ADMIN' } },
-        },
-        data: { state: 'INACTIVE' },
-      });
+      invitations: t.relation('invitations', {
+        authScopes: { $granted: '$space:admin' },
+        // @ts-expect-error pothos-prisma가 unauthorizedResolver 리턴값 타입 추론을 잘못하는듯
+        unauthorizedResolver: () => [],
+        grantScopes: ['$space.member.invitation'],
+      }),
 
-      await indexSpace({ db, spaceId: input.spaceId });
-      return space;
-    },
-  }),
-
-  createSpaceMemberInvitation: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceMemberInvitation',
-    grantScopes: ['$space.member.invitation'],
-    args: { input: t.arg({ type: CreateSpaceMemberInvitationInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const member = await db.spaceMember.findUniqueOrThrow({
-        where: {
-          spaceId_userId: {
-            spaceId: input.spaceId,
-            userId: context.session.userId,
-          },
-          role: 'ADMIN',
-          state: 'ACTIVE',
-        },
-      });
-
-      const targetUser = await db.user.findFirst({
-        where: { email: input.email.toLowerCase() },
-      });
-
-      if (targetUser) {
-        const isAlreadyMember = await db.spaceMember.existsUnique({
-          where: {
-            spaceId_userId: {
-              spaceId: input.spaceId,
-              userId: targetUser.id,
+      posts: t.prismaField({
+        type: ['Post'],
+        args: { mine: t.arg.boolean({ defaultValue: false }) },
+        resolve: async (query, space, input, { db, ...context }) => {
+          const meAsMember = context.session
+            ? await db.spaceMember.findUnique({
+                where: {
+                  spaceId_userId: {
+                    spaceId: space.id,
+                    userId: context.session.userId,
+                  },
+                },
+              })
+            : null;
+          if (input.mine && !meAsMember) {
+            return [];
+          }
+          return await db.post.findMany({
+            ...query,
+            where: {
+              spaceId: space.id,
+              state: 'PUBLISHED',
+              // input.mine이 true인데 meAsMember가 null이면 위에서 return되서 여기까지 안옴
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              memberId: input.mine ? meAsMember!.id : undefined,
+              visibility: meAsMember ? undefined : 'PUBLIC',
             },
-            state: 'ACTIVE',
-          },
-        });
+            orderBy: { publishedAt: 'desc' },
+          });
+        },
+      }),
 
-        if (isAlreadyMember) {
-          throw new FormValidationError('email', '이미 스페이스에 가입한 사용자예요.');
-        }
+      visibility: t.expose('visibility', { type: SpaceVisibility }),
+      externalLinks: t.relation('externalLinks'),
+
+      muted: t.field({
+        type: 'Boolean',
+        resolve: async (space, _, { db, ...context }) => {
+          if (!context.session) {
+            return false;
+          }
+
+          return db.userSpaceMute.existsUnique({
+            where: {
+              userId_spaceId: {
+                userId: context.session.userId,
+                spaceId: space.id,
+              },
+            },
+          });
+        },
+      }),
+
+      collections: t.relation('collections', {
+        query: { where: { state: 'ACTIVE' } },
+      }),
+
+      postCount: t.relationCount('posts', { where: { state: 'PUBLISHED' } }),
+      followerCount: t.relationCount('followers', { where: { user: { state: 'ACTIVE' } } }),
+    }),
+  });
+
+  builder.prismaObject('SpaceMember', {
+    grantScopes: async (member, { db, ...context }) => {
+      if (!context.session) {
+        return [];
       }
 
-      const isAlreadyInvited = await db.spaceMemberInvitation.exists({
-        where: {
-          spaceId: input.spaceId,
-          receivedEmail: input.email.toLowerCase(),
-          state: { not: 'ACCEPTED' },
-        },
-      });
-
-      if (isAlreadyInvited) {
-        throw new FormValidationError('email', '이미 초대한 사용자예요.');
-      }
-
-      return await db.spaceMemberInvitation.create({
-        ...query,
-        data: {
-          id: createId(),
-          spaceId: input.spaceId,
-          sentUserId: member.userId,
-          receivedUserId: targetUser?.id,
-          receivedEmail: input.email.toLowerCase(),
-          role: input.role,
-          state: 'PENDING',
-        },
-      });
-    },
-  }),
-
-  updateSpace: t.withAuth({ user: true }).prismaField({
-    type: 'Space',
-    grantScopes: ['$space:admin'],
-    args: { input: t.arg({ type: UpdateSpaceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const meAsMember = await db.spaceMember.existsUnique({
+      const meAsMember = await db.spaceMember.findUnique({
         where: {
           spaceId_userId: {
-            spaceId: input.spaceId,
+            spaceId: member.spaceId,
             userId: context.session.userId,
           },
           state: 'ACTIVE',
-          role: 'ADMIN',
         },
       });
 
       if (!meAsMember) {
-        throw new PermissionDeniedError();
+        return [];
       }
 
-      if (input.slug) {
+      return R.sift(['$space:member', meAsMember.role === 'ADMIN' && '$space:admin']);
+    },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      role: t.expose('role', { type: SpaceMemberRole }),
+      profile: t.relation('profile'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+      email: t.string({
+        authScopes: { $granted: '$space:member' },
+        resolve: async (member, _, { db }) => {
+          const user = await db.user.findUniqueOrThrow({
+            where: { id: member.userId },
+          });
+
+          return user?.email;
+        },
+      }),
+    }),
+  });
+
+  builder.prismaObject('SpaceMemberInvitation', {
+    authScopes: { $granted: '$space.member.invitation' },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      receivedEmail: t.exposeString('receivedEmail'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+      state: t.field({
+        type: SpaceMemberInvitationState,
+        authScopes: { $granted: '$space.member.invitation.state' },
+        resolve: (invitation) => invitation.state,
+        unauthorizedResolver: (invitation) =>
+          ['PENDING', 'ACCEPTED'].includes(invitation.state) ? invitation.state : 'PENDING',
+      }),
+      space: t.relation('space'),
+      respondedAt: t.expose('respondedAt', {
+        type: 'DateTime',
+        nullable: true,
+      }),
+    }),
+  });
+
+  builder.prismaObject('SpaceExternalLink', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      url: t.exposeString('url'),
+    }),
+  });
+
+  /**
+   * * Inputs
+   */
+
+  const CreateSpaceInput = builder.inputType('CreateSpaceInput', {
+    fields: (t) => ({
+      name: t.string(),
+      slug: t.string(),
+      iconId: t.id({ required: false }),
+      profileName: t.string({ required: false }),
+      profileAvatarId: t.id({ required: false }),
+      isPublic: t.boolean({ defaultValue: true }),
+    }),
+    validate: { schema: CreateSpaceSchema },
+  });
+
+  const DeleteSpaceInput = builder.inputType('DeleteSpaceInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+    }),
+  });
+
+  const UpdateSpaceInput = builder.inputType('UpdateSpaceInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+      name: t.string({ required: false }),
+      slug: t.string({ required: false }),
+      iconId: t.id({ required: false }),
+      description: t.string({ required: false }),
+      externalLinks: t.stringList({ required: false }),
+      isPublic: t.boolean({ required: false }),
+    }),
+    validate: { schema: UpdateSpaceSchema },
+  });
+
+  const UpdateSpaceProfileInput = builder.inputType('UpdateSpaceProfileInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+      profileName: t.string(),
+      profileAvatarId: t.id(),
+    }),
+  });
+
+  const DeleteSpaceProfileInput = builder.inputType('DeleteSpaceProfileInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+    }),
+  });
+
+  const CreateSpaceMemberInvitationInput = builder.inputType('CreateSpaceMemberInvitationInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+      email: t.string(),
+      role: t.field({ type: SpaceMemberRole }),
+    }),
+    validate: { schema: CreateSpaceMemberInvitationSchema },
+  });
+
+  const AcceptSpaceMemberInvitationInput = builder.inputType('AcceptSpaceMemberInvitationInput', {
+    fields: (t) => ({
+      invitationId: t.id(),
+      profileName: t.string({ required: false }),
+      profileAvatarId: t.id({ required: false }),
+    }),
+    validate: { schema: AcceptSpaceMemberInvitationSchema },
+  });
+
+  const IgnoreSpaceMemberInvitationInput = builder.inputType('IgnoreSpaceMemberInvitationInput', {
+    fields: (t) => ({
+      invitationId: t.id(),
+    }),
+  });
+
+  const LeaveSpaceInput = builder.inputType('LeaveSpaceInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+    }),
+  });
+
+  const RemoveSpaceMemberInput = builder.inputType('RemoveSpaceMemberInput', {
+    fields: (t) => ({
+      spaceMemberId: t.id(),
+    }),
+  });
+
+  const FollowSpaceInput = builder.inputType('FollowSpaceInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+    }),
+  });
+
+  const UnfollowSpaceInput = builder.inputType('UnfollowSpaceInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+    }),
+  });
+
+  const MuteSpaceInput = builder.inputType('MuteSpaceInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+    }),
+  });
+
+  const UnmuteSpaceInput = builder.inputType('UnmuteSpaceInput', {
+    fields: (t) => ({
+      spaceId: t.id(),
+    }),
+  });
+
+  const UpdateSpaceMemberRoleInput = builder.inputType('UpdateSpaceMemberRoleInput', {
+    fields: (t) => ({
+      spaceMemberId: t.id(),
+      role: t.field({ type: SpaceMemberRole }),
+    }),
+  });
+
+  /**
+   * * Queries
+   */
+
+  builder.queryFields((t) => ({
+    space: t.prismaField({
+      type: 'Space',
+      args: { slug: t.arg.string() },
+      resolve: async (query, _, args, { db, ...context }) => {
+        const space = await db.space.findFirst({
+          where: { slug: args.slug, state: 'ACTIVE' },
+        });
+
+        if (!space) {
+          throw new NotFoundError();
+        }
+
+        if (space.visibility === 'PRIVATE') {
+          if (!context.session) {
+            throw new PermissionDeniedError();
+          }
+
+          const isMember = await db.spaceMember.existsUnique({
+            where: {
+              spaceId_userId: {
+                spaceId: space.id,
+                userId: context.session.userId,
+              },
+              state: 'ACTIVE',
+            },
+          });
+
+          if (!isMember) {
+            throw new PermissionDeniedError();
+          }
+        }
+
+        return db.space.findUniqueOrThrow({
+          ...query,
+          where: { id: space.id },
+        });
+      },
+    }),
+  }));
+
+  /**
+   * * Mutations
+   */
+
+  builder.mutationFields((t) => ({
+    createSpace: t.withAuth({ user: true }).prismaField({
+      type: 'Space',
+      args: { input: t.arg({ type: CreateSpaceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
         const isSlugUsed = await db.space.exists({
-          where: { slug: input.slug, state: 'ACTIVE', id: { not: input.spaceId } },
+          where: { slug: input.slug, state: 'ACTIVE' },
         });
 
         if (isSlugUsed) {
-          throw new IntentionalError('이미 사용중인 URL이에요.');
+          throw new FormValidationError('slug', '이미 사용중인 URL이에요.');
         }
-      }
 
-      if (input.externalLinks) {
-        await db.spaceExternalLink.deleteMany({
-          where: { spaceId: input.spaceId },
-        });
+        let profileId: string;
+        if (input.profileName && input.profileAvatarId) {
+          const profile = await db.profile.create({
+            data: {
+              id: createId(),
+              name: input.profileName,
+              avatarId: input.profileAvatarId,
+            },
+          });
 
-        await db.spaceExternalLink.createMany({
-          data: input.externalLinks.map((url) => ({
-            id: createId(),
-            spaceId: input.spaceId,
-            url,
-          })),
-        });
-      }
+          profileId = profile.id;
+        } else {
+          const user = await db.user.findUniqueOrThrow({
+            where: { id: context.session.userId },
+          });
 
-      const space = await db.space.update({
-        ...query,
-        where: {
-          id: input.spaceId,
-          state: 'ACTIVE',
-        },
-        data: {
-          name: input.name ?? undefined,
-          slug: input.slug ?? undefined,
-          iconId: input.iconId ?? undefined,
-          description: input.description ?? undefined,
-          visibility: match(input.isPublic)
-            .with(true, () => 'PUBLIC' as const)
-            .with(false, () => 'PRIVATE' as const)
-            .otherwise(() => undefined),
-        },
-      });
+          profileId = user.profileId;
+        }
 
-      await indexSpace({ db, spaceId: input.spaceId });
-      return space;
-    },
-  }),
-
-  updateSpaceProfile: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceMember',
-    args: { input: t.arg({ type: UpdateSpaceProfileInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const meAsMember = await db.spaceMember.findUnique({
-        include: { user: true },
-        where: {
-          spaceId_userId: {
-            spaceId: input.spaceId,
+        let iconId = input.iconId;
+        if (!iconId) {
+          iconId = await directUploadImage({
+            db,
             userId: context.session.userId,
-          },
-          state: 'ACTIVE',
-        },
-      });
+            name: 'icon',
+            source: await createRandomIcon(),
+          });
+        }
 
-      if (!meAsMember) {
-        throw new PermissionDeniedError();
-      }
-
-      return db.spaceMember.update({
-        ...query,
-        where: {
-          id: meAsMember.id,
-        },
-        data: {
-          profile:
-            meAsMember.profileId === meAsMember.user.profileId
-              ? {
-                  create: {
-                    id: createId(),
-                    name: input.profileName,
-                    avatarId: input.profileAvatarId,
-                  },
-                }
-              : {
-                  update: {
-                    name: input.profileName,
-                    avatarId: input.profileAvatarId,
-                  },
-                },
-        },
-      });
-    },
-  }),
-
-  deleteSpaceProfile: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceMember',
-    args: { input: t.arg({ type: DeleteSpaceProfileInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const me = await db.user.findUniqueOrThrow({
-        where: {
-          id: context.session.userId,
-        },
-      });
-
-      return db.spaceMember.update({
-        ...query,
-        where: {
-          spaceId_userId: {
-            spaceId: input.spaceId,
-            userId: context.session.userId,
-          },
-          state: 'ACTIVE',
-        },
-        data: {
-          profileId: me.profileId,
-        },
-      });
-    },
-  }),
-
-  acceptSpaceMemberInvitation: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceMemberInvitation',
-    grantScopes: ['$space.member.invitation'],
-    args: { input: t.arg({ type: AcceptSpaceMemberInvitationInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const invitation = await db.spaceMemberInvitation.findUniqueOrThrow({
-        include: { space: true },
-        where: {
-          id: input.invitationId,
-          receivedUserId: context.session.userId,
-          state: { not: 'ACCEPTED' },
-        },
-      });
-
-      const user = await db.user.findUniqueOrThrow({
-        include: { profile: true },
-        where: { id: context.session.userId },
-      });
-
-      let profileId: string;
-      if (input.profileName && input.profileAvatarId) {
-        const profile = await db.profile.create({
+        const spaceId = createId();
+        const space = await db.space.create({
+          ...query,
           data: {
-            id: createId(),
-            name: input.profileName,
-            avatarId: input.profileAvatarId,
-          },
-        });
-
-        profileId = profile.id;
-      } else {
-        profileId = user.profile.id;
-      }
-
-      await db.spaceMember.upsert({
-        where: {
-          spaceId_userId: {
-            spaceId: invitation.spaceId,
-            userId: context.session.userId,
-          },
-        },
-        create: {
-          id: createId(),
-          spaceId: invitation.spaceId,
-          userId: context.session.userId,
-          profileId,
-          role: invitation.role,
-          state: 'ACTIVE',
-        },
-        update: {
-          profileId,
-          role: invitation.role,
-          state: 'ACTIVE',
-        },
-      });
-
-      await db.spaceFollow.upsert({
-        where: {
-          userId_spaceId: {
-            userId: context.session.userId,
-            spaceId: invitation.spaceId,
-          },
-        },
-        create: {
-          id: createId(),
-          userId: context.session.userId,
-          spaceId: invitation.spaceId,
-        },
-        update: {},
-      });
-
-      return await db.spaceMemberInvitation.update({
-        ...query,
-        where: { id: invitation.id },
-        data: {
-          state: 'ACCEPTED',
-          respondedAt: new Date(),
-        },
-      });
-    },
-  }),
-
-  ignoreSpaceMemberInvitation: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceMemberInvitation',
-    grantScopes: ['$space.member.invitation'],
-    args: { input: t.arg({ type: IgnoreSpaceMemberInvitationInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      return await db.spaceMemberInvitation.update({
-        ...query,
-        where: {
-          id: input.invitationId,
-          receivedUserId: context.session.userId,
-          state: { not: 'ACCEPTED' },
-        },
-        data: { state: 'IGNORED' },
-      });
-    },
-  }),
-
-  leaveSpace: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceMember',
-    args: { input: t.arg({ type: LeaveSpaceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const meAsMember = await db.spaceMember.findUniqueOrThrow({
-        include: { space: true },
-        where: {
-          spaceId_userId: {
-            spaceId: input.spaceId,
-            userId: context.session.userId,
-          },
-          state: 'ACTIVE',
-        },
-      });
-
-      if (meAsMember.role === 'ADMIN') {
-        const adminCount = await db.spaceMember.count({
-          where: {
-            spaceId: input.spaceId,
-            role: 'ADMIN',
+            id: spaceId,
+            name: input.name,
+            slug: input.slug,
             state: 'ACTIVE',
+            visibility: input.isPublic ? 'PUBLIC' : 'PRIVATE',
+            iconId,
+            members: {
+              create: {
+                id: createId(),
+                userId: context.session.userId,
+                profileId,
+                role: 'ADMIN',
+                state: 'ACTIVE',
+              },
+            },
           },
         });
 
-        if (adminCount <= 1) {
-          throw new IntentionalError('마지막 관리자는 스페이스를 나갈 수 없어요.');
-        }
-      }
+        await indexSpace({ db, spaceId });
+        return space;
+      },
+    }),
 
-      if (meAsMember.space.visibility === 'PRIVATE') {
-        await db.spaceFollow.deleteMany({
+    deleteSpace: t.withAuth({ user: true }).prismaField({
+      type: 'Space',
+      args: { input: t.arg({ type: DeleteSpaceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const space = await db.space.update({
+          ...query,
           where: {
-            userId: context.session.userId,
-            spaceId: input.spaceId,
-          },
-        });
-      }
-
-      return await db.spaceMember.update({
-        ...query,
-        where: {
-          id: meAsMember.id,
-        },
-        data: {
-          state: 'INACTIVE',
-        },
-      });
-    },
-  }),
-
-  removeSpaceMember: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceMember',
-    nullable: true,
-    args: { input: t.arg({ type: RemoveSpaceMemberInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const kickedMember = await db.spaceMember.findUniqueOrThrow({
-        where: {
-          id: input.spaceMemberId,
-          state: 'ACTIVE',
-        },
-      });
-
-      const meAsMember = await db.spaceMember.findUniqueOrThrow({
-        include: { space: true },
-        where: {
-          spaceId_userId: {
-            spaceId: kickedMember.spaceId,
-            userId: context.session.userId,
-          },
-          role: 'ADMIN',
-          state: 'ACTIVE',
-        },
-      });
-
-      if (meAsMember.id === kickedMember.id) {
-        throw new IntentionalError('자기 자신을 추방할 수 없어요.');
-      }
-
-      if (meAsMember.space.visibility === 'PRIVATE') {
-        await db.spaceFollow.deleteMany({
-          where: {
-            userId: context.session.userId,
-            spaceId: meAsMember.spaceId,
-          },
-        });
-      }
-
-      return await db.spaceMember.update({
-        ...query,
-        where: {
-          id: kickedMember.id,
-        },
-        data: {
-          state: 'INACTIVE',
-        },
-      });
-    },
-  }),
-
-  updateSpaceMemberRole: t.withAuth({ user: true }).prismaField({
-    type: 'SpaceMember',
-    args: { input: t.arg({ type: UpdateSpaceMemberRoleInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const targetMember = await db.spaceMember.findUniqueOrThrow({
-        where: {
-          id: input.spaceMemberId,
-          state: 'ACTIVE',
-        },
-      });
-
-      const meAsMember = await db.spaceMember.findFirstOrThrow({
-        where: {
-          spaceId: targetMember.spaceId,
-          userId: context.session.userId,
-          role: 'ADMIN',
-          state: 'ACTIVE',
-        },
-      });
-
-      if (meAsMember.id === targetMember.id && input.role !== 'ADMIN') {
-        const adminCount = await db.spaceMember.count({
-          where: {
-            spaceId: targetMember.spaceId,
-            role: 'ADMIN',
+            id: input.spaceId,
             state: 'ACTIVE',
+            members: { some: { userId: context.session.userId, role: 'ADMIN' } },
           },
+          data: { state: 'INACTIVE' },
         });
-        if (adminCount <= 1) {
-          throw new IntentionalError('마지막 관리자는 권한을 변경할 수 없어요.');
-        }
-      }
 
-      return await db.spaceMember.update({
-        ...query,
-        where: {
-          id: targetMember.id,
-        },
-        data: {
-          role: input.role,
-        },
-      });
-    },
-  }),
+        await indexSpace({ db, spaceId: input.spaceId });
+        return space;
+      },
+    }),
 
-  followSpace: t.withAuth({ user: true }).prismaField({
-    type: 'Space',
-    args: { input: t.arg({ type: FollowSpaceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const space = await db.space.findUniqueOrThrow({
-        where: {
-          id: input.spaceId,
-          state: 'ACTIVE',
-        },
-      });
-
-      if (space.visibility === 'PRIVATE') {
-        const isMember = await db.spaceMember.existsUnique({
+    createSpaceMemberInvitation: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceMemberInvitation',
+      grantScopes: ['$space.member.invitation'],
+      args: { input: t.arg({ type: CreateSpaceMemberInvitationInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const member = await db.spaceMember.findUniqueOrThrow({
           where: {
             spaceId_userId: {
+              spaceId: input.spaceId,
+              userId: context.session.userId,
+            },
+            role: 'ADMIN',
+            state: 'ACTIVE',
+          },
+        });
+
+        const targetUser = await db.user.findFirst({
+          where: { email: input.email.toLowerCase() },
+        });
+
+        if (targetUser) {
+          const isAlreadyMember = await db.spaceMember.existsUnique({
+            where: {
+              spaceId_userId: {
+                spaceId: input.spaceId,
+                userId: targetUser.id,
+              },
+              state: 'ACTIVE',
+            },
+          });
+
+          if (isAlreadyMember) {
+            throw new FormValidationError('email', '이미 스페이스에 가입한 사용자예요.');
+          }
+        }
+
+        const isAlreadyInvited = await db.spaceMemberInvitation.exists({
+          where: {
+            spaceId: input.spaceId,
+            receivedEmail: input.email.toLowerCase(),
+            state: { not: 'ACCEPTED' },
+          },
+        });
+
+        if (isAlreadyInvited) {
+          throw new FormValidationError('email', '이미 초대한 사용자예요.');
+        }
+
+        return await db.spaceMemberInvitation.create({
+          ...query,
+          data: {
+            id: createId(),
+            spaceId: input.spaceId,
+            sentUserId: member.userId,
+            receivedUserId: targetUser?.id,
+            receivedEmail: input.email.toLowerCase(),
+            role: input.role,
+            state: 'PENDING',
+          },
+        });
+      },
+    }),
+
+    updateSpace: t.withAuth({ user: true }).prismaField({
+      type: 'Space',
+      grantScopes: ['$space:admin'],
+      args: { input: t.arg({ type: UpdateSpaceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const meAsMember = await db.spaceMember.existsUnique({
+          where: {
+            spaceId_userId: {
+              spaceId: input.spaceId,
+              userId: context.session.userId,
+            },
+            state: 'ACTIVE',
+            role: 'ADMIN',
+          },
+        });
+
+        if (!meAsMember) {
+          throw new PermissionDeniedError();
+        }
+
+        if (input.slug) {
+          const isSlugUsed = await db.space.exists({
+            where: { slug: input.slug, state: 'ACTIVE', id: { not: input.spaceId } },
+          });
+
+          if (isSlugUsed) {
+            throw new IntentionalError('이미 사용중인 URL이에요.');
+          }
+        }
+
+        if (input.externalLinks) {
+          await db.spaceExternalLink.deleteMany({
+            where: { spaceId: input.spaceId },
+          });
+
+          await db.spaceExternalLink.createMany({
+            data: input.externalLinks.map((url) => ({
+              id: createId(),
+              spaceId: input.spaceId,
+              url,
+            })),
+          });
+        }
+
+        const space = await db.space.update({
+          ...query,
+          where: {
+            id: input.spaceId,
+            state: 'ACTIVE',
+          },
+          data: {
+            name: input.name ?? undefined,
+            slug: input.slug ?? undefined,
+            iconId: input.iconId ?? undefined,
+            description: input.description ?? undefined,
+            visibility: match(input.isPublic)
+              .with(true, () => 'PUBLIC' as const)
+              .with(false, () => 'PRIVATE' as const)
+              .otherwise(() => undefined),
+          },
+        });
+
+        await indexSpace({ db, spaceId: input.spaceId });
+        return space;
+      },
+    }),
+
+    updateSpaceProfile: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceMember',
+      args: { input: t.arg({ type: UpdateSpaceProfileInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const meAsMember = await db.spaceMember.findUnique({
+          include: { user: true },
+          where: {
+            spaceId_userId: {
+              spaceId: input.spaceId,
+              userId: context.session.userId,
+            },
+            state: 'ACTIVE',
+          },
+        });
+
+        if (!meAsMember) {
+          throw new PermissionDeniedError();
+        }
+
+        return db.spaceMember.update({
+          ...query,
+          where: {
+            id: meAsMember.id,
+          },
+          data: {
+            profile:
+              meAsMember.profileId === meAsMember.user.profileId
+                ? {
+                    create: {
+                      id: createId(),
+                      name: input.profileName,
+                      avatarId: input.profileAvatarId,
+                    },
+                  }
+                : {
+                    update: {
+                      name: input.profileName,
+                      avatarId: input.profileAvatarId,
+                    },
+                  },
+          },
+        });
+      },
+    }),
+
+    deleteSpaceProfile: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceMember',
+      args: { input: t.arg({ type: DeleteSpaceProfileInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const me = await db.user.findUniqueOrThrow({
+          where: {
+            id: context.session.userId,
+          },
+        });
+
+        return db.spaceMember.update({
+          ...query,
+          where: {
+            spaceId_userId: {
+              spaceId: input.spaceId,
+              userId: context.session.userId,
+            },
+            state: 'ACTIVE',
+          },
+          data: {
+            profileId: me.profileId,
+          },
+        });
+      },
+    }),
+
+    acceptSpaceMemberInvitation: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceMemberInvitation',
+      grantScopes: ['$space.member.invitation'],
+      args: { input: t.arg({ type: AcceptSpaceMemberInvitationInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const invitation = await db.spaceMemberInvitation.findUniqueOrThrow({
+          include: { space: true },
+          where: {
+            id: input.invitationId,
+            receivedUserId: context.session.userId,
+            state: { not: 'ACCEPTED' },
+          },
+        });
+
+        const user = await db.user.findUniqueOrThrow({
+          include: { profile: true },
+          where: { id: context.session.userId },
+        });
+
+        let profileId: string;
+        if (input.profileName && input.profileAvatarId) {
+          const profile = await db.profile.create({
+            data: {
+              id: createId(),
+              name: input.profileName,
+              avatarId: input.profileAvatarId,
+            },
+          });
+
+          profileId = profile.id;
+        } else {
+          profileId = user.profile.id;
+        }
+
+        await db.spaceMember.upsert({
+          where: {
+            spaceId_userId: {
+              spaceId: invitation.spaceId,
+              userId: context.session.userId,
+            },
+          },
+          create: {
+            id: createId(),
+            spaceId: invitation.spaceId,
+            userId: context.session.userId,
+            profileId,
+            role: invitation.role,
+            state: 'ACTIVE',
+          },
+          update: {
+            profileId,
+            role: invitation.role,
+            state: 'ACTIVE',
+          },
+        });
+
+        await db.spaceFollow.upsert({
+          where: {
+            userId_spaceId: {
+              userId: context.session.userId,
+              spaceId: invitation.spaceId,
+            },
+          },
+          create: {
+            id: createId(),
+            userId: context.session.userId,
+            spaceId: invitation.spaceId,
+          },
+          update: {},
+        });
+
+        return await db.spaceMemberInvitation.update({
+          ...query,
+          where: { id: invitation.id },
+          data: {
+            state: 'ACCEPTED',
+            respondedAt: new Date(),
+          },
+        });
+      },
+    }),
+
+    ignoreSpaceMemberInvitation: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceMemberInvitation',
+      grantScopes: ['$space.member.invitation'],
+      args: { input: t.arg({ type: IgnoreSpaceMemberInvitationInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        return await db.spaceMemberInvitation.update({
+          ...query,
+          where: {
+            id: input.invitationId,
+            receivedUserId: context.session.userId,
+            state: { not: 'ACCEPTED' },
+          },
+          data: { state: 'IGNORED' },
+        });
+      },
+    }),
+
+    leaveSpace: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceMember',
+      args: { input: t.arg({ type: LeaveSpaceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const meAsMember = await db.spaceMember.findUniqueOrThrow({
+          include: { space: true },
+          where: {
+            spaceId_userId: {
+              spaceId: input.spaceId,
+              userId: context.session.userId,
+            },
+            state: 'ACTIVE',
+          },
+        });
+
+        if (meAsMember.role === 'ADMIN') {
+          const adminCount = await db.spaceMember.count({
+            where: {
+              spaceId: input.spaceId,
+              role: 'ADMIN',
+              state: 'ACTIVE',
+            },
+          });
+
+          if (adminCount <= 1) {
+            throw new IntentionalError('마지막 관리자는 스페이스를 나갈 수 없어요.');
+          }
+        }
+
+        if (meAsMember.space.visibility === 'PRIVATE') {
+          await db.spaceFollow.deleteMany({
+            where: {
+              userId: context.session.userId,
+              spaceId: input.spaceId,
+            },
+          });
+        }
+
+        return await db.spaceMember.update({
+          ...query,
+          where: {
+            id: meAsMember.id,
+          },
+          data: {
+            state: 'INACTIVE',
+          },
+        });
+      },
+    }),
+
+    removeSpaceMember: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceMember',
+      nullable: true,
+      args: { input: t.arg({ type: RemoveSpaceMemberInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const kickedMember = await db.spaceMember.findUniqueOrThrow({
+          where: {
+            id: input.spaceMemberId,
+            state: 'ACTIVE',
+          },
+        });
+
+        const meAsMember = await db.spaceMember.findUniqueOrThrow({
+          include: { space: true },
+          where: {
+            spaceId_userId: {
+              spaceId: kickedMember.spaceId,
+              userId: context.session.userId,
+            },
+            role: 'ADMIN',
+            state: 'ACTIVE',
+          },
+        });
+
+        if (meAsMember.id === kickedMember.id) {
+          throw new IntentionalError('자기 자신을 추방할 수 없어요.');
+        }
+
+        if (meAsMember.space.visibility === 'PRIVATE') {
+          await db.spaceFollow.deleteMany({
+            where: {
+              userId: context.session.userId,
+              spaceId: meAsMember.spaceId,
+            },
+          });
+        }
+
+        return await db.spaceMember.update({
+          ...query,
+          where: {
+            id: kickedMember.id,
+          },
+          data: {
+            state: 'INACTIVE',
+          },
+        });
+      },
+    }),
+
+    updateSpaceMemberRole: t.withAuth({ user: true }).prismaField({
+      type: 'SpaceMember',
+      args: { input: t.arg({ type: UpdateSpaceMemberRoleInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const targetMember = await db.spaceMember.findUniqueOrThrow({
+          where: {
+            id: input.spaceMemberId,
+            state: 'ACTIVE',
+          },
+        });
+
+        const meAsMember = await db.spaceMember.findFirstOrThrow({
+          where: {
+            spaceId: targetMember.spaceId,
+            userId: context.session.userId,
+            role: 'ADMIN',
+            state: 'ACTIVE',
+          },
+        });
+
+        if (meAsMember.id === targetMember.id && input.role !== 'ADMIN') {
+          const adminCount = await db.spaceMember.count({
+            where: {
+              spaceId: targetMember.spaceId,
+              role: 'ADMIN',
+              state: 'ACTIVE',
+            },
+          });
+          if (adminCount <= 1) {
+            throw new IntentionalError('마지막 관리자는 권한을 변경할 수 없어요.');
+          }
+        }
+
+        return await db.spaceMember.update({
+          ...query,
+          where: {
+            id: targetMember.id,
+          },
+          data: {
+            role: input.role,
+          },
+        });
+      },
+    }),
+
+    followSpace: t.withAuth({ user: true }).prismaField({
+      type: 'Space',
+      args: { input: t.arg({ type: FollowSpaceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const space = await db.space.findUniqueOrThrow({
+          where: {
+            id: input.spaceId,
+            state: 'ACTIVE',
+          },
+        });
+
+        if (space.visibility === 'PRIVATE') {
+          const isMember = await db.spaceMember.existsUnique({
+            where: {
+              spaceId_userId: {
+                userId: context.session.userId,
+                spaceId: space.id,
+              },
+            },
+          });
+          if (!isMember) {
+            throw new PermissionDeniedError();
+          }
+        }
+
+        await db.spaceFollow.upsert({
+          where: {
+            userId_spaceId: {
               userId: context.session.userId,
               spaceId: space.id,
             },
           },
-        });
-        if (!isMember) {
-          throw new PermissionDeniedError();
-        }
-      }
-
-      await db.spaceFollow.upsert({
-        where: {
-          userId_spaceId: {
-            userId: context.session.userId,
-            spaceId: space.id,
-          },
-        },
-        create: {
-          id: createId(),
-          userId: context.session.userId,
-          spaceId: input.spaceId,
-        },
-        update: {},
-      });
-
-      return db.space.findUniqueOrThrow({
-        ...query,
-        where: { id: space.id },
-      });
-    },
-  }),
-
-  unfollowSpace: t.withAuth({ user: true }).prismaField({
-    type: 'Space',
-    args: { input: t.arg({ type: UnfollowSpaceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const space = await db.space.findUniqueOrThrow({
-        where: { id: input.spaceId },
-      });
-
-      await db.spaceFollow.deleteMany({
-        where: {
-          userId: context.session.userId,
-          spaceId: space.id,
-        },
-      });
-
-      return db.space.findUniqueOrThrow({
-        ...query,
-        where: { id: space.id },
-      });
-    },
-  }),
-
-  muteSpace: t.withAuth({ user: true }).prismaField({
-    type: 'Space',
-    args: { input: t.arg({ type: MuteSpaceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      await db.userSpaceMute.upsert({
-        where: {
-          userId_spaceId: {
+          create: {
+            id: createId(),
             userId: context.session.userId,
             spaceId: input.spaceId,
           },
-        },
-        create: {
-          id: createId(),
-          userId: context.session.userId,
-          spaceId: input.spaceId,
-        },
-        update: {},
-      });
-      return await db.space.findUniqueOrThrow({
-        ...query,
-        where: { id: input.spaceId },
-      });
-    },
-  }),
+          update: {},
+        });
 
-  unmuteSpace: t.withAuth({ user: true }).prismaField({
-    type: 'Space',
-    args: { input: t.arg({ type: UnmuteSpaceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      await db.userSpaceMute.deleteMany({
-        where: {
-          userId: context.session.userId,
-          spaceId: input.spaceId,
-        },
-      });
-      return await db.space.findUniqueOrThrow({
-        ...query,
-        where: { id: input.spaceId },
-      });
-    },
-  }),
-}));
+        return db.space.findUniqueOrThrow({
+          ...query,
+          where: { id: space.id },
+        });
+      },
+    }),
+
+    unfollowSpace: t.withAuth({ user: true }).prismaField({
+      type: 'Space',
+      args: { input: t.arg({ type: UnfollowSpaceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const space = await db.space.findUniqueOrThrow({
+          where: { id: input.spaceId },
+        });
+
+        await db.spaceFollow.deleteMany({
+          where: {
+            userId: context.session.userId,
+            spaceId: space.id,
+          },
+        });
+
+        return db.space.findUniqueOrThrow({
+          ...query,
+          where: { id: space.id },
+        });
+      },
+    }),
+
+    muteSpace: t.withAuth({ user: true }).prismaField({
+      type: 'Space',
+      args: { input: t.arg({ type: MuteSpaceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        await db.userSpaceMute.upsert({
+          where: {
+            userId_spaceId: {
+              userId: context.session.userId,
+              spaceId: input.spaceId,
+            },
+          },
+          create: {
+            id: createId(),
+            userId: context.session.userId,
+            spaceId: input.spaceId,
+          },
+          update: {},
+        });
+        return await db.space.findUniqueOrThrow({
+          ...query,
+          where: { id: input.spaceId },
+        });
+      },
+    }),
+
+    unmuteSpace: t.withAuth({ user: true }).prismaField({
+      type: 'Space',
+      args: { input: t.arg({ type: UnmuteSpaceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        await db.userSpaceMute.deleteMany({
+          where: {
+            userId: context.session.userId,
+            spaceId: input.spaceId,
+          },
+        });
+        return await db.space.findUniqueOrThrow({
+          ...query,
+          where: { id: input.spaceId },
+        });
+      },
+    }),
+  }));
+});

--- a/apps/penxle.com/src/lib/server/graphql/schemas/tag.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/tag.ts
@@ -1,356 +1,358 @@
 import dayjs from 'dayjs';
 import { createId } from '$lib/utils';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Types
- */
+export const tagSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-builder.prismaObject('Tag', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    name: t.exposeString('name'),
-    wiki: t.relation('wiki', { nullable: true }),
+  builder.prismaObject('Tag', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      name: t.exposeString('name'),
+      wiki: t.relation('wiki', { nullable: true }),
 
-    parents: t.prismaField({
-      type: ['Tag'],
-      select: (_, __, nestedSelection) => ({
-        parents: { include: { parentTag: nestedSelection() } },
+      parents: t.prismaField({
+        type: ['Tag'],
+        select: (_, __, nestedSelection) => ({
+          parents: { include: { parentTag: nestedSelection() } },
+        }),
+        resolve: (_, { parents }) => parents.map(({ parentTag }) => parentTag),
       }),
-      resolve: (_, { parents }) => parents.map(({ parentTag }) => parentTag),
-    }),
 
-    posts: t.prismaField({
-      type: ['Post'],
-      args: { dateBefore: t.arg.string({ required: false }) },
-      select: (input, context, nestedSelection) => {
-        const dateBefore = input.dateBefore ? dayjs(input.dateBefore).toDate() : undefined;
-        return {
-          postRevisions: {
-            include: { revision: { include: { post: nestedSelection() } } },
-            where: {
-              revision: {
-                tags: context.session
-                  ? {
-                      none: {
-                        tag: {
-                          userMutes: {
-                            some: { userId: context.session.userId },
+      posts: t.prismaField({
+        type: ['Post'],
+        args: { dateBefore: t.arg.string({ required: false }) },
+        select: (input, context, nestedSelection) => {
+          const dateBefore = input.dateBefore ? dayjs(input.dateBefore).toDate() : undefined;
+          return {
+            postRevisions: {
+              include: { revision: { include: { post: nestedSelection() } } },
+              where: {
+                revision: {
+                  tags: context.session
+                    ? {
+                        none: {
+                          tag: {
+                            userMutes: {
+                              some: { userId: context.session.userId },
+                            },
                           },
                         },
-                      },
-                    }
-                  : undefined,
-                post: {
-                  publishedAt: dateBefore ? { lt: dateBefore } : undefined,
-                  visibility: 'PUBLIC',
-                  password: null,
-                  space: {
-                    state: 'ACTIVE',
-                    userMutes: context.session
-                      ? {
-                          none: { userId: context.session.userId },
-                        }
-                      : undefined,
+                      }
+                    : undefined,
+                  post: {
+                    publishedAt: dateBefore ? { lt: dateBefore } : undefined,
+                    visibility: 'PUBLIC',
+                    password: null,
+                    space: {
+                      state: 'ACTIVE',
+                      userMutes: context.session
+                        ? {
+                            none: { userId: context.session.userId },
+                          }
+                        : undefined,
+                    },
                   },
                 },
               },
+
+              orderBy: { revision: { post: { publishedAt: 'desc' } } },
             },
+          };
+        },
 
-            orderBy: { revision: { post: { publishedAt: 'desc' } } },
+        resolve: (_, { postRevisions }) => postRevisions.map(({ revision }) => revision.post),
+      }),
+
+      followed: t.field({
+        type: 'Boolean',
+        select: (_, context) => ({
+          followers: {
+            where: { userId: context.session?.userId },
+            take: 1,
           },
-        };
-      },
-
-      resolve: (_, { postRevisions }) => postRevisions.map(({ revision }) => revision.post),
-    }),
-
-    followed: t.field({
-      type: 'Boolean',
-      select: (_, context) => ({
-        followers: {
-          where: { userId: context.session?.userId },
-          take: 1,
-        },
-      }),
-
-      resolve: ({ followers }, _, context) => !!context.session && followers.length > 0,
-    }),
-
-    muted: t.field({
-      type: 'Boolean',
-      select: (_, context) => ({
-        userMutes: {
-          where: { userId: context.session?.userId },
-          take: 1,
-        },
-      }),
-
-      resolve: ({ userMutes }, _, context) => !!context.session && userMutes.length > 0,
-    }),
-  }),
-});
-
-builder.prismaObject('TagWiki', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    lastRevision: t.prismaField({
-      type: 'TagWikiRevision',
-      select: (_, __, nestedSelection) => ({
-        revisions: nestedSelection({
-          orderBy: { createdAt: 'desc' },
-          take: 1,
         }),
+
+        resolve: ({ followers }, _, context) => !!context.session && followers.length > 0,
       }),
 
-      resolve: (_, { revisions }) => revisions[0],
+      muted: t.field({
+        type: 'Boolean',
+        select: (_, context) => ({
+          userMutes: {
+            where: { userId: context.session?.userId },
+            take: 1,
+          },
+        }),
+
+        resolve: ({ userMutes }, _, context) => !!context.session && userMutes.length > 0,
+      }),
     }),
-  }),
-});
+  });
 
-builder.prismaObject('TagWikiRevision', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    content: t.exposeString('content'),
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-  }),
-});
+  builder.prismaObject('TagWiki', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      lastRevision: t.prismaField({
+        type: 'TagWikiRevision',
+        select: (_, __, nestedSelection) => ({
+          revisions: nestedSelection({
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+          }),
+        }),
 
-/**
- * * Inputs
- */
+        resolve: (_, { revisions }) => revisions[0],
+      }),
+    }),
+  });
 
-const MuteTagInput = builder.inputType('MuteTagInput', {
-  fields: (t) => ({
-    tagId: t.id(),
-  }),
-});
+  builder.prismaObject('TagWikiRevision', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      content: t.exposeString('content'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+    }),
+  });
 
-const UnmuteTagInput = builder.inputType('UnmuteTagInput', {
-  fields: (t) => ({
-    tagId: t.id(),
-  }),
-});
+  /**
+   * * Inputs
+   */
 
-const FollowTagInput = builder.inputType('FollowTagInput', {
-  fields: (t) => ({
-    tagId: t.id(),
-  }),
-});
+  const MuteTagInput = builder.inputType('MuteTagInput', {
+    fields: (t) => ({
+      tagId: t.id(),
+    }),
+  });
 
-const UnfollowTagInput = builder.inputType('UnfollowTagInput', {
-  fields: (t) => ({
-    tagId: t.id(),
-  }),
-});
+  const UnmuteTagInput = builder.inputType('UnmuteTagInput', {
+    fields: (t) => ({
+      tagId: t.id(),
+    }),
+  });
 
-const SetParentTagInput = builder.inputType('SetParentTagInput', {
-  fields: (t) => ({
-    tagId: t.id(),
-    parentTagId: t.id(),
-  }),
-});
+  const FollowTagInput = builder.inputType('FollowTagInput', {
+    fields: (t) => ({
+      tagId: t.id(),
+    }),
+  });
 
-const UnsetParentTagInput = builder.inputType('UnsetParentTagInput', {
-  fields: (t) => ({
-    tagId: t.id(),
-    parentTagId: t.id(),
-  }),
-});
+  const UnfollowTagInput = builder.inputType('UnfollowTagInput', {
+    fields: (t) => ({
+      tagId: t.id(),
+    }),
+  });
 
-const ReviseTagWikiInput = builder.inputType('ReviseTagWikiInput', {
-  fields: (t) => ({
-    tagId: t.id(),
-    content: t.string(),
-  }),
-});
+  const SetParentTagInput = builder.inputType('SetParentTagInput', {
+    fields: (t) => ({
+      tagId: t.id(),
+      parentTagId: t.id(),
+    }),
+  });
 
-// const SetPostTagsInput = builder.inputType('SetPostTagsInput', {
-//   fields: (t) => ({
-//     postId: t.id(),
-//     tag: t.stringList(),
-//   }),
-// });
+  const UnsetParentTagInput = builder.inputType('UnsetParentTagInput', {
+    fields: (t) => ({
+      tagId: t.id(),
+      parentTagId: t.id(),
+    }),
+  });
 
-/**
- * * Queries
- */
+  const ReviseTagWikiInput = builder.inputType('ReviseTagWikiInput', {
+    fields: (t) => ({
+      tagId: t.id(),
+      content: t.string(),
+    }),
+  });
 
-builder.queryFields((t) => ({
-  tag: t.prismaField({
-    type: 'Tag',
-    args: { name: t.arg.string() },
-    resolve: (query, _, { name }, { db }) => {
-      return db.tag.findUniqueOrThrow({ ...query, where: { name } });
-    },
-  }),
-}));
+  // const SetPostTagsInput = builder.inputType('SetPostTagsInput', {
+  //   fields: (t) => ({
+  //     postId: t.id(),
+  //     tag: t.stringList(),
+  //   }),
+  // });
 
-/**
- * * Mutations
- */
+  /**
+   * * Queries
+   */
 
-builder.mutationFields((t) => ({
-  muteTag: t.withAuth({ user: true }).prismaField({
-    type: 'Tag',
-    args: { input: t.arg({ type: MuteTagInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const tag = await db.tag.findUniqueOrThrow({
-        ...query,
-        where: { id: input.tagId },
-      });
+  builder.queryFields((t) => ({
+    tag: t.prismaField({
+      type: 'Tag',
+      args: { name: t.arg.string() },
+      resolve: (query, _, { name }, { db }) => {
+        return db.tag.findUniqueOrThrow({ ...query, where: { name } });
+      },
+    }),
+  }));
 
-      await db.userTagMute.upsert({
-        where: {
-          userId_tagId: {
+  /**
+   * * Mutations
+   */
+
+  builder.mutationFields((t) => ({
+    muteTag: t.withAuth({ user: true }).prismaField({
+      type: 'Tag',
+      args: { input: t.arg({ type: MuteTagInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const tag = await db.tag.findUniqueOrThrow({
+          ...query,
+          where: { id: input.tagId },
+        });
+
+        await db.userTagMute.upsert({
+          where: {
+            userId_tagId: {
+              userId: context.session.userId,
+              tagId: input.tagId,
+            },
+          },
+          create: {
+            id: createId(),
             userId: context.session.userId,
             tagId: input.tagId,
           },
-        },
-        create: {
-          id: createId(),
-          userId: context.session.userId,
-          tagId: input.tagId,
-        },
-        update: {},
-      });
+          update: {},
+        });
 
-      return tag;
-    },
-  }),
+        return tag;
+      },
+    }),
 
-  unmuteTag: t.withAuth({ user: true }).prismaField({
-    type: 'Tag',
-    args: { input: t.arg({ type: UnmuteTagInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const tag = await db.tag.findUniqueOrThrow({
-        ...query,
-        where: { id: input.tagId },
-      });
+    unmuteTag: t.withAuth({ user: true }).prismaField({
+      type: 'Tag',
+      args: { input: t.arg({ type: UnmuteTagInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const tag = await db.tag.findUniqueOrThrow({
+          ...query,
+          where: { id: input.tagId },
+        });
 
-      await db.userTagMute.deleteMany({
-        where: {
-          userId: context.session.userId,
-          tagId: input.tagId,
-        },
-      });
-
-      return tag;
-    },
-  }),
-
-  followTag: t.withAuth({ user: true }).prismaField({
-    type: 'Tag',
-    args: { input: t.arg({ type: FollowTagInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      await db.tagFollow.upsert({
-        where: {
-          userId_tagId: {
+        await db.userTagMute.deleteMany({
+          where: {
             userId: context.session.userId,
             tagId: input.tagId,
           },
-        },
-        create: {
-          id: createId(),
-          userId: context.session.userId,
-          tagId: input.tagId,
-        },
-        update: {},
-      });
+        });
 
-      return db.tag.findUniqueOrThrow({
-        ...query,
-        where: { id: input.tagId },
-      });
-    },
-  }),
+        return tag;
+      },
+    }),
 
-  unfollowTag: t.withAuth({ user: true }).prismaField({
-    type: 'Tag',
-    args: { input: t.arg({ type: UnfollowTagInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      await db.tagFollow.deleteMany({
-        where: {
-          userId: context.session.userId,
-          tagId: input.tagId,
-        },
-      });
-
-      return db.tag.findUniqueOrThrow({
-        ...query,
-        where: { id: input.tagId },
-      });
-    },
-  }),
-
-  setParentTag: t.withAuth({ user: true }).prismaField({
-    type: 'Tag',
-    args: { input: t.arg({ type: SetParentTagInput }) },
-    resolve: async (query, _, { input }, { db }) => {
-      return await db.tag.update({
-        ...query,
-        where: { id: input.tagId },
-        data: {
-          parents: {
-            connect: { id: input.parentTagId },
+    followTag: t.withAuth({ user: true }).prismaField({
+      type: 'Tag',
+      args: { input: t.arg({ type: FollowTagInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        await db.tagFollow.upsert({
+          where: {
+            userId_tagId: {
+              userId: context.session.userId,
+              tagId: input.tagId,
+            },
           },
-        },
-      });
-    },
-  }),
-
-  unsetParentTag: t.withAuth({ user: true }).prismaField({
-    type: 'Tag',
-    args: { input: t.arg({ type: UnsetParentTagInput }) },
-    resolve: async (query, _, { input }, { db }) => {
-      return await db.tag.update({
-        ...query,
-        where: { id: input.tagId },
-        data: {
-          parents: {
-            disconnect: { id: input.parentTagId },
+          create: {
+            id: createId(),
+            userId: context.session.userId,
+            tagId: input.tagId,
           },
-        },
-      });
-    },
-  }),
+          update: {},
+        });
 
-  reviseTagWiki: t.withAuth({ user: true }).prismaField({
-    type: 'TagWiki',
-    args: { input: t.arg({ type: ReviseTagWikiInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const revisionData = {
-        id: createId(),
-        content: input.content,
-        createdAt: new Date(),
-        userId: context.session.userId,
-      };
+        return db.tag.findUniqueOrThrow({
+          ...query,
+          where: { id: input.tagId },
+        });
+      },
+    }),
 
-      return await db.tagWiki.upsert({
-        ...query,
-        where: { tagId: input.tagId },
-        create: {
+    unfollowTag: t.withAuth({ user: true }).prismaField({
+      type: 'Tag',
+      args: { input: t.arg({ type: UnfollowTagInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        await db.tagFollow.deleteMany({
+          where: {
+            userId: context.session.userId,
+            tagId: input.tagId,
+          },
+        });
+
+        return db.tag.findUniqueOrThrow({
+          ...query,
+          where: { id: input.tagId },
+        });
+      },
+    }),
+
+    setParentTag: t.withAuth({ user: true }).prismaField({
+      type: 'Tag',
+      args: { input: t.arg({ type: SetParentTagInput }) },
+      resolve: async (query, _, { input }, { db }) => {
+        return await db.tag.update({
+          ...query,
+          where: { id: input.tagId },
+          data: {
+            parents: {
+              connect: { id: input.parentTagId },
+            },
+          },
+        });
+      },
+    }),
+
+    unsetParentTag: t.withAuth({ user: true }).prismaField({
+      type: 'Tag',
+      args: { input: t.arg({ type: UnsetParentTagInput }) },
+      resolve: async (query, _, { input }, { db }) => {
+        return await db.tag.update({
+          ...query,
+          where: { id: input.tagId },
+          data: {
+            parents: {
+              disconnect: { id: input.parentTagId },
+            },
+          },
+        });
+      },
+    }),
+
+    reviseTagWiki: t.withAuth({ user: true }).prismaField({
+      type: 'TagWiki',
+      args: { input: t.arg({ type: ReviseTagWikiInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const revisionData = {
           id: createId(),
-          tagId: input.tagId,
-          revisions: { create: revisionData },
-        },
-        update: {
-          revisions: { create: revisionData },
-        },
-      });
-    },
-  }),
+          content: input.content,
+          createdAt: new Date(),
+          userId: context.session.userId,
+        };
 
-  // setPostTags: t.withAuth({ user: true }).prismaField({
-  //   type: 'Tag',
-  //   args: { input: t.arg({ type: SetPostTagsInput }) },
-  //   resolve: async (query, _, { input }, { db, ...context }) => {
-  //     const post = await db.post.findUniqueOrThrow({
-  //       where: { id: input.postId },
-  //     });
-  //     const tag = await db.tag.upsert({
+        return await db.tagWiki.upsert({
+          ...query,
+          where: { tagId: input.tagId },
+          create: {
+            id: createId(),
+            tagId: input.tagId,
+            revisions: { create: revisionData },
+          },
+          update: {
+            revisions: { create: revisionData },
+          },
+        });
+      },
+    }),
 
-  //     })
-  //   },
-  // }),
-}));
+    // setPostTags: t.withAuth({ user: true }).prismaField({
+    //   type: 'Tag',
+    //   args: { input: t.arg({ type: SetPostTagsInput }) },
+    //   resolve: async (query, _, { input }, { db, ...context }) => {
+    //     const post = await db.post.findUniqueOrThrow({
+    //       where: { id: input.postId },
+    //     });
+    //     const tag = await db.tag.upsert({
+
+    //     })
+    //   },
+    // }),
+  }));
+});

--- a/apps/penxle.com/src/lib/server/graphql/schemas/user.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/user.ts
@@ -30,811 +30,813 @@ import {
   UpdateUserEmailSchema,
   UpdateUserProfileSchema,
 } from '$lib/validations';
-import { builder } from '../builder';
+import { defineSchema } from '../builder';
 
-/**
- * * Types
- */
+export const userSchema = defineSchema((builder) => {
+  /**
+   * * Types
+   */
 
-builder.prismaObject('Profile', {
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    name: t.exposeString('name'),
+  builder.prismaObject('Profile', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      name: t.exposeString('name'),
 
-    avatar: t.relation('avatar'),
-  }),
-});
-
-builder.prismaObject('ProvisionedUser', {
-  authScopes: { $granted: '$user' },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    email: t.exposeString('email'),
-    name: t.exposeString('name', { nullable: true }),
-    avatarUrl: t.exposeString('avatarUrl', { nullable: true }),
-  }),
-});
-
-builder.prismaObject('User', {
-  authScopes: (user, context) => user.id === context.session?.userId || { $granted: '$user', staff: true },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    email: t.exposeString('email'),
-    state: t.expose('state', { type: UserState }),
-
-    contentFilterPreferences: t.relation('contentFilterPreferences', { grantScopes: ['$user'] }),
-    marketingConsent: t.relation('marketingConsent', { nullable: true, grantScopes: ['$user'] }),
-    notificationPreferences: t.relation('notificationPreferences', { grantScopes: ['$user'] }),
-    personalIdentity: t.relation('personalIdentity', { nullable: true, grantScopes: ['$user'] }),
-    profile: t.relation('profile'),
-    singleSignOns: t.relation('singleSignOns', { grantScopes: ['$user'] }),
-    bookmarks: t.relation('bookmarks'),
-
-    isAdulthood: t.boolean({
-      select: { personalIdentity: { select: { birthday: true } } },
-      resolve: (user) => {
-        if (!user.personalIdentity) {
-          return false;
-        }
-
-        return isAdulthood(user.personalIdentity.birthday);
-      },
+      avatar: t.relation('avatar'),
     }),
+  });
 
-    point: t.int({
-      resolve: async (user, _, { db }) => {
-        return getUserPoint({ db, userId: user.id });
-      },
+  builder.prismaObject('ProvisionedUser', {
+    authScopes: { $granted: '$user' },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      email: t.exposeString('email'),
+      name: t.exposeString('name', { nullable: true }),
+      avatarUrl: t.exposeString('avatarUrl', { nullable: true }),
     }),
+  });
 
-    channelIOMemberHash: t.string({
-      resolve: (user) => {
-        return crypto
-          .createHmac('sha256', Buffer.from(env.PRIVATE_CHANNEL_IO_SECRET_KEY, 'hex'))
-          .update(user.id)
-          .digest('hex');
-      },
-    }),
+  builder.prismaObject('User', {
+    authScopes: (user, context) => user.id === context.session?.userId || { $granted: '$user', staff: true },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      email: t.exposeString('email'),
+      state: t.expose('state', { type: UserState }),
 
-    spaces: t.prismaField({
-      type: ['Space'],
-      select: (_, __, nestedSelection) => ({
-        spaces: {
-          include: { space: nestedSelection() },
-          where: {
-            state: 'ACTIVE',
-            space: { state: 'ACTIVE' },
-          },
+      contentFilterPreferences: t.relation('contentFilterPreferences', { grantScopes: ['$user'] }),
+      marketingConsent: t.relation('marketingConsent', { nullable: true, grantScopes: ['$user'] }),
+      notificationPreferences: t.relation('notificationPreferences', { grantScopes: ['$user'] }),
+      personalIdentity: t.relation('personalIdentity', { nullable: true, grantScopes: ['$user'] }),
+      profile: t.relation('profile'),
+      singleSignOns: t.relation('singleSignOns', { grantScopes: ['$user'] }),
+      bookmarks: t.relation('bookmarks'),
+
+      isAdulthood: t.boolean({
+        select: { personalIdentity: { select: { birthday: true } } },
+        resolve: (user) => {
+          if (!user.personalIdentity) {
+            return false;
+          }
+
+          return isAdulthood(user.personalIdentity.birthday);
         },
       }),
-      resolve: (_, { spaces }) => spaces.map(({ space }) => space),
-    }),
 
-    followedSpaces: t.prismaField({
-      type: ['Space'],
-      select: (_, __, nestedSelection) => ({
-        followedSpaces: {
-          include: { space: nestedSelection() },
-          where: {
-            space: { state: 'ACTIVE' },
-          },
+      point: t.int({
+        resolve: async (user, _, { db }) => {
+          return getUserPoint({ db, userId: user.id });
         },
       }),
-      resolve: (_, { followedSpaces }) => followedSpaces.map(({ space }) => space),
-    }),
 
-    receivedSpaceMemberInvitations: t.relation('receivedSpaceMemberInvitations', {
-      grantScopes: ['$space.member.invitation', '$space.member.invitation.state'],
-      args: { state: t.arg({ type: SpaceMemberInvitationState, required: false }) },
-      query: ({ state }) => ({ where: { state: state ?? undefined } }),
-    }),
-
-    mutedSpaces: t.prismaField({
-      type: ['Space'],
-      select: (_, __, nestedSelection) => ({
-        mutedSpaces: {
-          include: { space: nestedSelection() },
-          where: {
-            space: { state: 'ACTIVE' },
-          },
+      channelIOMemberHash: t.string({
+        resolve: (user) => {
+          return crypto
+            .createHmac('sha256', Buffer.from(env.PRIVATE_CHANNEL_IO_SECRET_KEY, 'hex'))
+            .update(user.id)
+            .digest('hex');
         },
       }),
-      resolve: (_, { mutedSpaces }) => mutedSpaces.map(({ space }) => space),
-    }),
 
-    mutedTags: t.prismaField({
-      type: ['Tag'],
-      select: (_, __, nestedSelection) => ({
-        tagMutes: {
-          include: { tag: nestedSelection() },
-        },
-      }),
-      resolve: (_, { tagMutes }) => tagMutes.map(({ tag }) => tag),
-    }),
-
-    recentlyViewedPosts: t.prismaField({
-      type: ['Post'],
-      resolve: async (query, user, _, { db }) => {
-        const postView = await db.postView.findMany({
-          include: { post: query },
-          where: {
-            userId: user.id,
-            post: {
-              state: 'PUBLISHED',
-              space: {
-                state: 'ACTIVE',
-                OR: [{ visibility: 'PUBLIC' }, { visibility: 'PRIVATE', members: { some: { userId: user.id } } }],
-              },
-              OR: [
-                { visibility: 'PUBLIC' },
-                { visibility: 'UNLISTED' },
-                {
-                  visibility: 'SPACE',
-                  space: { members: { some: { userId: user.id } } },
-                },
-              ],
+      spaces: t.prismaField({
+        type: ['Space'],
+        select: (_, __, nestedSelection) => ({
+          spaces: {
+            include: { space: nestedSelection() },
+            where: {
+              state: 'ACTIVE',
+              space: { state: 'ACTIVE' },
             },
           },
-          orderBy: { createdAt: 'desc' },
-        });
-        return postView.map(({ post }) => post);
-      },
-    }),
-
-    posts: t.relation('posts', {
-      args: { state: t.arg({ type: PostState, defaultValue: 'PUBLISHED' }) },
-      query: ({ state }) => ({
-        where: { state },
-        orderBy: { createdAt: 'desc' },
+        }),
+        resolve: (_, { spaces }) => spaces.map(({ space }) => space),
       }),
-    }),
 
-    likedPosts: t.prismaField({
-      type: ['Post'],
-      resolve: async (query, user, _, { db }) => {
-        const likes = await db.postLike.findMany({
-          include: { post: query },
-          where: {
-            userId: user.id,
-            post: {
-              state: 'PUBLISHED',
-              space: {
-                state: 'ACTIVE',
-                OR: [{ visibility: 'PUBLIC' }, { visibility: 'PRIVATE', members: { some: { userId: user.id } } }],
-              },
-              OR: [
-                { visibility: 'PUBLIC' },
-                { visibility: 'UNLISTED' },
-                {
-                  visibility: 'SPACE',
-                  space: { members: { some: { userId: user.id } } },
-                },
-              ],
+      followedSpaces: t.prismaField({
+        type: ['Space'],
+        select: (_, __, nestedSelection) => ({
+          followedSpaces: {
+            include: { space: nestedSelection() },
+            where: {
+              space: { state: 'ACTIVE' },
             },
           },
-          orderBy: { createdAt: 'desc' },
-        });
-
-        return likes.map(({ post }) => post);
-      },
-    }),
-
-    purchasedPosts: t.prismaField({
-      type: ['Post'],
-      select: (_, __, nestedSelection) => ({
-        postPurchases: {
-          include: { post: nestedSelection() },
-          orderBy: { createdAt: 'desc' },
-        },
-      }),
-      resolve: (_, { postPurchases }) => postPurchases.map(({ post }) => post),
-    }),
-
-    followedTags: t.prismaField({
-      type: ['Tag'],
-      select: (_, __, nestedSelection) => ({
-        followedTags: {
-          include: { tag: nestedSelection() },
-        },
+        }),
+        resolve: (_, { followedSpaces }) => followedSpaces.map(({ space }) => space),
       }),
 
-      resolve: (_, { followedTags }) => followedTags.map(({ tag }) => tag),
+      receivedSpaceMemberInvitations: t.relation('receivedSpaceMemberInvitations', {
+        grantScopes: ['$space.member.invitation', '$space.member.invitation.state'],
+        args: { state: t.arg({ type: SpaceMemberInvitationState, required: false }) },
+        query: ({ state }) => ({ where: { state: state ?? undefined } }),
+      }),
+
+      mutedSpaces: t.prismaField({
+        type: ['Space'],
+        select: (_, __, nestedSelection) => ({
+          mutedSpaces: {
+            include: { space: nestedSelection() },
+            where: {
+              space: { state: 'ACTIVE' },
+            },
+          },
+        }),
+        resolve: (_, { mutedSpaces }) => mutedSpaces.map(({ space }) => space),
+      }),
+
+      mutedTags: t.prismaField({
+        type: ['Tag'],
+        select: (_, __, nestedSelection) => ({
+          tagMutes: {
+            include: { tag: nestedSelection() },
+          },
+        }),
+        resolve: (_, { tagMutes }) => tagMutes.map(({ tag }) => tag),
+      }),
+
+      recentlyViewedPosts: t.prismaField({
+        type: ['Post'],
+        resolve: async (query, user, _, { db }) => {
+          const postView = await db.postView.findMany({
+            include: { post: query },
+            where: {
+              userId: user.id,
+              post: {
+                state: 'PUBLISHED',
+                space: {
+                  state: 'ACTIVE',
+                  OR: [{ visibility: 'PUBLIC' }, { visibility: 'PRIVATE', members: { some: { userId: user.id } } }],
+                },
+                OR: [
+                  { visibility: 'PUBLIC' },
+                  { visibility: 'UNLISTED' },
+                  {
+                    visibility: 'SPACE',
+                    space: { members: { some: { userId: user.id } } },
+                  },
+                ],
+              },
+            },
+            orderBy: { createdAt: 'desc' },
+          });
+          return postView.map(({ post }) => post);
+        },
+      }),
+
+      posts: t.relation('posts', {
+        args: { state: t.arg({ type: PostState, defaultValue: 'PUBLISHED' }) },
+        query: ({ state }) => ({
+          where: { state },
+          orderBy: { createdAt: 'desc' },
+        }),
+      }),
+
+      likedPosts: t.prismaField({
+        type: ['Post'],
+        resolve: async (query, user, _, { db }) => {
+          const likes = await db.postLike.findMany({
+            include: { post: query },
+            where: {
+              userId: user.id,
+              post: {
+                state: 'PUBLISHED',
+                space: {
+                  state: 'ACTIVE',
+                  OR: [{ visibility: 'PUBLIC' }, { visibility: 'PRIVATE', members: { some: { userId: user.id } } }],
+                },
+                OR: [
+                  { visibility: 'PUBLIC' },
+                  { visibility: 'UNLISTED' },
+                  {
+                    visibility: 'SPACE',
+                    space: { members: { some: { userId: user.id } } },
+                  },
+                ],
+              },
+            },
+            orderBy: { createdAt: 'desc' },
+          });
+
+          return likes.map(({ post }) => post);
+        },
+      }),
+
+      purchasedPosts: t.prismaField({
+        type: ['Post'],
+        select: (_, __, nestedSelection) => ({
+          postPurchases: {
+            include: { post: nestedSelection() },
+            orderBy: { createdAt: 'desc' },
+          },
+        }),
+        resolve: (_, { postPurchases }) => postPurchases.map(({ post }) => post),
+      }),
+
+      followedTags: t.prismaField({
+        type: ['Tag'],
+        select: (_, __, nestedSelection) => ({
+          followedTags: {
+            include: { tag: nestedSelection() },
+          },
+        }),
+
+        resolve: (_, { followedTags }) => followedTags.map(({ tag }) => tag),
+      }),
     }),
-  }),
-});
+  });
 
-builder.prismaObject('UserContentFilterPreference', {
-  authScopes: { $granted: '$user' },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    category: t.expose('category', { type: ContentFilterCategory }),
-    action: t.expose('action', { type: ContentFilterAction }),
-  }),
-});
+  builder.prismaObject('UserContentFilterPreference', {
+    authScopes: { $granted: '$user' },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      category: t.expose('category', { type: ContentFilterCategory }),
+      action: t.expose('action', { type: ContentFilterAction }),
+    }),
+  });
 
-builder.prismaObject('UserEmailVerification', {
-  authScopes: { $granted: '$user' },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    kind: t.expose('kind', { type: UserEmailVerificationKind }),
-    email: t.exposeString('email'),
-    expiresAt: t.expose('expiresAt', { type: 'DateTime' }),
-  }),
-});
+  builder.prismaObject('UserEmailVerification', {
+    authScopes: { $granted: '$user' },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      kind: t.expose('kind', { type: UserEmailVerificationKind }),
+      email: t.exposeString('email'),
+      expiresAt: t.expose('expiresAt', { type: 'DateTime' }),
+    }),
+  });
 
-builder.prismaObject('UserMarketingConsent', {
-  authScopes: { $granted: '$user' },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-  }),
-});
+  builder.prismaObject('UserMarketingConsent', {
+    authScopes: { $granted: '$user' },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+    }),
+  });
 
-builder.prismaObject('UserNotificationPreference', {
-  authScopes: { $granted: '$user' },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    category: t.expose('category', { type: UserNotificationCategory }),
-    method: t.expose('method', { type: UserNotificationMethod }),
-    opted: t.exposeBoolean('opted'),
-  }),
-});
+  builder.prismaObject('UserNotificationPreference', {
+    authScopes: { $granted: '$user' },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      category: t.expose('category', { type: UserNotificationCategory }),
+      method: t.expose('method', { type: UserNotificationMethod }),
+      opted: t.exposeBoolean('opted'),
+    }),
+  });
 
-builder.prismaObject('UserPersonalIdentity', {
-  authScopes: { $granted: '$user' },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    createdAt: t.expose('createdAt', { type: 'DateTime' }),
-  }),
-});
+  builder.prismaObject('UserPersonalIdentity', {
+    authScopes: { $granted: '$user' },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      createdAt: t.expose('createdAt', { type: 'DateTime' }),
+    }),
+  });
 
-builder.prismaObject('UserSingleSignOn', {
-  authScopes: { $granted: '$user' },
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    provider: t.expose('provider', { type: UserSingleSignOnProvider }),
-    email: t.exposeString('email'),
-  }),
-});
+  builder.prismaObject('UserSingleSignOn', {
+    authScopes: { $granted: '$user' },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      provider: t.expose('provider', { type: UserSingleSignOnProvider }),
+      email: t.exposeString('email'),
+    }),
+  });
 
-const IssueUserSingleSignOnAuthorizationUrlResult = builder.simpleObject(
-  'IssueUserSingleSignOnAuthorizationUrlResult',
-  {
+  const IssueUserSingleSignOnAuthorizationUrlResult = builder.simpleObject(
+    'IssueUserSingleSignOnAuthorizationUrlResult',
+    {
+      fields: (t) => ({
+        url: t.string(),
+      }),
+    },
+  );
+
+  const IssueUserEmailAuthorizationUrlResult = builder.simpleObject('IssueUserEmailAuthorizationUrlResult', {
     fields: (t) => ({
       url: t.string(),
     }),
-  },
-);
+  });
 
-const IssueUserEmailAuthorizationUrlResult = builder.simpleObject('IssueUserEmailAuthorizationUrlResult', {
-  fields: (t) => ({
-    url: t.string(),
-  }),
-});
+  /**
+   * * Inputs
+   */
 
-/**
- * * Inputs
- */
+  const IssueUserSingleSignOnAuthorizationUrlInput = builder.inputType('IssueUserSingleSignOnAuthorizationUrlInput', {
+    fields: (t) => ({
+      type: t.field({ type: UserSingleSignOnAuthorizationType }),
+      provider: t.field({ type: UserSingleSignOnProvider }),
+    }),
+  });
 
-const IssueUserSingleSignOnAuthorizationUrlInput = builder.inputType('IssueUserSingleSignOnAuthorizationUrlInput', {
-  fields: (t) => ({
-    type: t.field({ type: UserSingleSignOnAuthorizationType }),
-    provider: t.field({ type: UserSingleSignOnProvider }),
-  }),
-});
+  const LoginUserInput = builder.inputType('LoginUserInput', {
+    fields: (t) => ({
+      email: t.string(),
+    }),
+    validate: { schema: LoginUserSchema },
+  });
 
-const LoginUserInput = builder.inputType('LoginUserInput', {
-  fields: (t) => ({
-    email: t.string(),
-  }),
-  validate: { schema: LoginUserSchema },
-});
+  const CreateUserInput = builder.inputType('CreateUserInput', {
+    fields: (t) => ({
+      token: t.string(),
+      name: t.string(),
+      termsConsent: t.boolean(),
+      marketingConsent: t.boolean(),
+    }),
+    validate: { schema: CreateUserSchema },
+  });
 
-const CreateUserInput = builder.inputType('CreateUserInput', {
-  fields: (t) => ({
-    token: t.string(),
-    name: t.string(),
-    termsConsent: t.boolean(),
-    marketingConsent: t.boolean(),
-  }),
-  validate: { schema: CreateUserSchema },
-});
+  const UpdateUserEmailInput = builder.inputType('UpdateUserEmailInput', {
+    fields: (t) => ({
+      email: t.string(),
+    }),
+    validate: { schema: UpdateUserEmailSchema },
+  });
 
-const UpdateUserEmailInput = builder.inputType('UpdateUserEmailInput', {
-  fields: (t) => ({
-    email: t.string(),
-  }),
-  validate: { schema: UpdateUserEmailSchema },
-});
+  const UnlinkUserSingleSignOnInput = builder.inputType('UnlinkUserSingleSignOnInput', {
+    fields: (t) => ({
+      provider: t.field({ type: UserSingleSignOnProvider }),
+    }),
+  });
 
-const UnlinkUserSingleSignOnInput = builder.inputType('UnlinkUserSingleSignOnInput', {
-  fields: (t) => ({
-    provider: t.field({ type: UserSingleSignOnProvider }),
-  }),
-});
+  const UpdateUserContentFilterPreferenceInput = builder.inputType('UpdateUserContentFilterPreferenceInput', {
+    fields: (t) => ({
+      category: t.field({ type: ContentFilterCategory }),
+      action: t.field({ type: ContentFilterAction }),
+    }),
+  });
 
-const UpdateUserContentFilterPreferenceInput = builder.inputType('UpdateUserContentFilterPreferenceInput', {
-  fields: (t) => ({
-    category: t.field({ type: ContentFilterCategory }),
-    action: t.field({ type: ContentFilterAction }),
-  }),
-});
+  const UpdateUserMarketingConsentInput = builder.inputType('UpdateUserMarketingConsentInput', {
+    fields: (t) => ({
+      consent: t.boolean(),
+    }),
+  });
 
-const UpdateUserMarketingConsentInput = builder.inputType('UpdateUserMarketingConsentInput', {
-  fields: (t) => ({
-    consent: t.boolean(),
-  }),
-});
+  const UpdateUserNotificationPreferenceInput = builder.inputType('UpdateUserNotificationPreferenceInput', {
+    fields: (t) => ({
+      category: t.field({ type: UserNotificationCategory }),
+      method: t.field({ type: UserNotificationMethod }),
+      opted: t.boolean(),
+    }),
+  });
 
-const UpdateUserNotificationPreferenceInput = builder.inputType('UpdateUserNotificationPreferenceInput', {
-  fields: (t) => ({
-    category: t.field({ type: UserNotificationCategory }),
-    method: t.field({ type: UserNotificationMethod }),
-    opted: t.boolean(),
-  }),
-});
+  const UpdateUserProfileInput = builder.inputType('UpdateUserProfileInput', {
+    fields: (t) => ({
+      avatarId: t.id(),
+      name: t.string(),
+    }),
+    validate: { schema: UpdateUserProfileSchema },
+  });
 
-const UpdateUserProfileInput = builder.inputType('UpdateUserProfileInput', {
-  fields: (t) => ({
-    avatarId: t.id(),
-    name: t.string(),
-  }),
-  validate: { schema: UpdateUserProfileSchema },
-});
+  const IssueUserEmailAuthorizationUrlInput = builder.inputType('IssueUserEmailAuthorizationUrlInput', {
+    fields: (t) => ({
+      email: t.string(),
+      code: t.string(),
+    }),
+    validate: { schema: IssueUserEmailAuthorizationUrlSchema },
+  });
 
-const IssueUserEmailAuthorizationUrlInput = builder.inputType('IssueUserEmailAuthorizationUrlInput', {
-  fields: (t) => ({
-    email: t.string(),
-    code: t.string(),
-  }),
-  validate: { schema: IssueUserEmailAuthorizationUrlSchema },
-});
+  /**
+   * * Queries
+   */
 
-/**
- * * Queries
- */
+  builder.queryFields((t) => ({
+    auth: t.field({
+      type: 'Void',
+      nullable: true,
+      authScopes: (_, args) => ({ [args.scope.toLowerCase()]: true }),
+      args: { scope: t.arg({ type: AuthScope }) },
+      resolve: () => null,
+      unauthorizedError: (_, args) =>
+        match(args.scope)
+          .with('USER', () => new IntentionalError('로그인이 필요해요'))
+          .otherwise(() => new PermissionDeniedError()),
+    }),
 
-builder.queryFields((t) => ({
-  auth: t.field({
-    type: 'Void',
-    nullable: true,
-    authScopes: (_, args) => ({ [args.scope.toLowerCase()]: true }),
-    args: { scope: t.arg({ type: AuthScope }) },
-    resolve: () => null,
-    unauthorizedError: (_, args) =>
-      match(args.scope)
-        .with('USER', () => new IntentionalError('로그인이 필요해요'))
-        .otherwise(() => new PermissionDeniedError()),
-  }),
+    me: t.prismaField({
+      type: 'User',
+      nullable: true,
+      resolve: async (query, _, __, { db, ...context }) => {
+        if (!context.session) {
+          return null;
+        }
 
-  me: t.prismaField({
-    type: 'User',
-    nullable: true,
-    resolve: async (query, _, __, { db, ...context }) => {
-      if (!context.session) {
-        return null;
-      }
-
-      return await db.user.findUnique({
-        ...query,
-        where: { id: context.session.userId },
-      });
-    },
-  }),
-
-  provisionedUser: t.prismaField({
-    type: 'ProvisionedUser',
-    grantScopes: ['$user'],
-    args: { token: t.arg({ type: 'String' }) },
-    resolve: async (query, _, args, { db }) => {
-      return await db.provisionedUser.findUniqueOrThrow({
-        ...query,
-        where: { token: args.token },
-      });
-    },
-  }),
-}));
-
-/**
- * * Mutations
- */
-
-builder.mutationFields((t) => ({
-  loginUser: t.prismaField({
-    type: 'UserEmailVerification',
-    grantScopes: ['$user'],
-    args: { input: t.arg({ type: LoginUserInput }) },
-    resolve: async (query, __, { input }, { db, ...context }) => {
-      const isEmailExists = await db.user.exists({
-        where: {
-          email: input.email.toLowerCase(),
-          state: 'ACTIVE',
-        },
-      });
-
-      const code = random(100_000, 999_999).toString();
-      const token = nanoid();
-
-      await sendEmail({
-        subject: `펜슬 ${isEmailExists ? '로그인' : '가입'}하기`,
-        recipient: input.email,
-        template: LoginUser,
-        props: {
-          action: isEmailExists ? '로그인' : '가입',
-          code,
-          url: qs.stringifyUrl({
-            url: `${context.url.origin}/api/email`,
-            query: { token },
-          }),
-        },
-      });
-
-      return await db.userEmailVerification.create({
-        ...query,
-        data: {
-          id: createId(),
-          kind: 'USER_LOGIN',
-          email: input.email.toLowerCase(),
-          token,
-          code,
-          expiresAt: dayjs().add(1, 'hour').toDate(),
-        },
-      });
-    },
-  }),
-
-  logoutUser: t.withAuth({ user: true }).field({
-    type: 'Void',
-    nullable: true,
-    resolve: async (_, __, { db, ...context }) => {
-      await db.userSession.delete({
-        where: { id: context.session.id },
-      });
-
-      context.cookies.delete('penxle-at', { path: '/' });
-    },
-  }),
-
-  issueUserEmailAuthorizationUrl: t.field({
-    type: IssueUserEmailAuthorizationUrlResult,
-    args: { input: t.arg({ type: IssueUserEmailAuthorizationUrlInput }) },
-    resolve: async (_, { input }, { db, ...context }) => {
-      const emailVerification = await db.userEmailVerification.findFirst({
-        where: {
-          email: input.email,
-          kind: 'USER_LOGIN',
-          code: input.code,
-        },
-      });
-
-      if (!emailVerification) {
-        throw new IntentionalError('올바르지 않은 코드예요.');
-      }
-
-      return {
-        url: qs.stringifyUrl({
-          url: `${context.url.origin}/api/email`,
-          query: { token: emailVerification.token },
-        }),
-      };
-    },
-  }),
-
-  createUser: t.prismaField({
-    type: 'User',
-    grantScopes: ['$user'],
-    args: { input: t.arg({ type: CreateUserInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const provisionedUser = await db.provisionedUser.findUniqueOrThrow({
-        where: { token: input.token },
-      });
-
-      const isEmailUsed = await db.user.exists({
-        where: {
-          email: provisionedUser.email.toLowerCase(),
-          state: 'ACTIVE',
-        },
-      });
-      if (isEmailUsed) {
-        throw new IntentionalError('이미 가입된 이메일이에요.');
-      }
-
-      const avatarId = await directUploadImage({
-        db,
-        name: 'avatar',
-        source: await createRandomAvatar(),
-      });
-
-      const profile = await db.profile.create({
-        data: {
-          id: createId(),
-          name: input.name,
-          avatarId,
-        },
-      });
-
-      const user = await db.user.create({
-        data: {
-          id: createId(),
-          email: provisionedUser.email,
-          profileId: profile.id,
-          state: 'ACTIVE',
-        },
-      });
-
-      await db.image.update({
-        where: { id: avatarId },
-        data: { userId: user.id },
-      });
-
-      if (input.marketingConsent) {
-        await db.userMarketingConsent.create({
-          data: {
-            id: createId(),
-            userId: user.id,
-          },
-        });
-      }
-
-      if (provisionedUser.provider && provisionedUser.principal) {
-        await db.userSingleSignOn.create({
-          data: {
-            id: createId(),
-            userId: user.id,
-            provider: provisionedUser.provider,
-            principal: provisionedUser.principal,
-            email: provisionedUser.email,
-          },
-        });
-      }
-
-      await db.provisionedUser.delete({
-        where: { id: provisionedUser.id },
-      });
-
-      const session = await db.userSession.create({
-        data: { id: createId(), userId: user.id },
-      });
-
-      const accessToken = await createAccessToken(session.id);
-      context.cookies.set('penxle-at', accessToken, {
-        path: '/',
-        maxAge: dayjs.duration(1, 'year').asSeconds(),
-      });
-
-      return await db.user.findUniqueOrThrow({
-        ...query,
-        where: { id: user.id },
-      });
-    },
-  }),
-
-  issueUserSingleSignOnAuthorizationUrl: t.field({
-    type: IssueUserSingleSignOnAuthorizationUrlResult,
-    args: { input: t.arg({ type: IssueUserSingleSignOnAuthorizationUrlInput }) },
-    resolve: (_, { input }, context) => {
-      const provider = match(input.provider)
-        .with('GOOGLE', () => google)
-        .with('NAVER', () => naver)
-        .exhaustive();
-
-      return {
-        url: provider.generateAuthorizationUrl(context, input.type),
-      };
-    },
-  }),
-
-  updateUserEmail: t.withAuth({ user: true }).field({
-    type: 'Void',
-    nullable: true,
-    args: { input: t.arg({ type: UpdateUserEmailInput }) },
-    resolve: async (_, { input }, { db, ...context }) => {
-      const isEmailUsed = await db.user.exists({
-        where: {
-          email: input.email.toLowerCase(),
-          state: 'ACTIVE',
-        },
-      });
-
-      if (isEmailUsed) {
-        return;
-      }
-
-      const user = await db.user.findUniqueOrThrow({
-        include: { profile: true },
-        where: { id: context.session.userId },
-      });
-
-      const token = nanoid();
-
-      await db.userEmailVerification.create({
-        data: {
-          id: createId(),
-          userId: user.id,
-          kind: 'USER_EMAIL_UPDATE',
-          email: input.email.toLowerCase(),
-          token,
-          expiresAt: dayjs().add(1, 'hour').toDate(),
-        },
-      });
-
-      await sendEmail({
-        subject: 'PENXLE 이메일 변경',
-        recipient: input.email,
-        template: UpdateUserEmail,
-        props: {
-          name: user.profile.name,
-          email: input.email,
-          url: qs.stringifyUrl({
-            url: `${context.url.origin}/api/email`,
-            query: { token },
-          }),
-        },
-      });
-    },
-  }),
-
-  updateUserProfile: t.withAuth({ user: true }).prismaField({
-    type: 'Profile',
-    args: { input: t.arg({ type: UpdateUserProfileInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      const avatar = await db.image.findUniqueOrThrow({
-        where: {
-          id: input.avatarId,
-          userId: context.session.userId,
-        },
-      });
-
-      const user = await db.user.update({
-        include: { profile: query },
-        where: { id: context.session.userId },
-        data: {
-          profile: {
-            update: {
-              avatarId: avatar.id,
-              name: input.name,
-            },
-          },
-        },
-      });
-
-      return user.profile;
-    },
-  }),
-
-  updateUserMarketingConsent: t.withAuth({ user: true }).prismaField({
-    type: 'User',
-    args: { input: t.arg({ type: UpdateUserMarketingConsentInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      if (input.consent) {
-        return await db.user.update({
+        return await db.user.findUnique({
           ...query,
           where: { id: context.session.userId },
-          data: {
-            marketingConsent: {
-              create: {
-                id: createId(),
-              },
-            },
-          },
         });
-      } else {
-        return await db.user.update({
+      },
+    }),
+
+    provisionedUser: t.prismaField({
+      type: 'ProvisionedUser',
+      grantScopes: ['$user'],
+      args: { token: t.arg({ type: 'String' }) },
+      resolve: async (query, _, args, { db }) => {
+        return await db.provisionedUser.findUniqueOrThrow({
           ...query,
-          where: { id: context.session.userId },
-          data: {
-            marketingConsent: {
-              delete: true,
-            },
-          },
+          where: { token: args.token },
         });
-      }
-    },
-  }),
+      },
+    }),
+  }));
 
-  unlinkUserSingleSignOn: t.withAuth({ user: true }).prismaField({
-    type: 'User',
-    args: { input: t.arg({ type: UnlinkUserSingleSignOnInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      return await db.user.update({
-        ...query,
-        where: { id: context.session.userId },
-        data: {
-          singleSignOns: {
-            delete: {
-              userId_provider: {
-                userId: context.session.userId,
-                provider: input.provider,
-              },
-            },
-          },
-        },
-      });
-    },
-  }),
+  /**
+   * * Mutations
+   */
 
-  updateUserNotificationPreference: t.withAuth({ user: true }).prismaField({
-    type: 'User',
-    args: { input: t.arg({ type: UpdateUserNotificationPreferenceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      if (input.category === 'ALL') {
-        await db.userNotificationPreference.updateMany({
+  builder.mutationFields((t) => ({
+    loginUser: t.prismaField({
+      type: 'UserEmailVerification',
+      grantScopes: ['$user'],
+      args: { input: t.arg({ type: LoginUserInput }) },
+      resolve: async (query, __, { input }, { db, ...context }) => {
+        const isEmailExists = await db.user.exists({
           where: {
-            userId: context.session.userId,
-            method: input.method,
-          },
-          data: {
-            opted: input.opted,
+            email: input.email.toLowerCase(),
+            state: 'ACTIVE',
           },
         });
-      }
 
-      return await db.user.update({
-        ...query,
-        where: { id: context.session.userId },
-        data: {
-          notificationPreferences: {
-            upsert: {
-              where: {
-                userId_category_method: {
+        const code = random(100_000, 999_999).toString();
+        const token = nanoid();
+
+        await sendEmail({
+          subject: `펜슬 ${isEmailExists ? '로그인' : '가입'}하기`,
+          recipient: input.email,
+          template: LoginUser,
+          props: {
+            action: isEmailExists ? '로그인' : '가입',
+            code,
+            url: qs.stringifyUrl({
+              url: `${context.url.origin}/api/email`,
+              query: { token },
+            }),
+          },
+        });
+
+        return await db.userEmailVerification.create({
+          ...query,
+          data: {
+            id: createId(),
+            kind: 'USER_LOGIN',
+            email: input.email.toLowerCase(),
+            token,
+            code,
+            expiresAt: dayjs().add(1, 'hour').toDate(),
+          },
+        });
+      },
+    }),
+
+    logoutUser: t.withAuth({ user: true }).field({
+      type: 'Void',
+      nullable: true,
+      resolve: async (_, __, { db, ...context }) => {
+        await db.userSession.delete({
+          where: { id: context.session.id },
+        });
+
+        context.cookies.delete('penxle-at', { path: '/' });
+      },
+    }),
+
+    issueUserEmailAuthorizationUrl: t.field({
+      type: IssueUserEmailAuthorizationUrlResult,
+      args: { input: t.arg({ type: IssueUserEmailAuthorizationUrlInput }) },
+      resolve: async (_, { input }, { db, ...context }) => {
+        const emailVerification = await db.userEmailVerification.findFirst({
+          where: {
+            email: input.email,
+            kind: 'USER_LOGIN',
+            code: input.code,
+          },
+        });
+
+        if (!emailVerification) {
+          throw new IntentionalError('올바르지 않은 코드예요.');
+        }
+
+        return {
+          url: qs.stringifyUrl({
+            url: `${context.url.origin}/api/email`,
+            query: { token: emailVerification.token },
+          }),
+        };
+      },
+    }),
+
+    createUser: t.prismaField({
+      type: 'User',
+      grantScopes: ['$user'],
+      args: { input: t.arg({ type: CreateUserInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const provisionedUser = await db.provisionedUser.findUniqueOrThrow({
+          where: { token: input.token },
+        });
+
+        const isEmailUsed = await db.user.exists({
+          where: {
+            email: provisionedUser.email.toLowerCase(),
+            state: 'ACTIVE',
+          },
+        });
+        if (isEmailUsed) {
+          throw new IntentionalError('이미 가입된 이메일이에요.');
+        }
+
+        const avatarId = await directUploadImage({
+          db,
+          name: 'avatar',
+          source: await createRandomAvatar(),
+        });
+
+        const profile = await db.profile.create({
+          data: {
+            id: createId(),
+            name: input.name,
+            avatarId,
+          },
+        });
+
+        const user = await db.user.create({
+          data: {
+            id: createId(),
+            email: provisionedUser.email,
+            profileId: profile.id,
+            state: 'ACTIVE',
+          },
+        });
+
+        await db.image.update({
+          where: { id: avatarId },
+          data: { userId: user.id },
+        });
+
+        if (input.marketingConsent) {
+          await db.userMarketingConsent.create({
+            data: {
+              id: createId(),
+              userId: user.id,
+            },
+          });
+        }
+
+        if (provisionedUser.provider && provisionedUser.principal) {
+          await db.userSingleSignOn.create({
+            data: {
+              id: createId(),
+              userId: user.id,
+              provider: provisionedUser.provider,
+              principal: provisionedUser.principal,
+              email: provisionedUser.email,
+            },
+          });
+        }
+
+        await db.provisionedUser.delete({
+          where: { id: provisionedUser.id },
+        });
+
+        const session = await db.userSession.create({
+          data: { id: createId(), userId: user.id },
+        });
+
+        const accessToken = await createAccessToken(session.id);
+        context.cookies.set('penxle-at', accessToken, {
+          path: '/',
+          maxAge: dayjs.duration(1, 'year').asSeconds(),
+        });
+
+        return await db.user.findUniqueOrThrow({
+          ...query,
+          where: { id: user.id },
+        });
+      },
+    }),
+
+    issueUserSingleSignOnAuthorizationUrl: t.field({
+      type: IssueUserSingleSignOnAuthorizationUrlResult,
+      args: { input: t.arg({ type: IssueUserSingleSignOnAuthorizationUrlInput }) },
+      resolve: (_, { input }, context) => {
+        const provider = match(input.provider)
+          .with('GOOGLE', () => google)
+          .with('NAVER', () => naver)
+          .exhaustive();
+
+        return {
+          url: provider.generateAuthorizationUrl(context, input.type),
+        };
+      },
+    }),
+
+    updateUserEmail: t.withAuth({ user: true }).field({
+      type: 'Void',
+      nullable: true,
+      args: { input: t.arg({ type: UpdateUserEmailInput }) },
+      resolve: async (_, { input }, { db, ...context }) => {
+        const isEmailUsed = await db.user.exists({
+          where: {
+            email: input.email.toLowerCase(),
+            state: 'ACTIVE',
+          },
+        });
+
+        if (isEmailUsed) {
+          return;
+        }
+
+        const user = await db.user.findUniqueOrThrow({
+          include: { profile: true },
+          where: { id: context.session.userId },
+        });
+
+        const token = nanoid();
+
+        await db.userEmailVerification.create({
+          data: {
+            id: createId(),
+            userId: user.id,
+            kind: 'USER_EMAIL_UPDATE',
+            email: input.email.toLowerCase(),
+            token,
+            expiresAt: dayjs().add(1, 'hour').toDate(),
+          },
+        });
+
+        await sendEmail({
+          subject: 'PENXLE 이메일 변경',
+          recipient: input.email,
+          template: UpdateUserEmail,
+          props: {
+            name: user.profile.name,
+            email: input.email,
+            url: qs.stringifyUrl({
+              url: `${context.url.origin}/api/email`,
+              query: { token },
+            }),
+          },
+        });
+      },
+    }),
+
+    updateUserProfile: t.withAuth({ user: true }).prismaField({
+      type: 'Profile',
+      args: { input: t.arg({ type: UpdateUserProfileInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        const avatar = await db.image.findUniqueOrThrow({
+          where: {
+            id: input.avatarId,
+            userId: context.session.userId,
+          },
+        });
+
+        const user = await db.user.update({
+          include: { profile: query },
+          where: { id: context.session.userId },
+          data: {
+            profile: {
+              update: {
+                avatarId: avatar.id,
+                name: input.name,
+              },
+            },
+          },
+        });
+
+        return user.profile;
+      },
+    }),
+
+    updateUserMarketingConsent: t.withAuth({ user: true }).prismaField({
+      type: 'User',
+      args: { input: t.arg({ type: UpdateUserMarketingConsentInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        if (input.consent) {
+          return await db.user.update({
+            ...query,
+            where: { id: context.session.userId },
+            data: {
+              marketingConsent: {
+                create: {
+                  id: createId(),
+                },
+              },
+            },
+          });
+        } else {
+          return await db.user.update({
+            ...query,
+            where: { id: context.session.userId },
+            data: {
+              marketingConsent: {
+                delete: true,
+              },
+            },
+          });
+        }
+      },
+    }),
+
+    unlinkUserSingleSignOn: t.withAuth({ user: true }).prismaField({
+      type: 'User',
+      args: { input: t.arg({ type: UnlinkUserSingleSignOnInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        return await db.user.update({
+          ...query,
+          where: { id: context.session.userId },
+          data: {
+            singleSignOns: {
+              delete: {
+                userId_provider: {
                   userId: context.session.userId,
+                  provider: input.provider,
+                },
+              },
+            },
+          },
+        });
+      },
+    }),
+
+    updateUserNotificationPreference: t.withAuth({ user: true }).prismaField({
+      type: 'User',
+      args: { input: t.arg({ type: UpdateUserNotificationPreferenceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        if (input.category === 'ALL') {
+          await db.userNotificationPreference.updateMany({
+            where: {
+              userId: context.session.userId,
+              method: input.method,
+            },
+            data: {
+              opted: input.opted,
+            },
+          });
+        }
+
+        return await db.user.update({
+          ...query,
+          where: { id: context.session.userId },
+          data: {
+            notificationPreferences: {
+              upsert: {
+                where: {
+                  userId_category_method: {
+                    userId: context.session.userId,
+                    category: input.category,
+                    method: input.method,
+                  },
+                },
+                create: {
+                  id: createId(),
                   category: input.category,
                   method: input.method,
+                  opted: input.opted,
                 },
-              },
-              create: {
-                id: createId(),
-                category: input.category,
-                method: input.method,
-                opted: input.opted,
-              },
-              update: {
-                opted: input.opted,
+                update: {
+                  opted: input.opted,
+                },
               },
             },
           },
-        },
-      });
-    },
-  }),
-
-  updateUserContentFilterPreference: t.withAuth({ user: true }).prismaField({
-    type: 'User',
-    args: { input: t.arg({ type: UpdateUserContentFilterPreferenceInput }) },
-    resolve: async (query, _, { input }, { db, ...context }) => {
-      if (input.category === 'ADULT' && input.action === 'EXPOSE') {
-        const identity = await db.userPersonalIdentity.findUnique({
-          where: { userId: context.session.userId },
         });
+      },
+    }),
 
-        if (!identity || !isAdulthood(identity.birthday)) {
-          throw new IntentionalError('성인인증이 필요해요.');
+    updateUserContentFilterPreference: t.withAuth({ user: true }).prismaField({
+      type: 'User',
+      args: { input: t.arg({ type: UpdateUserContentFilterPreferenceInput }) },
+      resolve: async (query, _, { input }, { db, ...context }) => {
+        if (input.category === 'ADULT' && input.action === 'EXPOSE') {
+          const identity = await db.userPersonalIdentity.findUnique({
+            where: { userId: context.session.userId },
+          });
+
+          if (!identity || !isAdulthood(identity.birthday)) {
+            throw new IntentionalError('성인인증이 필요해요.');
+          }
         }
-      }
-      return await db.user.update({
-        ...query,
-        where: { id: context.session.userId },
-        data: {
-          contentFilterPreferences: {
-            upsert: {
-              where: {
-                userId_category: {
-                  userId: context.session.userId,
-                  category: input.category,
+        return await db.user.update({
+          ...query,
+          where: { id: context.session.userId },
+          data: {
+            contentFilterPreferences: {
+              upsert: {
+                where: {
+                  userId_category: {
+                    userId: context.session.userId,
+                    category: input.category,
+                  },
                 },
-              },
-              create: {
-                id: createId(),
-                category: input.category,
-                action: input.action,
-              },
-              update: {
-                action: input.action,
+                create: {
+                  id: createId(),
+                  category: input.category,
+                  action: input.action,
+                },
+                update: {
+                  action: input.action,
+                },
               },
             },
           },
-        },
-      });
-    },
-  }),
-}));
+        });
+      },
+    }),
+  }));
+});


### PR DESCRIPTION
개발환경에서 랜덤하게 발생하는 `BookmarkGroup`이 중복 선언되었다거나 `[object Object]`가 없다거나 하는 고질적인 pothos 스키마 빌드 오류들을 해치움

해결 방법: builder와 schema들을 전역 변수로 핸들링하지 않고 HMR시에 늘 재생성하는 일반 객체로 만듬
참고: 개발환경에서는 서버 코드 변경시마다 builder 전체를 재생성하지만 프로덕션에서는 HMR 리로드가 안 일어나기에 실제로는 최초 한번만 셋업됨