### PR TITLE
에디터에 흰색 글씨 색상 추가

### DIFF
--- a/apps/penxle.com/src/routes/editor/ArticleBubbleMenu.svelte
+++ b/apps/penxle.com/src/routes/editor/ArticleBubbleMenu.svelte
@@ -46,7 +46,7 @@
             }
           }}
         >
-          <div class={clsx('inline-flex items-center body-14-m', color.value ?? 'text-primary')}>
+          <div class={clsx('inline-flex items-center body-14-m', color.display ?? color.value ?? 'text-primary')}>
             <i class="bg-[currentColor] rounded-full square-4.5 m-r-0.5rem" />
             {color.label}
           </div>

--- a/apps/penxle.com/src/routes/editor/formats.svelte
+++ b/apps/penxle.com/src/routes/editor/formats.svelte
@@ -14,6 +14,7 @@
     { label: '갈색', value: 'text-orange-70' },
     { label: '초록색', value: 'text-green-60' },
     { label: '보라색', value: 'text-purple-60' },
+    { label: '흰색', value: 'text-white', display: 'text-gray-20' },
   ];
 
   export const heading = Heading.name as 'heading';

--- a/apps/penxle.com/src/styles/prose.css
+++ b/apps/penxle.com/src/styles/prose.css
@@ -159,6 +159,10 @@
     --uno: text-purple-60;
   }
 
+  & [data-text-color='text-white'] {
+    --uno: text-white;
+  }
+
   /*
    * extensions
   */


### PR DESCRIPTION
팁탭 에디터에서 흰색을 글씨 색상으로 선택할 수 있도록 함

- 흰색으로 글씨를 써서 드래그했을 때만 보여지는 연출을 원하는 이용자들이 있음 (피드백 사이트 참고)
- 색상 선택 팔레트에서는 흰색은 아예 안 보이므로, 팔레트에서만 `text-gray-20` 색상으로 보여지도록 함.
  - 실제 렌더링시에는 `text-white` 색상으로 보여짐
  - 추후 다크모드 지원시 고려 필요
