### PR TITLE
vscode prettier 확장으로 svelte/prisma 파일 포매팅 안 되던 이슈 해결

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
   "eslint.format.enable": true,
   "eslint.experimental.useFlatConfig": true,
   "eslint.validate": ["javascript", "typescript", "svelte"],
+  "prettier.documentSelectors": ["**/*"],
   "svelte.enable-ts-plugin": true,
   "svelte.plugin.svelte.defaultScriptLanguage": "ts",
   "typescript.tsdk": "node_modules/typescript/lib",


### PR DESCRIPTION
왜 발생한건지는... 아직도 모름

그치만 여튼 해결함
