### PR TITLE
모달 상단에 title 고정시킴

### DIFF
--- a/apps/penxle.com/src/lib/components/Modal.svelte
+++ b/apps/penxle.com/src/lib/components/Modal.svelte
@@ -46,13 +46,22 @@
         in:fly={{ y: '10%', duration: 150 }}
         out:fade={{ duration: 150 }}
       >
-        <div class={clsx('content flex flex-col w-full overflow-y-scroll', size === 'sm' && 'max-w-92', _class)}>
+        <div
+          class={clsx(
+            'content flex flex-col w-full overflow-y-scroll',
+            size === 'sm' && 'max-w-92',
+            $$slots.title && size !== 'sm' && 'pt-20',
+            $$slots.title && $$slots.subtitle && size !== 'sm' && 'pt-27',
+            _class,
+          )}
+        >
           {#if $$slots.title}
             <div
               class={clsx(
                 'flex justify-between py-3',
                 size === 'sm' && 'justify-center! text-center',
-                size !== 'sm' && 'pt-4 pb-0',
+                size !== 'sm' && 'pt-8 pb-0 px-6 absolute top-0 left-0 w-full bg-cardprimary rounded-t-2xl z-1',
+                size === 'lg' && 'px-7',
               )}
             >
               <div


### PR DESCRIPTION
모달 안의 내용이 길어지는 경우 제목 영역이 고정되어 있지 않아 x 버튼만 중간에 떠있고 다른 영역과 겹치는 문제가 있었습니다.
따라서 스크롤을 해도 제목 영역이 상단에 고정되어 있도록 수정했습니다.

|수정 전|수정 후|
|--|--|
<img width="419" alt="image" src="https://github.com/penxle/penxle/assets/76952602/2cb1aafd-2acf-4e1a-86d4-a3b555e25ab2">|<img width="413" alt="image" src="https://github.com/penxle/penxle/assets/76952602/616a84d7-0e8d-4c08-8bdf-109df6d49de3">
