### PR TITLE
스페이스 피드 UI 내 태그 최대 너비 설정하기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/(space)/Feed.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/(space)/Feed.svelte
@@ -146,7 +146,7 @@
     {#if $post.publishedRevision?.tags}
       <div class="flex gap-1.5 flex-wrap">
         {#each $post.publishedRevision.tags.slice(0, 4) as tag (tag.id)}
-          <Tag href={`/tag/${tag.name}`} size="sm">#{tag.name}</Tag>
+          <Tag class="max-w-65" href={`/tag/${tag.name}`} size="sm">#{tag.name}</Tag>
         {/each}
         {#if $post.publishedRevision.tags.length > 4}
           <Tag size="sm">+{$post.publishedRevision.tags.length - 4}개의 태그</Tag>


### PR DESCRIPTION
| 이전 | 이후 |
|:--:| :--: |
| <img width="450" alt="스크린샷 2023-12-15 오전 11 54 08" src="https://github.com/penxle/penxle/assets/5278201/958aa534-a678-425d-8d10-eef3e4aee02a"> | <img width="451" alt="스크린샷 2023-12-15 오전 11 54 23" src="https://github.com/penxle/penxle/assets/5278201/11423523-a724-42c0-b45f-e0da633e12ac">|


태그가 긴 경우 박스를 벗어나는 문제가 있어서 메인 피드 컴포넌트 클래스 네임을 참고해서 스타일을 수정했습니다.