### PR TITLE
텍스트 선택 시 나타나는 메뉴를 선택 범위 밑에 띄우기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Helmet } from '@penxle/ui';
-  import { isTextSelection } from '@tiptap/core';
   import clsx from 'clsx';
   import dayjs from 'dayjs';
   import { afterNavigate, goto } from '$app/navigation';
@@ -13,10 +12,11 @@
   import Emoji from '$lib/emoji/Emoji.svelte';
   import { FormValidationError } from '$lib/errors';
   import { toast } from '$lib/notification';
-  import { TiptapBubbleMenu, TiptapRenderer } from '$lib/tiptap/components';
+  import { TiptapRenderer } from '$lib/tiptap/components';
   import { calcurateReadingTime, createTiptapDocument, humanizeNumber } from '$lib/utils';
   import LoginRequireModal from '../LoginRequireModal.svelte';
   import GalleryPost from './GalleryPost.svelte';
+  import SelectionBubbleMenu from './SelectionBubbleMenu.svelte';
   import ShareContent from './ShareContent/ShareContent.svelte';
   import Toolbar from './Toolbar.svelte';
   import type { Editor, JSONContent } from '@tiptap/core';
@@ -506,13 +506,9 @@
         {/if}
 
         {#if editor && !preview}
-          <TiptapBubbleMenu
-            class="bg-gray-90 text-sm text-gray-30 rounded-lg p-2
-                              after:(absolute content-[''] bg-transparent top-110% left-50% translate--50% border-transparent border-t-color-gray-90 border-width-[0.5rem_0.5rem_0])"
-            {editor}
-            when={(view) => isTextSelection(view.state.selection)}
-          >
+          <SelectionBubbleMenu class="flex" {editor}>
             <button
+              class="shrink-0"
               type="button"
               on:click={() => {
                 if (!editor) throw new Error('editor is not initialized');
@@ -532,7 +528,7 @@
             >
               공유
             </button>
-          </TiptapBubbleMenu>
+          </SelectionBubbleMenu>
         {/if}
       </div>
     {:else}

--- a/apps/penxle.com/src/routes/(default)/[space]/SelectionBubbleMenu.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/SelectionBubbleMenu.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import { arrow, computePosition, flip, offset, shift } from '@floating-ui/dom';
+  import { Editor, isTextSelection, posToDOMRect } from '@tiptap/core';
+  import { Plugin, PluginKey } from '@tiptap/pm/state';
+  import { EditorView } from '@tiptap/pm/view';
+  import clsx from 'clsx';
+  import * as R from 'radash';
+  import { onMount, tick } from 'svelte';
+  import { portal } from '$lib/svelte/actions';
+
+  let key = 'share-bubble-menu';
+  export let editor: Editor;
+  let _class: string | undefined = undefined;
+  export { _class as class };
+
+  let menuEl: HTMLElement;
+  let arrowEl: HTMLElement;
+  let open = false;
+  let preventUpdate = false;
+
+  const update = R.debounce({ delay: 150 }, async (view: EditorView) => {
+    if (preventUpdate) {
+      preventUpdate = false;
+      return;
+    }
+
+    const { empty, from, to } = view.state.selection;
+
+    const isEmptyTextBlock = view.state.doc.textBetween(from, to).length === 0 && isTextSelection(view.state.selection);
+
+    if (empty || isEmptyTextBlock || isTextSelection(view.state.selection) === false) {
+      open = false;
+      return;
+    }
+
+    open = true;
+    await tick();
+
+    const targetEl = {
+      getBoundingClientRect: () => posToDOMRect(view, to, to),
+    };
+
+    const position = await computePosition(targetEl, menuEl, {
+      placement: 'right',
+      middleware: [offset(8), flip(), shift({ padding: 8 }), arrow({ element: arrowEl })],
+    });
+
+    Object.assign(menuEl.style, {
+      left: `${position.x}px`,
+      top: `${position.y}px`,
+    });
+
+    if (position.middlewareData.arrow) {
+      const { x, y } = position.middlewareData.arrow;
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const staticSide = {
+        top: 'bottom',
+        right: 'left',
+        bottom: 'top',
+        left: 'right',
+      }[position.placement.split('-')[0]]!;
+
+      Object.assign(arrowEl.style, {
+        left: x === undefined ? '' : `${x}px`,
+        top: y === undefined ? '' : `${y}px`,
+        [staticSide]: '-0.25rem',
+      });
+    }
+  });
+
+  onMount(() => {
+    editor.registerPlugin(
+      new Plugin({
+        key: new PluginKey(key),
+        view: () => ({ update }),
+      }),
+    );
+
+    const resize = () => update(editor.view);
+    window.addEventListener('resize', resize);
+
+    return () => {
+      window.removeEventListener('resize', resize);
+      editor.unregisterPlugin(key);
+    };
+  });
+</script>
+
+<!-- <svelte:document
+  on:mousedown={() => {
+    if (open) {
+      update.flush(editor.view);
+      open = false;
+    }
+  }}
+/> -->
+
+{#if open}
+  <div
+    bind:this={menuEl}
+    class={clsx('absolute z-1 select-none bg-gray-90 text-sm text-gray-30 rounded-lg p-2', _class)}
+    role="menu"
+    tabindex="-1"
+    on:mousedown|stopPropagation={() => (preventUpdate = true)}
+    use:portal
+  >
+    <slot />
+    <div bind:this={arrowEl} class="absolute square-2 rotate-45 bg-gray-90" />
+  </div>
+{/if}


### PR DESCRIPTION
<img width="793" alt="스크린샷 2023-12-13 오후 9 44 43" src="https://github.com/penxle/penxle/assets/5278201/acdd3276-bd6d-4c04-9af8-040e4e46449e">

선택한 범위의 끝에 더미 엘리먼트를 삽입하여 이를 참조하는 식으로 구현을 했는데
여러 번 텍스트 선택을 반복하면 Web Selection API 내부에서 아래 사진의 오류를 내뱉으면서 더 이상 메뉴 UI가 나오지 않게 되는 문제가 있습니다.

Tiptap API 를 통해 엘리먼트를 핸들링하면 결과가 다를지 내일 확인해봐야 겠네요.

> <img width="1000" alt="스크린샷 2023-12-13 오후 10 01 36" src="https://github.com/penxle/penxle/assets/5278201/dc1b0981-7e70-44e5-924c-d953d6985efc">
> Uncaught DOMException: Selection.collapse: The offset is out of range.
