### PR TITLE
에디터에서 스페이스 생성을 연속으로 할 수 없는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/editor/CreateSpaceModal.svelte
+++ b/apps/penxle.com/src/routes/editor/CreateSpaceModal.svelte
@@ -47,6 +47,10 @@
   let avatar: typeof $user.profile.avatar;
   $: avatar = $user.profile.avatar;
 
+  $: if (open) {
+    useSpaceProfile = true;
+  }
+
   const { form, handleSubmit, isSubmitting, data, setFields, setInitialValues } = createMutationForm({
     mutation: graphql(`
       mutation EditorPage_CreateSpaceModal_CreateSpace_Mutation($input: CreateSpaceInput!) {


### PR DESCRIPTION
스페이스 전용 프로필 사용을 Off로 한 채로 스페이스를 연속으로 만들 경우 생성이 안되는 문제가 있었음
`profileName`과 `profileAvatarId`의 초기값을 각각 `''`, `undefined`로 설정한 후 `useSpaceProfile` 여부가 바뀔 때마다 setFields를 해주고 있었는데, 두 번째 생성할 때는 `useSpaceProfile`이 이미 `false`이기 때문에 setFields가 되지 않아 `profileName`의 값이 `''`로 들어가기 때문이었음
따라서 스페이스를 연속으로 생성할 때는 `useSpaceProfile`을 `true`로 설정해 스페이스 생성 시 무조건 스페이스 전용 프로필 필드를 수정하도록 함