### PR TITLE
이벤트 핸들러에 타겟 타입 강제하지 않고 정의하기

### DIFF
--- a/apps/penxle.com/src/lib/components/Tag.svelte
+++ b/apps/penxle.com/src/lib/components/Tag.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import clsx from 'clsx';
+  import type { HTMLInputAttributes } from 'svelte/elements';
 
   export let size: 'sm' | 'lg' = 'lg';
   let _class: string | undefined = undefined;
@@ -8,6 +9,10 @@
   export let as: 'div' | 'a' | 'label' = 'a';
   export let checked = false;
   export let name: string | undefined = undefined;
+
+  type $$Events = {
+    change: Parameters<NonNullable<HTMLInputAttributes['on:change']>>[0];
+  };
 </script>
 
 <svelte:element

--- a/apps/penxle.com/src/lib/components/forms/Checkbox.svelte
+++ b/apps/penxle.com/src/lib/components/forms/Checkbox.svelte
@@ -10,6 +10,9 @@
   export { _class as class };
 
   type $$Props = HTMLInputAttributes;
+  type $$Events = {
+    change: Parameters<NonNullable<HTMLInputAttributes['on:change']>>[0];
+  };
 
   const { field } = getFormContext();
 

--- a/apps/penxle.com/src/lib/components/pages/posts/PostManageTable.svelte
+++ b/apps/penxle.com/src/lib/components/pages/posts/PostManageTable.svelte
@@ -9,6 +9,7 @@
   import { Menu, MenuItem } from '$lib/components/menu';
   import { Table, TableData, TableHead, TableRow } from '$lib/components/table';
   import { toast } from '$lib/notification';
+  import type { ChangeEventHandler } from 'svelte/elements';
   import type { PostManageTable_Collection, PostManageTable_Post_query, PostManageTable_SpaceMember } from '$glitch';
   import type { PublishPostInput } from '$lib/validations/post';
 
@@ -224,10 +225,7 @@
     }
   }
 
-  function handleSelectAllPost(event: Event) {
-    if (!(event.currentTarget instanceof HTMLInputElement))
-      throw new Error('event.currentTarget is not HTMLInputElement');
-
+  const handleSelectAllPost: ChangeEventHandler<HTMLInputElement> = (event) => {
     const { checked } = event.currentTarget;
 
     if (checked) {
@@ -240,11 +238,8 @@
       }
     }
     selectedPostIds = selectedPostIds;
-  }
-  function handleSelectPost(event: Event) {
-    if (!(event.currentTarget instanceof HTMLInputElement))
-      throw new Error('event.currentTarget is not HTMLInputElement');
-
+  };
+  const handleSelectPost: ChangeEventHandler<HTMLInputElement> = (event) => {
     const { checked, value } = event.currentTarget;
     if (checked) {
       selectedPostIds.add(value);
@@ -253,7 +248,7 @@
     }
 
     selectedPostIds = selectedPostIds;
-  }
+  };
 
   const createSpaceCollection = graphql(`
     mutation PostManageTable_CreateSpaceCollection_Mutation($input: CreateSpaceCollectionInput!) {

--- a/apps/penxle.com/src/routes/(auth)/signup/+page.svelte
+++ b/apps/penxle.com/src/routes/(auth)/signup/+page.svelte
@@ -7,6 +7,7 @@
   import { Checkbox, FormField, TextInput } from '$lib/components/forms';
   import { createMutationForm } from '$lib/form';
   import { CreateUserSchema } from '$lib/validations';
+  import type { ChangeEventHandler } from 'svelte/elements';
 
   $: query = graphql(`
     query SignupPage_Query($token: String!) {
@@ -42,8 +43,8 @@
   });
 
   $: consentAll = $data.termsConsent && $data.marketingConsent;
