### PR TITLE
인프라 스케일 업

### DIFF
--- a/apps/bedrock/pulumi/aws/elasticache.ts
+++ b/apps/bedrock/pulumi/aws/elasticache.ts
@@ -9,7 +9,7 @@ const cluster = new aws.elasticache.ReplicationGroup('penxle', {
   engine: 'redis',
   engineVersion: '7.1',
 
-  nodeType: 'cache.t4g.micro',
+  nodeType: 'cache.r6g.large',
   numCacheClusters: 1,
 
   subnetGroupName: new aws.elasticache.SubnetGroup('private', {

--- a/apps/bedrock/pulumi/aws/opensearch.ts
+++ b/apps/bedrock/pulumi/aws/opensearch.ts
@@ -8,8 +8,8 @@ const domain = new aws.opensearch.Domain('penxle', {
   domainName: 'penxle',
 
   clusterConfig: {
-    instanceType: 'r6g.large.search',
-    instanceCount: 2,
+    instanceType: 'r6g.2xlarge.search',
+    instanceCount: 1,
   },
 
   ebsOptions: {

--- a/apps/bedrock/pulumi/aws/rds.ts
+++ b/apps/bedrock/pulumi/aws/rds.ts
@@ -49,7 +49,7 @@ const instance = new aws.rds.ClusterInstance('penxle-1', {
   identifier: 'penxle-1',
 
   engine: 'aurora-postgresql',
-  instanceClass: 'db.t4g.medium',
+  instanceClass: 'db.r6g.xlarge',
 
   availabilityZone: subnets.private.az1.availabilityZone,
   caCertIdentifier: 'rds-ca-rsa2048-g1',

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -80,6 +80,7 @@
     "vbank",
     "vite",
     "wonka",
+    "xlarge",
     "xvda",
     "zstd",
     "zxcvbn"


### PR DESCRIPTION
db: `db.t4g.medium` -> `db.r6g.xlarge`
redis: `cache.t4g.micro` -> `cache.r6g.large`
es: `r6g.large.search` -> `r6g.x2large.search`