### PR TITLE
스페이스 레이아웃 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/(space)/(index)/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/(space)/(index)/+page.svelte
@@ -30,7 +30,7 @@
 
 <article
   class={clsx(
-    'w-full min-h-11rem max-w-50rem flex flex-col items-center py-9 grow <sm:(p-0 gap-2 bg-surface-primary)',
+    'w-full min-h-11rem max-w-50rem flex flex-col items-center py-6.5 grow <sm:(p-0 gap-2 bg-surface-primary)',
     $query.space.posts.length === 0 && 'center',
   )}
 >
@@ -38,21 +38,16 @@
     <div class="flex flex-col center">
       <h2 class="body-15-b text-secondary">아직 스페이스에 업로드된 포스트가 없어요</h2>
       {#if $query.space.meAsMember}
-        <Button class="mt-5 sm:hidden" href={`/editor?space=${$query.space.slug}`} size="lg" type="link">
-          포스트 작성하기
-        </Button>
-        <Button class="mt-5 <sm:hidden" href={`/editor?space=${$query.space.slug}`} size="xl" type="link">
-          포스트 작성하기
-        </Button>
+        <Button class="mt-5" href={`/editor?space=${$query.space.slug}`} size="lg" type="link">포스트 작성하기</Button>
       {/if}
     </div>
+  {:else}
+    <ul class="w-full space-y-4 <sm:space-y-2">
+      {#each $query.space.posts as post (post.id)}
+        <li>
+          <Feed class="<sm:(border-none rounded-none)" $post={post} />
+        </li>
+      {/each}
+    </ul>
   {/if}
-
-  <ul class="w-full space-y-8 <sm:space-y-2">
-    {#each $query.space.posts as post (post.id)}
-      <li>
-        <Feed class="<sm:(border-none rounded-none)" $post={post} />
-      </li>
-    {/each}
-  </ul>
 </article>

--- a/apps/penxle.com/src/routes/(default)/[space]/(space)/collections/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/(space)/collections/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Helmet } from '@penxle/ui';
+  import clsx from 'clsx';
   import { graphql } from '$glitch';
   import { Button, Image } from '$lib/components';
   import { CreateCollectionModal } from '$lib/components/pages/collections';
@@ -33,7 +34,12 @@
 
 <Helmet title={`컬렉션 | ${$query.space.name}`} />
 
-<div class="m-y-6 min-h-11rem w-full max-w-50rem flex flex-col gap-xs">
+<div
+  class={clsx(
+    'min-h-11rem w-full max-w-50rem flex flex-col grow gap-xs <sm:(p-0 gap-2 bg-surface-primary) sm:py-4',
+    $query.space.collections.length === 0 && 'center',
+  )}
+>
   {#if $query.space.collections.length > 0}
     <ul class="space-y-1">
       {#each $query.space.collections as collection (collection.id)}
@@ -53,19 +59,25 @@
         </li>
       {/each}
     </ul>
+
+    {#if $query.space.meAsMember}
+      <Button
+        class="flex gap-2"
+        color="tertiary"
+        size="lg"
+        variant="outlined"
+        on:click={() => (openCreateCollectionModal = true)}
+      >
+        새 컬렉션 추가하기 <i class="i-lc-plus square-5" />
+      </Button>
+    {/if}
   {:else}
-    <p class="body-15-b text-secondary">아직 스페이스에 업로드된 컬렉션이 없어요</p>
-  {/if}
-  {#if $query.space.meAsMember}
-    <Button
-      class="flex gap-2"
-      color="tertiary"
-      size="lg"
-      variant="outlined"
-      on:click={() => (openCreateCollectionModal = true)}
-    >
-      새 컬렉션 추가하기 <i class="i-lc-plus square-5" />
-    </Button>
+    <div class="flex flex-col center">
+      <p class="body-15-b text-secondary">아직 스페이스에 업로드된 컬렉션이 없어요</p>
+      {#if $query.space.meAsMember}
+        <Button class="mt-5" size="lg" on:click={() => (openCreateCollectionModal = true)}>컬렉션 생성하기</Button>
+      {/if}
+    </div>
   {/if}
 </div>
 


### PR DESCRIPTION
|수정 전|스페이스 로고에 border 추가, 로고와 스페이스 이름 사이 간격 좁힘, 본인의 스페이스에서 더보기 메뉴 없앰|
|--|--|
<img width="803" alt="image" src="https://github.com/penxle/penxle/assets/76952602/60e5dfad-bf02-44e0-adfd-811b79b53686">|<img width="827" alt="image" src="https://github.com/penxle/penxle/assets/76952602/5894099d-53dd-4796-a305-879667236873">

|수정 전|포스트 간 간격 수정, 메뉴탭 아래 간격 수정|
|--|--|
<img width="824" alt="image" src="https://github.com/penxle/penxle/assets/76952602/2cacc7ae-5b47-422b-a651-3e1e08915e63">|<img width="824" alt="image" src="https://github.com/penxle/penxle/assets/76952602/37ead1b1-96d1-4c9f-899c-a2984504691e">

|수정 전|컬렉션 없을 때 디자인과 맞게 수정, 버튼 크기 모바일/데스크탑 모두 40으로 고정|
|--|--|
<img width="414" alt="image" src="https://github.com/penxle/penxle/assets/76952602/5597d46c-58b8-4b20-a9e3-3f3d9db42fc3">|<img width="402" alt="image" src="https://github.com/penxle/penxle/assets/76952602/fd56a217-eb4b-46af-9b4f-bf32a96ae61b">
