### PR TITLE
갤러리 에디터에서 업로드중인 이미지 경과 상태 UI/UX 추가함

### DIFF
--- a/apps/penxle.com/src/routes/editor/FileImage.svelte
+++ b/apps/penxle.com/src/routes/editor/FileImage.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+
+  let _class: string | undefined = undefined;
+  export { _class as class };
+  export let file: File;
+
+  const src = URL.createObjectURL(file);
+
+  onDestroy(() => {
+    URL.revokeObjectURL(src);
+  });
+</script>
+
+<img class={_class} alt="" {src} />


### PR DESCRIPTION
<img width="952" alt="CleanShot 2023-12-11 at 13 03 20" src="https://github.com/penxle/penxle/assets/337728/a638bd46-83fe-4a35-ac38-d8dca1fc9b60">

기존에는 파일 업로드중 UI에 비주얼 피드백이 없던 문제를 업로드한 이미지 프리뷰 + 업로드 대기중 스피너 추가로 업로드중이라는 상태를 가시적으로 변경함