### PR TITLE
s3 upload 버킷 cors 룰에 스테이징 도메인 추가

### DIFF
--- a/apps/bedrock/pulumi/aws/s3.ts
+++ b/apps/bedrock/pulumi/aws/s3.ts
@@ -30,7 +30,12 @@ const uploads = new aws.s3.Bucket('uploads', {
     {
       allowedHeaders: ['*'],
       allowedMethods: ['PUT'],
-      allowedOrigins: ['https://penxle.com', 'https://*.pnxl.site', 'http://localhost:4000'],
+      allowedOrigins: [
+        'https://penxle.com',
+        'https://staging.penxle.com',
+        'https://*.pnxl.site',
+        'http://localhost:4000',
+      ],
     },
   ],
 });


### PR DESCRIPTION
s3 `penxle-uploads` 버킷 cors 룰에 스테이징 도메인(`https://staging.penxle.com`)이 누락되어 있어 추가함
