### PR TITLE
썸네일 그라데이션 재설정 및 썸네일 없을 때 보여줄 배경색 설정하기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/(space)/collections/[entity]/+page@(default).svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/(space)/collections/[entity]/+page@(default).svelte
@@ -47,8 +47,10 @@
 
 <section class="flex flex-col items-center w-full bg-cardprimary grow">
   <header
-    style={`background-image: url(${collection?.thumbnail?.url})`}
-    class="w-full h-12.875rem p-x-6 p-y-6 bg-gradient-to-b from-black to-black flex justify-center items-end text-darkprimary bg-cover bg-center bg-no-repeat"
+    style={typeof collection?.thumbnail?.url === 'string'
+      ? `background-image: linear-gradient(transparent, rgba(0, 0, 0, 0.8)), url(${collection.thumbnail.url})`
+      : ''}
+    class="w-full h-12.875rem p-x-6 p-y-6 flex justify-center items-end text-darkprimary bg-(cover center no-repeat alphagray-50)"
   >
     <div class="max-w-75rem flex-1">
       <h1 class="title-20-b m-b-2">{collection?.name}</h1>


### PR DESCRIPTION
tailwind 로 설정한 그라데이션 배경 이미지 값이 인라인 스타일에 덮어 씌워져서 적용이 안되었었습니다.
인라인 스타일과 함께 집어넣어 해결을 하고, 썸네일 이미지가 없을 때 대신
보여주는 배경 색으로 회색을 지정했습니다.