### PR TITLE
쿠콘 거래내역통지 서비스 릴레이와 컨슈머로 분리함

### DIFF
--- a/apps/nocooc/package.json
+++ b/apps/nocooc/package.json
@@ -7,6 +7,10 @@
     "build": "tsup",
     "lint:typecheck": "tsc"
   },
+  "dependencies": {
+    "@aws-sdk/client-sqs": "^3.478.0",
+    "aws-lambda-ric": "^3.1.0"
+  },
   "devDependencies": {
     "@penxle/lib": "workspace:^",
     "@penxle/pulumi": "workspace:^",
@@ -14,6 +18,7 @@
     "@pulumi/aws": "^6.15.0",
     "@pulumi/kubernetes": "^4.5.6",
     "@pulumi/pulumi": "^3.99.0",
+    "@types/aws-lambda": "^8.10.130",
     "tsup": "^8.0.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"

--- a/apps/nocooc/pulumi/index.ts
+++ b/apps/nocooc/pulumi/index.ts
@@ -1,3 +1,4 @@
+import * as penxle from '@penxle/pulumi/components';
 import * as aws from '@pulumi/aws';
 import * as k8s from '@pulumi/kubernetes';
 import * as pulumi from '@pulumi/pulumi';
@@ -17,6 +18,82 @@ const eip2 = new aws.ec2.Eip('public-nlb@az2', {
   tags: { Name: 'public-nlb@az2' },
 });
 
+const sqs = new aws.sqs.Queue('nocooc', {
+  name: 'nocooc',
+
+  visibilityTimeoutSeconds: 600,
+  messageRetentionSeconds: 14 * 24 * 60 * 60, // 14 days
+});
+
+const role = new aws.iam.Role('nocooc@lambda', {
+  name: 'nocooc@lambda',
+  assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+    Service: 'lambda.amazonaws.com',
+  }),
+  managedPolicyArns: [aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole],
+});
+
+new aws.iam.RolePolicy('nocooc@lambda', {
+  name: 'nocooc@lambda',
+  role: role.name,
+
+  policy: {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Action: ['sqs:ReceiveMessage', 'sqs:DeleteMessage', 'sqs:GetQueueAttributes'],
+        Resource: [sqs.arn],
+      },
+    ],
+  },
+});
+
+const lambda = new aws.lambda.Function('nocooc', {
+  name: 'nocooc',
+  role: role.arn,
+
+  packageType: 'Image',
+  architectures: ['x86_64'],
+
+  memorySize: 256,
+  timeout: 60,
+
+  imageUri: pulumi.interpolate`${image.registryId}.dkr.ecr.ap-northeast-2.amazonaws.com/${image.repositoryName}@${image.imageDigest}`,
+  sourceCodeHash: image.imageDigest.apply((v) => v.split(':')[1]),
+
+  environment: {
+    variables: {
+      MODE: 'consumer',
+    },
+  },
+});
+
+new aws.lambda.EventSourceMapping('nocooc', {
+  functionName: lambda.name,
+  eventSourceArn: sqs.arn,
+  batchSize: 1,
+});
+
+const serviceAccount = new penxle.IAMServiceAccount('nocooc', {
+  metadata: {
+    name: 'nocooc',
+    namespace: 'prod',
+  },
+  spec: {
+    policy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: ['sqs:SendMessage'],
+          Resource: [sqs.arn],
+        },
+      ],
+    },
+  },
+});
+
 new k8s.apps.v1.Deployment('nocooc', {
   metadata: {
     name: 'nocooc',
@@ -28,6 +105,7 @@ new k8s.apps.v1.Deployment('nocooc', {
     template: {
       metadata: { labels },
       spec: {
+        serviceAccountName: serviceAccount.metadata.name,
         containers: [
           {
             name: 'app',
@@ -36,6 +114,10 @@ new k8s.apps.v1.Deployment('nocooc', {
               requests: { cpu: '100m' },
               limits: { memory: '100Mi' },
             },
+            env: [
+              { name: 'SQS_URL', value: sqs.url },
+              { name: 'MODE', value: 'relay' },
+            ],
             livenessProbe: {
               tcpSocket: { port: 2266 },
               initialDelaySeconds: 5,

--- a/apps/nocooc/src/consumer.ts
+++ b/apps/nocooc/src/consumer.ts
@@ -1,0 +1,8 @@
+import type { SQSHandler } from 'aws-lambda';
+
+export const handler: SQSHandler = async (event) => {
+  for (const record of event.Records) {
+    const buffer = Buffer.from(record.body, 'base64');
+    console.log(buffer);
+  }
+};

--- a/apps/nocooc/src/index.ts
+++ b/apps/nocooc/src/index.ts
@@ -1,23 +1,9 @@
-import net from 'node:net';
+import { run } from 'aws-lambda-ric';
+import { handler } from './consumer';
+import { startServer } from './relay';
 
-const server = net.createServer((socket) => {
-  const clientName = `${socket.remoteAddress}:${socket.remotePort}`;
-
-  console.log(`Client connected: ${clientName}`);
-
-  socket.on('data', (data) => {
-    console.log(`${clientName} said: ${data}`);
-  });
-
-  socket.on('end', () => {
-    console.log(`Client disconnected: ${clientName}`);
-  });
-
-  socket.on('error', (err) => {
-    console.log(`Socket error: ${err}`);
-  });
-});
-
-server.listen(2266, '0.0.0.0', () => {
-  console.log(`Server started on port 2266`);
-});
+if (process.env.MODE === 'relay') {
+  startServer();
+} else if (process.env.MODE === 'consumer') {
+  await run(handler);
+}

--- a/apps/nocooc/src/relay.ts
+++ b/apps/nocooc/src/relay.ts
@@ -1,0 +1,36 @@
+import net from 'node:net';
+import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+
+export const startServer = () => {
+  const sqs = new SQSClient();
+
+  const server = net.createServer((socket) => {
+    const clientName = `${socket.remoteAddress}:${socket.remotePort}`;
+
+    console.log(`Client connected: ${clientName}`);
+
+    socket.on('data', (data) => {
+      sqs
+        .send(
+          new SendMessageCommand({
+            QueueUrl: process.env.SQS_URL,
+            MessageBody: data.toString('base64'),
+          }),
+        )
+        .then((res) => console.log(`[SQS] Message ID: ${res.MessageId}`))
+        .catch((err) => console.error(err));
+    });
+
+    socket.on('end', () => {
+      console.log(`Client disconnected: ${clientName}`);
+    });
+
+    socket.on('error', (err) => {
+      console.log(`Socket error: ${err}`);
+    });
+  });
+
+  server.listen(2266, '0.0.0.0', () => {
+    console.log(`Server started on port 2266`);
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,13 @@ importers:
         version: 5.3.3
 
   apps/nocooc:
+    dependencies:
+      '@aws-sdk/client-sqs':
+        specifier: ^3.478.0
+        version: 3.478.0
+      aws-lambda-ric:
+        specifier: ^3.1.0
+        version: 3.1.0
     devDependencies:
       '@penxle/lib':
         specifier: workspace:^
@@ -203,6 +210,9 @@ importers:
       '@pulumi/pulumi':
         specifier: ^3.99.0
         version: 3.99.0
+      '@types/aws-lambda':
+        specifier: ^8.10.130
+        version: 8.10.130
       tsup:
         specifier: ^8.0.1
         version: 8.0.1(typescript@5.3.3)
@@ -1105,6 +1115,56 @@ packages:
       - aws-crt
     dev: true
 
+  /@aws-sdk/client-sqs@3.478.0:
+    resolution: {integrity: sha512-Uz7XtXVab8bhgT3iRJP4kryxu7Sgn9tgHE/sd9xitHwHu34HyOoaWxLU+nT/1fPzPnAtzIMcp05lB9o4W7ZYYw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.478.0
+      '@aws-sdk/core': 3.477.0
+      '@aws-sdk/credential-provider-node': 3.478.0
+      '@aws-sdk/middleware-host-header': 3.468.0
+      '@aws-sdk/middleware-logger': 3.468.0
+      '@aws-sdk/middleware-recursion-detection': 3.468.0
+      '@aws-sdk/middleware-sdk-sqs': 3.468.0
+      '@aws-sdk/middleware-user-agent': 3.478.0
+      '@aws-sdk/region-config-resolver': 3.470.0
+      '@aws-sdk/types': 3.468.0
+      '@aws-sdk/util-endpoints': 3.478.0
+      '@aws-sdk/util-user-agent-browser': 3.468.0
+      '@aws-sdk/util-user-agent-node': 3.470.0
+      '@smithy/config-resolver': 2.0.21
+      '@smithy/core': 1.2.1
+      '@smithy/fetch-http-handler': 2.3.1
+      '@smithy/hash-node': 2.0.17
+      '@smithy/invalid-dependency': 2.0.15
+      '@smithy/md5-js': 2.0.17
+      '@smithy/middleware-content-length': 2.0.17
+      '@smithy/middleware-endpoint': 2.2.3
+      '@smithy/middleware-retry': 2.0.24
+      '@smithy/middleware-serde': 2.0.15
+      '@smithy/middleware-stack': 2.0.9
+      '@smithy/node-config-provider': 2.1.8
+      '@smithy/node-http-handler': 2.2.1
+      '@smithy/protocol-http': 3.0.11
+      '@smithy/smithy-client': 2.1.18
+      '@smithy/types': 2.7.0
+      '@smithy/url-parser': 2.0.15
+      '@smithy/util-base64': 2.0.1
+      '@smithy/util-body-length-browser': 2.0.1
+      '@smithy/util-body-length-node': 2.1.0
+      '@smithy/util-defaults-mode-browser': 2.0.22
+      '@smithy/util-defaults-mode-node': 2.0.29
+      '@smithy/util-endpoints': 1.0.7
+      '@smithy/util-middleware': 2.0.8
+      '@smithy/util-retry': 2.0.8
+      '@smithy/util-utf8': 2.0.2
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/client-sso@3.478.0:
     resolution: {integrity: sha512-Jxy9cE1JMkPR0PklCpq3cORHnZq/Z4klhSTNGgZNeBWovMa+plor52kyh8iUNHKl3XEJvTbHM7V+dvrr/x0P1g==}
     engines: {node: '>=14.0.0'}
@@ -1365,6 +1425,17 @@ packages:
       '@smithy/types': 2.7.0
       '@smithy/util-config-provider': 2.0.0
       tslib: 2.6.2
+
+  /@aws-sdk/middleware-sdk-sqs@3.468.0:
+    resolution: {integrity: sha512-ehDQHKimed1DrdXYG12LPKWzHlG9iXihGEok07nOJR/2RpOuSpAcavc4eeuOVeEHh58Eu8TXvvVAJ906Vtm6YA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.468.0
+      '@smithy/types': 2.7.0
+      '@smithy/util-hex-encoding': 2.0.0
+      '@smithy/util-utf8': 2.0.2
+      tslib: 2.6.2
+    dev: false
 
   /@aws-sdk/middleware-signing@3.468.0:
     resolution: {integrity: sha512-s+7fSB1gdnnTj5O0aCCarX3z5Vppop8kazbNSZADdkfHIDWCN80IH4ZNjY3OWqaAz0HmR4LNNrovdR304ojb4Q==}
@@ -5810,6 +5881,10 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
     dev: false
+
+  /@types/aws-lambda@8.10.130:
+    resolution: {integrity: sha512-HxTfLeGvD1wTJqIGwcBCpNmHKenja+We1e0cuzeIDFfbEj3ixnlTInyPR/81zAe0Ss/Ip12rFK6XNeMLVucOSg==}
+    dev: true
 
   /@types/body-scroll-lock@3.1.2:
     resolution: {integrity: sha512-ELhtuphE/YbhEcpBf/rIV9Tl3/O0A0gpCVD+oYFSS8bWstHFJUgA4nNw1ZakVlRC38XaQEIsBogUZKWIPBvpfQ==}


### PR DESCRIPTION
- 릴레이: TCP 통신 받아서 페이로드를 SQS에 밀어 넣음
- 컨슈머: SQS에서 페이로드를 꺼내서 실제로 처리하고 결과를 DynamoDB에 저장 (별도 PR 예정)
