### PR TITLE
iOS 에서 텍스트 공유 메뉴가 오른쪽에 위치하지 않은 경우 숨기게 하기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/SelectionBubbleMenu.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/SelectionBubbleMenu.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { arrow, computePosition, flip, offset, shift } from '@floating-ui/dom';
-  import { Editor, isTextSelection, posToDOMRect } from '@tiptap/core';
+  import { Editor, isiOS, isTextSelection, posToDOMRect } from '@tiptap/core';
   import { Plugin, PluginKey } from '@tiptap/pm/state';
   import { EditorView } from '@tiptap/pm/view';
   import clsx from 'clsx';
@@ -43,6 +43,11 @@
       placement: 'right',
       middleware: [offset(8), flip(), shift({ padding: 8 }), arrow({ element: arrowEl })],
     });
+
+    if (position.placement !== 'right' && isiOS()) {
+      open = false;
+      return;
+    }
 
     Object.assign(menuEl.style, {
       left: `${position.x}px`,


### PR DESCRIPTION
해당 메뉴 UI가 선택 범위를 나타나는 시스템 UI 보다 레이어가 낮은 문제로 이 경우에 버튼 클릭이 안되는 버그가 있어 오른쪽에 띄우지 않은 경우 숨기게 패치를 합니다.
