### PR TITLE
externalLinks 유효성 오류 발생 시 오류 토스트로 피드백 제공하기

### DIFF
--- a/apps/penxle.com/src/lib/validations/space.ts
+++ b/apps/penxle.com/src/lib/validations/space.ts
@@ -35,7 +35,7 @@ export const UpdateSpaceSchema = z.object({
   name: spaceName.optional(),
   slug: SpaceSlugSchema.optional(),
   description: z.string().max(200, '스페이스 소개는 200자를 넘을 수 없어요').optional(),
-  externalLinks: z.array(z.string().url()).optional(),
+  externalLinks: z.array(z.string().url('추가한 링크 중 하나가 유효하지 않은 URL이에요')).optional(),
   isPublic: z.boolean().optional(),
 });
 

--- a/apps/penxle.com/src/routes/(default)/[space]/dashboard/settings/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/dashboard/settings/+page.svelte
@@ -8,7 +8,6 @@
   import { mixpanel } from '$lib/analytics';
   import { Button } from '$lib/components';
   import { FormField, Switch, TextArea, TextInput } from '$lib/components/forms';
-  import FormValidationMessage from '$lib/components/forms/FormValidationMessage.svelte';
   import Image from '$lib/components/Image.svelte';
   import { ThumbnailPicker } from '$lib/components/media';
   import { createMutationForm } from '$lib/form';
@@ -101,7 +100,7 @@
   let icon: typeof $query.space.icon;
   $: icon = $query.space.icon;
 
-  const { form, data, setInitialValues, isSubmitting, handleSubmit } = createMutationForm({
+  const { form, data, errors, setInitialValues, isSubmitting, handleSubmit } = createMutationForm({
     mutation: graphql(`
       mutation SpaceDashboardSettingsPage_UpdateSpace_Mutation($input: UpdateSpaceInput!) {
         updateSpace(input: $input) {
@@ -150,6 +149,12 @@
       sortable.destroy();
     }
   });
+
+  $: externalLinkError = isSubmitting && $errors.externalLinks?.find((externalLink) => externalLink !== null);
+
+  $: if (typeof externalLinkError === 'string') {
+    toast.error(externalLinkError);
+  }
 </script>
 
 <Helmet title={`스페이스 설정 | ${$query.space.name}`} />
@@ -237,16 +242,14 @@
               class="w-full flex flex-col gap-1.5 border border-gray-5 rounded-2xl transition bg-primary pt-3 pb-4 px-3.5 hover:border-secondary focus-within:border-tertiary! [&:has(textarea[aria-invalid])]:border-action-error disabled:opacity-50"
             >
               <label class="body-13-b" for={`url${index + 1}`}>{`URL ${index + 1}`}</label>
+
               <TextInput
-                id={`externalLinks[${index}]`}
-                name={`externalLinks[${index}]`}
-                class="w-full"
+                name={`externalLinks.${index}`}
                 autocomplete="on"
                 placeholder="URL을 입력해주세요"
                 type="url"
                 bind:value={url}
               />
-              <FormValidationMessage for={`externalLinks[${index}]`} />
             </div>
           </li>
         {/each}


### PR DESCRIPTION
felt array field 사용 시 오류 데이터 순서가 부정확한 버그로 FormValidationMessage 컴포넌트를 통해 오류가 제대로 표시되지 않은 문제가 있습니다. 해당 버그의 대안으로 토스트로 피드백을 주는 장치를 추가했습니다.

버그를 제보하고 답변이 오길 기다리고 있습니다. https://github.com/pablo-abc/felte/issues/284