### PR TITLE
IOS Safari 에서 모달 내용 스크롤이 안되는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/Modal.svelte
+++ b/apps/penxle.com/src/lib/components/Modal.svelte
@@ -46,7 +46,10 @@
         in:fly={{ y: '10%', duration: 150 }}
         out:fade={{ duration: 150 }}
       >
-        <div class={clsx('content flex flex-col w-full overflow-y-scroll', size === 'sm' && 'max-w-92', _class)}>
+        <div
+          class={clsx('content flex flex-col w-full overflow-y-auto', size === 'sm' && 'max-w-92', _class)}
+          data-scroll-lock-ignore
+        >
           {#if $$slots.title}
             <div
               class={clsx(

--- a/apps/penxle.com/src/lib/svelte/actions/scroll-lock.ts
+++ b/apps/penxle.com/src/lib/svelte/actions/scroll-lock.ts
@@ -2,7 +2,17 @@ import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import type { Action } from 'svelte/action';
 
 export const scrollLock: Action<HTMLElement> = (element) => {
-  disableBodyScroll(element);
+  disableBodyScroll(element, {
+    allowTouchMove: (el) => {
+      while (el !== document.body) {
+        if (el instanceof HTMLElement && el.dataset.scrollLockIgnore !== undefined) return true;
+        if (el.parentElement === null) return false;
+        el = el.parentElement;
+      }
+
+      return false;
+    },
+  });
 
   return {
     destroy: () => {


### PR DESCRIPTION
IOS Safari 에서 모달 내용 스크롤이 안되는 문제 고치기

지난 변경 사항인 스크롤 잠금 #861 을 넣으면서 내용 영역도 같이 잠금이 되는 문제가 있었습니다.
모달 내용 영역에 한해 `touchMove` 이벤트를 허용을 하는 설정을 추가해서 해결했습니다.

1. [body-scroll-lock 사용법(feat. 모달 내부에서 원하는 요소는 스크롤
  가능하도록)](https://velog.io/@_woogie/body-scroll-lock-사용법feat.-모달-내부에서-원하는-요소는-스크롤-가능하도록#body-scroll-lock)
2. [`allowTouchMove` - body-scroll-lock](https://github.com/willmcpo/body-scroll-lock#allowtouchmove)

overflow-y-auto 로 변경