### PR TITLE
링크 수정이 안되는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/extensions/link/link.ts
+++ b/apps/penxle.com/src/lib/tiptap/extensions/link/link.ts
@@ -60,6 +60,13 @@ declare module '@tiptap/core' {
         rel?: string | null;
         class?: string | null;
       }) => ReturnType;
+
+      updateLink: (attributes: {
+        href: string;
+        target?: string | null;
+        rel?: string | null;
+        class?: string | null;
+      }) => ReturnType;
       /**
        * Unset a link mark
        */
@@ -148,6 +155,12 @@ export const Link = Mark.create<LinkOptions>({
             .toggleMark(this.name, attributes, { extendEmptyMarkRange: true })
             .setMeta('preventAutolink', true)
             .run();
+        },
+
+      updateLink:
+        (attributes) =>
+        ({ chain }) => {
+          return chain().extendMarkRange(this.name).updateAttributes(this.name, attributes).run();
         },
 
       unsetLink:

--- a/apps/penxle.com/src/routes/editor/ArticleLinkEditMenu.svelte
+++ b/apps/penxle.com/src/routes/editor/ArticleLinkEditMenu.svelte
@@ -92,7 +92,7 @@
     on:submit|preventDefault={() => {
       const command = editor.chain().focus();
       if (trimmedHref.length > 0) {
-        command.setLink({ href: trimmedHref }).run();
+        command.updateLink({ href: trimmedHref }).run();
       } else {
         command.unsetLink().run();
       }


### PR DESCRIPTION
석고대죄 합니다... `updateAttribute` API를 활용해야 되었고, 아래 문서 내 예제를 참고하여 해결했습니다.

https://tiptap.dev/docs/editor/api/commands/extend-mark-range#usage