### PR TITLE
rds/opensearch 인스턴스 스케일 다운

### DIFF
--- a/apps/bedrock/pulumi/aws/opensearch.ts
+++ b/apps/bedrock/pulumi/aws/opensearch.ts
@@ -8,7 +8,7 @@ const domain = new aws.opensearch.Domain('penxle', {
   domainName: 'penxle',
 
   clusterConfig: {
-    instanceType: 'r6g.2xlarge.search',
+    instanceType: 'r6g.large.search',
     instanceCount: 1,
   },
 

--- a/apps/bedrock/pulumi/aws/rds.ts
+++ b/apps/bedrock/pulumi/aws/rds.ts
@@ -49,7 +49,7 @@ const instance = new aws.rds.ClusterInstance('penxle-1', {
   identifier: 'penxle-1',
 
   engine: 'aurora-postgresql',
-  instanceClass: 'db.r6g.xlarge',
+  instanceClass: 'db.r6g.large',
 
   availabilityZone: subnets.private.az1.availabilityZone,
   caCertIdentifier: 'rds-ca-rsa2048-g1',


### PR DESCRIPTION
- rds: `db.r6g.xlarge` -> `db.r6g.large`
- opensearch: `r6g.2xlarge.search` -> `r6g.large.search`
