### PR TITLE
새 컬렉션 기본 이름이 비어서 전송이 안되는 문제 해결하기

### DIFF
--- a/apps/penxle.com/src/lib/components/pages/collections/CreateCollectionModal.svelte
+++ b/apps/penxle.com/src/lib/components/pages/collections/CreateCollectionModal.svelte
@@ -38,7 +38,7 @@
     `),
     schema: UpdateSpaceCollectionSchema,
     extra: async () => {
-      const defaultName = '';
+      const defaultName = '_';
       const createdCollection = await createSpaceCollection({ spaceId, name: defaultName });
 
       return { collectionId: createdCollection.id };


### PR DESCRIPTION
먼저 컬렉션 ID 정보를 받기 위해 더미 타이틀을 만들게 되는데 이때 값이 비어 있어 나는 문제였습니다. 

제가 #767 리뷰하면서 컬렉션 수정만 간소하게 검수해서 벌어진 문제였습니다. 죄송합니다.