### PR TITLE
포스트 관리에서 포스트 일괄 옵션 메뉴 열기 유지하기

### DIFF
--- a/apps/penxle.com/src/lib/components/pages/posts/PostManageTable.svelte
+++ b/apps/penxle.com/src/lib/components/pages/posts/PostManageTable.svelte
@@ -421,7 +421,7 @@
         <MenuItem on:click={() => updateVisibilities('UNLISTED')}>링크 공개</MenuItem>
         <MenuItem on:click={() => updateVisibilities('SPACE')}>멤버 공개</MenuItem>
       </Menu>
-      <Menu class="<sm:hidden" as="div" offset={toolbarMenuOffset} placement="top">
+      <Menu class="<sm:hidden" as="div" offset={toolbarMenuOffset} placement="top" preventClose>
         <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">포스트 옵션 설정</Button>
         <MenuItem type="div">
           <Switch


### PR DESCRIPTION
포스트 관리에서 포스트 일괄 옵션 변경이 적용이 안되는 것처럼 보여
수정하게 되었습니다.