### PR TITLE
나의 서랍 포스트 목록 모바일 레이아웃 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/me/cabinets/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/+layout.svelte
@@ -116,7 +116,7 @@
       <TabHeadItem id={3} href="/me/cabinets/purchased">구매</TabHeadItem>
     </TabHead>
 
-    <div class="sm:px-8">
+    <div class="px-4 sm:px-8">
       <ul class="space-y-6">
         <slot />
       </ul>


### PR DESCRIPTION
모바일에서 양옆 padding 추가함
<img width="431" alt="image" src="https://github.com/penxle/penxle/assets/76952602/534fcc74-e97f-45ae-83fa-d239d73d598c">
<img width="431" alt="image" src="https://github.com/penxle/penxle/assets/76952602/10e1babf-c9a2-4746-8af7-83bd6a7f1d37">
