### PR TITLE
penxle.com 프로젝트 iam 권한 좀 더 narrow 함

### DIFF
--- a/apps/penxle.com/pulumi/index.ts
+++ b/apps/penxle.com/pulumi/index.ts
@@ -33,11 +33,16 @@ const site = new penxle.Site('penxle.com', {
       Statement: [
         {
           Effect: 'Allow',
-          Action: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+          Action: ['s3:GetObject', 's3:PutObject'],
           Resource: [
             pulumi.concat(bedrockRef('AWS_S3_BUCKET_DATA_ARN'), '/*'),
             pulumi.concat(bedrockRef('AWS_S3_BUCKET_UPLOADS_ARN'), '/*'),
           ],
+        },
+        {
+          Effect: 'Allow',
+          Action: ['s3:DeleteObject'],
+          Resource: [pulumi.concat(bedrockRef('AWS_S3_BUCKET_UPLOADS_ARN'), '/*')],
         },
         {
           Effect: 'Allow',


### PR DESCRIPTION
`penxle-data` s3 버킷에 불필요하게 's3:DeleteObject` 권한이 부여되고 있던 점 수정함
