### PR TITLE
글 이미지 공유 첫 시도 시 Safari 에서 문구가 비는 문제를  임시 방편으로 해결하기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/ShareContent/ShareContent.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/ShareContent/ShareContent.svelte
@@ -71,10 +71,6 @@
 
     const file = dataurl2file(dataUrl, `${title}.png`);
 
-    if (navigator.share) {
-      navigator.share({ title, text: '밑줄 공유', files: [file] });
-      return;
-    }
     if (typeof ClipboardItem === 'undefined') {
       const link = document.createElement('a');
       link.download = `${title}.png`;


### PR DESCRIPTION
Web Share API 를 빼고 다운로드/클립보드 복사만 남기겠습니다.