### PR TITLE
폼 데이터 필드 깊이가 두단계 이상인 경우 오류 메세지가 표시되지 않은 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/forms/FormValidationMessage.svelte
+++ b/apps/penxle.com/src/lib/components/forms/FormValidationMessage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getValue } from 'felte';
   import { getFormContext } from '$lib/form';
 
   let errorFor: string;
@@ -11,9 +12,9 @@
   }
 
   $: store = type === 'error' ? form.errors : form.warnings;
-  $: message = $store[errorFor]?.[0];
+  $: message = getValue($store, errorFor);
 </script>
 
-{#if message}
+{#if typeof message === 'string'}
   <slot {message} />
 {/if}


### PR DESCRIPTION
felt getValue API 를 사용했습니다.
https://felte.dev/docs/svelte/helper-functions#getvalue