### PR TITLE
나의 펜슬 포스트 관리에 모바일 메뉴 항목 추가

### DIFF
--- a/apps/penxle.com/src/lib/components/pages/posts/PostManageTable.svelte
+++ b/apps/penxle.com/src/lib/components/pages/posts/PostManageTable.svelte
@@ -428,7 +428,13 @@
         <MenuItem on:click={() => updateVisibilities('UNLISTED')}>링크 공개</MenuItem>
         <MenuItem on:click={() => updateVisibilities('SPACE')}>멤버 공개</MenuItem>
       </Menu>
-      <Menu class="<sm:hidden" as="div" offset={toolbarMenuOffset} placement="top" preventClose>
+      <Menu
+        class={clsx(type === 'space' && '<sm:hidden')}
+        as="div"
+        offset={toolbarMenuOffset}
+        placement="top"
+        preventClose
+      >
         <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">포스트 옵션 설정</Button>
         <MenuItem type="div">
           <Switch
@@ -499,7 +505,7 @@
     {/if}
     {#if selectedOwnPosts || $spaceMember?.role === 'ADMIN'}
       <Button
-        class="<sm:hidden whitespace-nowrap"
+        class="whitespace-nowrap <sm:hidden"
         color="red"
         size="md"
         on:click={() => {
@@ -508,6 +514,17 @@
         }}
       >
         삭제하기
+      </Button>
+      <Button
+        class={clsx('whitespace-nowrap sm:hidden', type === 'me' && '<sm:block')}
+        color="red"
+        size="md"
+        on:click={() => {
+          deletePostIds = _selectedPostIds;
+          openDeletePostWaring = true;
+        }}
+      >
+        삭제
       </Button>
     {/if}
   </div>


### PR DESCRIPTION
나의 펜슬의 포스트 관리 테이블 모바일 뷰에서 하단 메뉴 항목이 뜨지 않는 문제 수정
|수정 전|수정 후!|
|--|--|
<img width="461" alt="image" src="https://github.com/penxle/penxle/assets/76952602/f2fb2919-b259-4893-b37e-926724a0d496">|<img width="463" alt="image" src="https://github.com/penxle/penxle/assets/76952602/7e56af7f-d265-4430-8f2e-3a12c2122765">
