### PR TITLE
갤러리 에디터 최초 이미지 업로드 안 되는 버그 수정

### DIFF
--- a/apps/penxle.com/src/routes/editor/GalleryEditor.svelte
+++ b/apps/penxle.com/src/routes/editor/GalleryEditor.svelte
@@ -80,7 +80,7 @@
     description = content.content.find((c) => c.type === 'paragraph');
 
     if (!thumbnailId) {
-      const thumbnail = content.content.find((c) => c.type === 'image')?.attrs?.__data;
+      const thumbnail = content.content.find((c) => c.type === 'image') as Image;
 
       if (thumbnail) {
         setThumbnail(thumbnail);
@@ -115,6 +115,10 @@
           dispatch('change', resp);
         });
       }
+    }
+
+    if (validFiles.length === 0) {
+      return;
     }
 
     if (content?.content) {


### PR DESCRIPTION
`setThumbnail` 호출 인자 타입 오류로 js 에러 발생해 이미지 추가가 안 되고 있었음
