### PR TITLE
컬렉션 생성 모달에서 업로드를 시도한 이전 썸네일 이미지가 남아 있는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/pages/collections/CreateCollectionModal.svelte
+++ b/apps/penxle.com/src/lib/components/pages/collections/CreateCollectionModal.svelte
@@ -16,6 +16,10 @@
 
   let thumbnail: (Image_image & { id: string }) | null = null;
 
+  $: if (open) {
+    thumbnail = null;
+  }
+
   const createSpaceCollection = graphql(`
     mutation CreateCollectionModal_CreateSpaceCollection_Mutation($input: CreateSpaceCollectionInput!) {
       createSpaceCollection(input: $input) {
@@ -49,7 +53,6 @@
     },
     onSuccess: ({ id }) => {
       open = false;
-      thumbnail = null;
       mixpanel.track('space:collection:create', { spaceId, collectionId: id });
       toast.success('컬렉션이 생성되었어요');
     },


### PR DESCRIPTION
컬렉션 생성 단계 중 썸네일 업로드만 하고 모달을 닫고 다시 열었을 때 썸네일 이미지가 null 로 초기화가 안되어 있는 문제가 있었습니다.

로컬 개발 환경에서 썸네일 업로드가 인증 문제로 안되는 상황이라 스테이징에 올린 후 확인이 필요합니다.