### PR TITLE
Safari 에서 문장 이미지 공유 시 비어 있는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/ShareContent/ShareContent.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/ShareContent/ShareContent.svelte
@@ -67,27 +67,29 @@
   async function onSubmit(event: Event) {
     event.preventDefault();
 
-    const dataUrl = await htmlToImage.toPng(captureEl);
+    const canvas = await htmlToImage.toCanvas(captureEl);
+    const dataUrl = canvas.toDataURL();
 
     const file = dataurl2file(dataUrl, `${title}.png`);
 
-    if (typeof ClipboardItem === 'undefined') {
-      const link = document.createElement('a');
-      link.download = `${title}.png`;
-      link.href = dataUrl;
-      link.click();
-      toast.success('이미지가 다운로드되었어요');
+    if (navigator.share) {
+      navigator.share({ title, text: '밑줄 공유', files: [file] });
       return;
     }
-    navigator.clipboard.write([new ClipboardItem({ 'image/png': file })]);
-    toast.success('클립보드에 이미지가 복사되었어요');
+
+    const link = document.createElement('a');
+    link.download = `${title}.png`;
+    link.href = dataUrl;
+    link.click();
+    toast.success('이미지가 다운로드되었어요');
+    return;
   }
 </script>
 
 <Modal size="md" bind:open>
   <svelte:fragment slot="title">밑줄 공유</svelte:fragment>
   <svelte:fragment slot="subtitle">포스트에서 인상깊었던 내용을 공유할 수 있어요</svelte:fragment>
-  <form id="share-content-as-image" class="flex flex-col items-center" on:submit={onSubmit}>
+  <form class="flex flex-col items-center" on:submit={onSubmit}>
     <article
       bind:this={captureEl}
       class={clsx(
@@ -130,8 +132,8 @@
       options={backgroundColorClassnames}
       bind:value={backgroundColorClassname}
     />
+    <Button class="flex-grow" size="xl" type="submit">공유하기</Button>
   </form>
-  <Button slot="action" class="flex-grow" form="share-content-as-image" size="xl" type="submit">공유하기</Button>
 </Modal>
 
 <style>


### PR DESCRIPTION
Safari 에서 이미지 공유 첫 시도 시 아래와 같은 이미지를 받게 되는 문제가 있었습니다.
<img src="https://github.com/penxle/penxle/assets/5278201/d860e7de-12c5-415b-a2c7-27348c9c00be" width="400em">


canvas - dataUrl 변환을 거쳐서 해결을 했습니다. 프리뷰를 통해 모바일에서도 제대로 작동이 되는지 확인이 필요하여 우선 Draft 로 올립니다.