### PR TITLE
elasticsearch 빌드타임 코드 실행 오류 해결

### DIFF
--- a/apps/penxle.com/src/lib/server/search.ts
+++ b/apps/penxle.com/src/lib/server/search.ts
@@ -3,7 +3,7 @@ import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
 
 export const elasticSearch = new Client({
-  cloud: { id: env.PRIVATE_ELASTICSEARCH_CLOUD_ID },
+  cloud: { id: env.PRIVATE_ELASTICSEARCH_CLOUD_ID || ':' },
   auth: { apiKey: env.PRIVATE_ELASTICSEARCH_API_KEY },
 });
 


### PR DESCRIPTION
`vite build` 시에 elasticsearch 클라이언트 초기화가 실패하던 문제 해결

elasticsearch cloud id가 `penxle:12341234` 식인데, 내부적으로 `:` 로 split해서 연결을 시도하는지 값이 `:`를 포함하고 있지 않을 경우 실행시에 오류가 남