### PR TITLE
뷰포트 470크기 이하에서 검색결과 페이지 레이아웃 깨지는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/search/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/+layout.svelte
@@ -80,7 +80,7 @@
 
 <Helmet title="{$page.url.searchParams.get('q')} - 검색" />
 
-<div class="grid max-w-300 <sm:(w-full bg-cardprimary py-5) sm:(grid-cols-[2fr_7fr] mx-10 gap-11.5 my-9.5)">
+<div class="max-w-300 <sm:(w-full bg-cardprimary py-5) sm:(grid grid-cols-[2fr_7fr] mx-10 gap-11.5 my-9.5)">
   <aside class="min-w-38 <sm:hidden">
     <div class="bg-cardprimary border border-secondary rounded-2xl px-3 py-4">
       <button


### PR DESCRIPTION
개발 환경에서는 발생하지 않았으나, 실제 프로덕션 환경에서는 레이아웃이 깨져보이는 문제가 있었습니다.
-> grid 속성을 sm 크기부터 지정하도록 수정했습니다.

|수정 전|수정 후|
|--|--|
<img width="419" alt="image" src="https://github.com/penxle/penxle/assets/76952602/2c31e130-d0bc-4074-866e-93cd6d4a79f7">|<img width="404" alt="image" src="https://github.com/penxle/penxle/assets/76952602/1ff60f5b-4142-4e2c-a30d-d839ba11263e">

