### PR TITLE
링크에 마우스 올릴 때마다 채널톡 버튼 리로드되는 문제 해결

### DIFF
--- a/apps/penxle.com/src/lib/channel.io/Button.svelte
+++ b/apps/penxle.com/src/lib/channel.io/Button.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import * as ChannelService from '@channel.io/channel-web-sdk-loader';
-  import { onDestroy } from 'svelte';
-  import { browser } from '$app/environment';
+  import { onMount } from 'svelte';
   import { env } from '$env/dynamic/public';
   import { fragment, graphql } from '$glitch';
   import type { ChannelIOButton_query } from '$glitch';
@@ -32,7 +31,7 @@
     `),
   );
 
-  $: if (browser && $query) {
+  onMount(() => {
     if ($query.me) {
       ChannelService.boot({
         pluginKey: env.PUBLIC_CHANNEL_IO_PLUGIN_KEY,
@@ -50,12 +49,8 @@
       });
     }
 
-    ChannelService.showChannelButton();
-  }
-
-  onDestroy(() => {
-    if (browser) {
-      ChannelService.hideChannelButton();
-    }
+    return () => {
+      ChannelService.shutdown();
+    };
   });
 </script>

--- a/apps/penxle.com/src/routes/(default)/Footer.svelte
+++ b/apps/penxle.com/src/routes/(default)/Footer.svelte
@@ -42,7 +42,7 @@
         </Link>
         <div class="h-2 border-l border-gray-50 mx-1" />
         <div class="flex flex-wrap items-center">
-          <Link class="hover:text-secondary" href="https://help.penxle.com">도움 센터</Link>
+          <Link class="hover:text-secondary" href="https://penxle.channel.io">고객 센터</Link>
           <div class="h-2 border-l border-gray-50 mx-1" />
           <Link class="hover:text-secondary" href="/penxle">펜슬 소식</Link>
           <div class="h-2 border-l border-gray-50 mx-1" />


### PR DESCRIPTION
메인페이지 등 채널톡 버튼이 뜨는 페이지에서 아무 링크에 마우스를 올리면 data preload로 인해 reactive statement가 실행, 채널톡 버튼이 깜빡이는 문제를 해결함
