### PR TITLE
Safari 에서 문장 이미지 공유 첫 시도 시 문장이 비어 있는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/ShareContent/ShareContent.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/ShareContent/ShareContent.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import clsx from 'clsx';
   import * as htmlToImage from 'html-to-image';
+  import { browser } from '$app/environment';
   import Logo from '$assets/branding/logo-chalk-transparent.svg?component';
   import Wordmark from '$assets/branding/wordmark.svg?component';
   import { Button, Image, Modal } from '$lib/components';
@@ -64,12 +65,22 @@
 
   $: color = textColorFromBackgroundColor[backgroundColorClassname];
 
+  $: if (browser && open && content) {
+    htmlToImage.toCanvas(captureEl);
+  }
+
   async function onSubmit(event: Event) {
     event.preventDefault();
 
-    const dataUrl = await htmlToImage.toPng(captureEl);
+    const canvas = await htmlToImage.toCanvas(captureEl);
+    const dataUrl = canvas.toDataURL();
 
     const file = dataurl2file(dataUrl, `${title}.png`);
+
+    if (navigator.share) {
+      navigator.share({ title, text: '밑줄 공유', files: [file] });
+      return;
+    }
 
     if (typeof ClipboardItem === 'undefined') {
       const link = document.createElement('a');


### PR DESCRIPTION
ref: #829 

사용하는 라이브러리에서 두번째 시도 이후에야 제대로 된 결과가 나와서 임시방편으로 마운트 시 한번 실행하도록 했습니다.
프리뷰를 통해 모바일에서도 제대로 작동이 되는지 확인이 필요하여 우선 Draft 로 올립니다.