-  const handleConsentAll = (event: Event) => {
-    const { checked } = event.currentTarget as HTMLInputElement;
+  const handleConsentAll: ChangeEventHandler<HTMLInputElement> = (event) => {
+    const { checked } = event.currentTarget;
     setFields('termsConsent', checked);
     setFields('marketingConsent', checked);
   };

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/FollowTagModal.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/FollowTagModal.svelte
@@ -3,6 +3,7 @@
   import { mixpanel } from '$lib/analytics';
   import { Button, Modal, Tag } from '$lib/components';
   import { toast } from '$lib/notification';
+  import type { ChangeEventHandler } from 'svelte/elements';
   import type { MeCabinetsPage_FollowTagModal_user } from '$glitch';
 
   let _user: MeCabinetsPage_FollowTagModal_user;
@@ -38,8 +39,11 @@
     return Promise.all(tags.map(({ id }) => unfollowTag({ tagId: id })));
   };
 
-  const handleChange = (e: Event, tag: (typeof $user.followedTags)[0]) => {
-    const { checked } = e.currentTarget as HTMLInputElement;
+  const handleChange = (
+    e: Parameters<ChangeEventHandler<HTMLInputElement>>[0],
+    tag: (typeof $user.followedTags)[0],
+  ) => {
+    const { checked } = e.currentTarget;
 
     tags = checked ? [...tags, tag] : tags.filter((t) => t.id !== tag.id);
   };

--- a/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/MutedTagModal.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/MutedTagModal.svelte
@@ -3,6 +3,7 @@
   import { mixpanel } from '$lib/analytics';
   import { Button, Modal, Tag } from '$lib/components';
   import { toast } from '$lib/notification';
+  import type { ChangeEventHandler } from 'svelte/elements';
   import type { MeSettingsContentFiltersPage_MutedTagModal_user } from '$glitch';
 
   let _user: MeSettingsContentFiltersPage_MutedTagModal_user;
@@ -39,8 +40,8 @@
     return Promise.all(tags.map(({ id }) => unmuteTag({ tagId: id })));
   };
 
-  const handleChange = (e: Event, tag: (typeof $user.mutedTags)[0]) => {
-    const { checked } = e.currentTarget as HTMLInputElement;
+  const handleChange = (e: Parameters<ChangeEventHandler<HTMLInputElement>>[0], tag: (typeof $user.mutedTags)[0]) => {
+    const { checked } = e.currentTarget;
 
     tags = checked ? [...tags, tag] : tags.filter((t) => t.id !== tag.id);
   };

--- a/apps/penxle.com/src/routes/editor/Footer.svelte
+++ b/apps/penxle.com/src/routes/editor/Footer.svelte
@@ -6,7 +6,7 @@
   import { toast } from '$lib/notification';
   import type { Writable } from '@svelte-kits/store';
   import type { JSONContent } from '@tiptap/core';
-  import type { KeyboardEventHandler } from 'svelte/elements';
+  import type { ChangeEventHandler, KeyboardEventHandler } from 'svelte/elements';
   import type { Image_image, PostRevisionContentKind } from '$glitch';
   import type { ImageBounds } from '$lib/utils';
 
@@ -66,8 +66,8 @@
     $autoSaveCount += 1;
   };
 
-  const handleImageCaptionInputChange = (e: Event) => {
-    const { value } = e.currentTarget as HTMLInputElement;
+  const handleImageCaptionInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const { value } = e.currentTarget;
 
     if (!content) {
       content = {

--- a/apps/penxle.com/src/routes/editor/Header.svelte
+++ b/apps/penxle.com/src/routes/editor/Header.svelte
@@ -24,6 +24,7 @@
   import { preventRevise } from './store';
   import ToolbarButton from './ToolbarButton.svelte';
   import type { Editor, JSONContent } from '@tiptap/core';
+  import type { ChangeEventHandler } from 'svelte/elements';
   import type { Writable } from 'svelte/store';
   import type {
     ContentFilterCategory,
@@ -375,8 +376,11 @@
     void update();
   }
 
-  const checkContentFilter = (e: Event, contentFilter: ContentFilterCategory) => {
-    const { checked } = e.currentTarget as HTMLInputElement;
+  const checkContentFilter = (
+    e: Parameters<ChangeEventHandler<HTMLInputElement>>[0],
+    contentFilter: ContentFilterCategory,
+  ) => {
+    const { checked } = e.currentTarget;
 
     $data.contentFilters = checked
       ? $data.contentFilters


### PR DESCRIPTION
타입 단언(assertion) 이나 타입 가드 대신에 이벤트 핸들러에 명시적으로 타입을 정의가 가능하여 적용했습니다.