### PR TITLE
컬렉션 제목 수정 직후 업데이트하기

### DIFF
--- a/apps/penxle.com/src/lib/components/forms/Editable.svelte
+++ b/apps/penxle.com/src/lib/components/forms/Editable.svelte
@@ -7,6 +7,7 @@
   type $$Props = HTMLInputAttributes & { value?: typeof value };
   type $$Events = {
     input: Parameters<NonNullable<HTMLInputAttributes['on:input']>>[0];
+    blur: Parameters<NonNullable<HTMLInputAttributes['on:blur']>>[0];
   };
 
   let editing = false;
@@ -34,6 +35,7 @@
       editing = false;
     }}
     bind:value
+    on:blur
   />
   <button
     class={clsx('i-px-edit-2-outline square-6 text-secondary disabled:text-disabled', editing && 'hidden')}


### PR DESCRIPTION
https://github.com/penxle/penxle/assets/5278201/ac1c22a8-91a8-45b3-a7b9-2f74c5a76f3e

수정한 제목을 업데이트 하는 걸 <저장하기> 버튼을 누른 시점으로 미루게 되면 초점을 뺀 이후에 제목이 수정됨을 직접 핸즈온해보면서 기대 및 착각을 하여 조금 헷갈렸습니다.

컬렉션명 수정 기능은 폼 저장 액션 <저장하기> 버튼과 별개로 수정 박스에 초점을 벗어난 직후에  이름 변경이 반영이 되는게 조금 더 자연스러운 플로우로 추가 논의되어 반영합니다.