### PR TITLE
direct image upload시에도 format에 `image/` prefix 추가함

### DIFF
--- a/apps/penxle.com/src/lib/server/utils/image.ts
+++ b/apps/penxle.com/src/lib/server/utils/image.ts
@@ -118,7 +118,7 @@ export const directUploadImage = async ({ db, userId, name, source, bounds }: Di
       id: createId(),
       userId,
       name,
-      format: res.format,
+      format: `image/${res.format}`,
       size: res.size,
       width: res.width,
       height: res.height,


### PR DESCRIPTION
일반 이미지 업로드와 포맷을 맞춤
