### PR TITLE
컬렉션 포스트 목록 관리 기능에서 폼 전송 이후 모달이 닫히지 않은 버그 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/pages/collections/ManageCollectionModal.svelte
+++ b/apps/penxle.com/src/lib/components/pages/collections/ManageCollectionModal.svelte
@@ -89,11 +89,11 @@
     `),
     extra: () => ({ postIds: [...registeredPostIds.values()] }),
     schema: SetSpaceCollectionPostSchema,
-    onSuccess: ({ id }) => {
+    onSuccess: () => {
       open = false;
       mixpanel.track('space:collection:update', {
         spaceId,
-        collectionId: id,
+        collectionId: $collection.id,
         postIds: [...registeredPostIds.values()],
       });
       toast.success('컬렉션에 등록된 포스트 목록을 수정되었어요');


### PR DESCRIPTION
`onSucess` 인자 값으로 `{ id: string }` 이 아닌 `null` 이 전달되어서 함수 블럭 내 코드가 실행되지 않은 문제가 있었습니다. 

컬렉션 관련 기능에 추적 코드를 붙이는 작업 #930 이후에 나타난 오류로 파악했습니다. 혹시 몰라 비슷한 다른 모달도 닫히지 않는지 획인하였고, 다행히 해당 UI 하나에만 발생하는 문제로 확인했습니다.
이로 인해 추적 코드 하나가 전송 누락이 되는 문제가 있었습니다. 석고대죄 드립니다...