### PR TITLE
파일 컴포넌트 레이아웃 깨지는 문제 수정

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/file/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/file/Component.svelte
@@ -60,7 +60,7 @@
 
 <NodeView
   class={clsx(
-    'flex gap-2 items-center m-4 px-8 py-4 border relative w-full',
+    'flex gap-2 items-center m-4 px-8 py-4 border relative grow',
     editor?.isEditable && selected && 'ring-4 ring-brand-50',
   )}
   as={editor?.isEditable ? undefined : 'a'}


### PR DESCRIPTION
|전|후!|
|--|--|
<img width="774" alt="image" src="https://github.com/penxle/penxle/assets/76952602/b6a77122-4bf3-4a07-9ac3-3315722230fe">|<img width="762" alt="image" src="https://github.com/penxle/penxle/assets/76952602/6fac72a4-5e98-4487-afe5-5a4fd62218f1">
