### PR TITLE
디자인 단계에서 누락된 엠티 스테이트 문구 추가하기

### DIFF
--- a/apps/penxle.com/src/lib/components/pages/posts/PostManageTable.svelte
+++ b/apps/penxle.com/src/lib/components/pages/posts/PostManageTable.svelte
@@ -269,255 +269,264 @@
 </script>
 
 <div class="overflow-auto">
-  <Table class="text-left border-separate border-spacing-y-0.125rem">
-    <TableRow>
-      <TableHead class="w-2.5rem">
-        <Checkbox on:change={handleSelectAllPost} />
-      </TableHead>
-      <TableHead class="sm:max-w-14rem">제목</TableHead>
-      <TableHead class="<sm:hidden max-w-10rem">
-        {#if type === 'space'}
-          작성자
-        {:else}
-          스페이스
-        {/if}
-      </TableHead>
-      <TableHead class="w-12rem <sm:hidden">태그</TableHead>
-      <TableHead class="<sm:w-5.25rem">공개옵션</TableHead>
-      <TableHead class="<sm:hidden">관리</TableHead>
-      <!-- 모바일 화면 너비에서 마지막에 빈 테이블 헤드 요소가 없으면 테이블 헤더 오른쪽이 잘리는 문제가 있어서 추가했습니다. -->
-      <TableHead class="w-0" />
-    </TableRow>
+  {#if $posts.length > 0}
+    <Table class="text-left border-separate border-spacing-y-0.125rem">
+      <TableRow>
+        <TableHead class="w-2.5rem">
+          <Checkbox on:change={handleSelectAllPost} />
+        </TableHead>
+        <TableHead class="sm:max-w-14rem">제목</TableHead>
+        <TableHead class="<sm:hidden max-w-10rem">
+          {#if type === 'space'}
+            작성자
+          {:else}
+            스페이스
+          {/if}
+        </TableHead>
+        <TableHead class="w-12rem <sm:hidden">태그</TableHead>
+        <TableHead class="<sm:w-5.25rem">공개옵션</TableHead>
+        <TableHead class="<sm:hidden">관리</TableHead>
+        <!-- 모바일 화면 너비에서 마지막에 빈 테이블 헤드 요소가 없으면 테이블 헤더 오른쪽이 잘리는 문제가 있어서 추가했습니다. -->
+        <TableHead class="w-0" />
+      </TableRow>
 
-    {#each $posts as post (post.id)}
-      <TableRow
-        class="rounded-2 [&[aria-selected='true']]:bg-primary border-solid border-b border-alphagray-10 last:border-b-0 [&>td>div]:(items-center <sm:justify-end) aria-selected:bg-primary"
-        aria-selected={selectedPostIds.has('post.id')}
-      >
-        <TableData class="p-r-none!">
-          <Checkbox checked={selectedPostIds.has(post.id)} value={post.id} on:change={handleSelectPost} />
-        </TableData>
-        <TableData class="sm:max-w-14rem">
-          <a
-            class="flex justify-start gap-xs"
-            href={`/${post.space.slug}/${post.permalink}`}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {#if post.publishedRevision.croppedThumbnail}
-              <Image class="square-2.625rem flex-shrink-0 rounded-2" $image={post.publishedRevision.croppedThumbnail} />
-            {/if}
-            <dl class="truncate [&>dt]:truncate">
-              <dt class="body-15-b">
-                {post.publishedRevision.title}
-              </dt>
-              <dd class="body-13-m text-secondary">
-                {dayjs(post.publishedAt).formatAsDate()}
-              </dd>
-            </dl>
-          </a>
-        </TableData>
-        <TableData class="<sm:hidden max-w-10rem">
-          <div class="flex gap-1">
-            {#if type === 'space'}
-              <Avatar class="square-5 shrink-0" $profile={post.member.profile} />
-              <span class="body-13-b truncate">{post.member.profile.name}</span>
-              {#if post.member.id === $spaceMember?.id}
-                <Badge class="w-fit px-2 py-1" color="green">나</Badge>
+      {#each $posts as post (post.id)}
+        <TableRow
+          class="rounded-2 [&[aria-selected='true']]:bg-primary border-solid border-b border-alphagray-10 last:border-b-0 [&>td>div]:(items-center <sm:justify-end) aria-selected:bg-primary"
+          aria-selected={selectedPostIds.has('post.id')}
+        >
+          <TableData class="p-r-none!">
+            <Checkbox checked={selectedPostIds.has(post.id)} value={post.id} on:change={handleSelectPost} />
+          </TableData>
+          <TableData class="sm:max-w-14rem">
+            <a
+              class="flex justify-start gap-xs"
+              href={`/${post.space.slug}/${post.permalink}`}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {#if post.publishedRevision.croppedThumbnail}
+                <Image
+                  class="square-2.625rem flex-shrink-0 rounded-2"
+                  $image={post.publishedRevision.croppedThumbnail}
+                />
               {/if}
-            {:else if type === 'me'}
-              <Avatar class="square-5" $profile={post.member.profile} />
-              <span class="body-13-b">{post.space.name}</span>
-            {/if}
-          </div>
-        </TableData>
-        <TableData class="<sm:hidden max-w-12rem">
-          <div class="flex gap-1">
-            {#each post.publishedRevision.tags.slice(0, 3) as tag (tag.id)}
-              <Tag size="sm">{tag.name}</Tag>
-            {/each}
-            {#if post.publishedRevision.tags.length > 2}
-              <Tooltip
-                message={post.publishedRevision.tags
-                  .slice(2)
-                  .map((tag) => (tag.name.length < 20 ? tag.name : `${tag.name.slice(0, 20)}...`))
-                  .join(', ')}
-                placement="top"
-              >
-                <span class="body-13-b">+{post.publishedRevision.tags.length - 2}</span>
-              </Tooltip>
-            {/if}
-          </div>
-        </TableData>
-        <TableData class="overflow-visible!">
-          <div class="flex gap-0.125rem">
-            <Menu
-              class="disabled:[&>i.i-lc-chevron-down]:hidden "
-              disabled={!hasPermissionToUpdatePost(post.member.id)}
-              placement="bottom-end"
-            >
-              <span slot="value" class="flex items-center body-13-b [&>i]:text-icon-secondary">
-                <i class={clsx(visibilityToIcon[post.visibility], 'square-4 m-r-0.15rem')} />
-                {visibilityToLocaleString[post.visibility]}
-                <i class="i-lc-chevron-down square-4" />
-              </span>
-
-              {#each visibilityOptions as visibilityOption (visibilityOption.value)}
-                <MenuItem
-                  aria-pressed={post.visibility === visibilityOption.value}
-                  on:click={() =>
-                    updateVisibility({
-                      postId: post.id,
-                      visibility: visibilityOption.value,
-                    })}
-                >
-                  {visibilityOption.label}
-                </MenuItem>
+              <dl class="truncate [&>dt]:truncate">
+                <dt class="body-15-b">
+                  {post.publishedRevision.title}
+                </dt>
+                <dd class="body-13-m text-secondary">
+                  {dayjs(post.publishedAt).formatAsDate()}
+                </dd>
+              </dl>
+            </a>
+          </TableData>
+          <TableData class="<sm:hidden max-w-10rem">
+            <div class="flex gap-1">
+              {#if type === 'space'}
+                <Avatar class="square-5 shrink-0" $profile={post.member.profile} />
+                <span class="body-13-b truncate">{post.member.profile.name}</span>
+                {#if post.member.id === $spaceMember?.id}
+                  <Badge class="w-fit px-2 py-1" color="green">나</Badge>
+                {/if}
+              {:else if type === 'me'}
+                <Avatar class="square-5" $profile={post.member.profile} />
+                <span class="body-13-b">{post.space.name}</span>
+              {/if}
+            </div>
+          </TableData>
+          <TableData class="<sm:hidden max-w-12rem">
+            <div class="flex gap-1">
+              {#each post.publishedRevision.tags.slice(0, 3) as tag (tag.id)}
+                <Tag size="sm">{tag.name}</Tag>
               {/each}
-            </Menu>
-          </div>
-        </TableData>
-        <TableData class="<sm:hidden">
-          <div class={clsx('flex gap-2')} hidden={!hasPermissionToUpdatePost(post.member.id)}>
-            <Button
-              class="disabled:invisible"
-              color="tertiary"
-              disabled={type === 'space' && post.member.id !== $spaceMember?.id}
-              external
-              href={`/editor/${post.permalink}`}
-              size="sm"
-              type="link"
-              variant="outlined"
-            >
-              수정
-            </Button>
-            <Button
-              class="p-none! disabled:invisible"
-              disabled={type === 'space' && (post.member.id !== $spaceMember?.id || $spaceMember?.role !== 'ADMIN')}
-              size="sm"
-              variant="text"
-              on:click={() => {
-                deletePostId = post.id;
-                openDeletePostWaring = true;
+              {#if post.publishedRevision.tags.length > 2}
+                <Tooltip
+                  message={post.publishedRevision.tags
+                    .slice(2)
+                    .map((tag) => (tag.name.length < 20 ? tag.name : `${tag.name.slice(0, 20)}...`))
+                    .join(', ')}
+                  placement="top"
+                >
+                  <span class="body-13-b">+{post.publishedRevision.tags.length - 2}</span>
+                </Tooltip>
+              {/if}
+            </div>
+          </TableData>
+          <TableData class="overflow-visible!">
+            <div class="flex gap-0.125rem">
+              <Menu
+                class="disabled:[&>i.i-lc-chevron-down]:hidden "
+                disabled={!hasPermissionToUpdatePost(post.member.id)}
+                placement="bottom-end"
+              >
+                <span slot="value" class="flex items-center body-13-b [&>i]:text-icon-secondary">
+                  <i class={clsx(visibilityToIcon[post.visibility], 'square-4 m-r-0.15rem')} />
+                  {visibilityToLocaleString[post.visibility]}
+                  <i class="i-lc-chevron-down square-4" />
+                </span>
+
+                {#each visibilityOptions as visibilityOption (visibilityOption.value)}
+                  <MenuItem
+                    aria-pressed={post.visibility === visibilityOption.value}
+                    on:click={() =>
+                      updateVisibility({
+                        postId: post.id,
+                        visibility: visibilityOption.value,
+                      })}
+                  >
+                    {visibilityOption.label}
+                  </MenuItem>
+                {/each}
+              </Menu>
+            </div>
+          </TableData>
+          <TableData class="<sm:hidden">
+            <div class={clsx('flex gap-2')} hidden={!hasPermissionToUpdatePost(post.member.id)}>
+              <Button
+                class="disabled:invisible"
+                color="tertiary"
+                disabled={type === 'space' && post.member.id !== $spaceMember?.id}
+                external
+                href={`/editor/${post.permalink}`}
+                size="sm"
+                type="link"
+                variant="outlined"
+              >
+                수정
+              </Button>
+              <Button
+                class="p-none! disabled:invisible"
+                disabled={type === 'space' && (post.member.id !== $spaceMember?.id || $spaceMember?.role !== 'ADMIN')}
+                size="sm"
+                variant="text"
+                on:click={() => {
+                  deletePostId = post.id;
+                  openDeletePostWaring = true;
+                }}
+              >
+                <i class="i-lc-trash-2 square-4 text-secondary hover:text-action-red-primary" />
+              </Button>
+            </div>
+          </TableData>
+          <TableData></TableData>
+        </TableRow>
+      {/each}
+    </Table>
+  {:else}
+    <p class="body-16-m text-center m-y-30">작성한 포스트가 없어요</p>
+  {/if}
+</div>
+
+{#if $posts.length > 0}
+  <div
+    class={clsx(
+      selectedPostCount > 0 ? 'visible opacity-100 translate-y-0' : 'invisible opacity-0 translate-y-1rem',
+      'self-center flex justify-center flex-wrap gap-4 items-center px-6 py-2 flex-wrap sticky bottom-1rem bg-white rounded-2xl shadow-[0_0.25rem_1rem_0_rgba(0,0,0,0.15)] transition-all-300',
+    )}
+  >
+    <span class="body-15-b" aria-live="polite">
+      {selectedPostCount}개의 포스트 선택됨
+    </span>
+    <div class="flex gap-4 flex-wrap justify-center">
+      {#if selectedOwnPosts || $spaceMember?.role === 'ADMIN'}
+        <Menu class="<sm:hidden" as="div" offset={toolbarMenuOffset} placement="top">
+          <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">공개범위 설정</Button>
+          <MenuItem on:click={() => updateVisibilities('PUBLIC')}>전체 공개</MenuItem>
+          <MenuItem on:click={() => updateVisibilities('UNLISTED')}>링크 공개</MenuItem>
+          <MenuItem on:click={() => updateVisibilities('SPACE')}>멤버 공개</MenuItem>
+        </Menu>
+        <Menu
+          class={clsx(type === 'space' && '<sm:hidden')}
+          as="div"
+          offset={toolbarMenuOffset}
+          placement="top"
+          preventClose
+        >
+          <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">포스트 옵션 설정</Button>
+          <MenuItem type="div">
+            <Switch
+              class="flex gap-0.63rem body-14-m items-center justify-between"
+              checked={receiveFeedback}
+              on:change={(event) => {
+                receiveFeedback = event.currentTarget.checked;
+
+                updatePostsOptions({ receiveFeedback });
               }}
             >
-              <i class="i-lc-trash-2 square-4 text-secondary hover:text-action-red-primary" />
-            </Button>
-          </div>
-        </TableData>
-        <TableData></TableData>
-      </TableRow>
-    {/each}
-  </Table>
-</div>
-
-<div
-  class={clsx(
-    selectedPostCount > 0 ? 'visible opacity-100 translate-y-0' : 'invisible opacity-0 translate-y-1rem',
-    'self-center flex justify-center flex-wrap gap-4 items-center px-6 py-2 flex-wrap sticky bottom-1rem bg-white rounded-2xl shadow-[0_0.25rem_1rem_0_rgba(0,0,0,0.15)] transition-all-300',
-  )}
->
-  <span class="body-15-b" aria-live="polite">
-    {selectedPostCount}개의 포스트 선택됨
-  </span>
-  <div class="flex gap-4 flex-wrap justify-center">
-    {#if selectedOwnPosts || $spaceMember?.role === 'ADMIN'}
-      <Menu class="<sm:hidden" as="div" offset={toolbarMenuOffset} placement="top">
-        <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">공개범위 설정</Button>
-        <MenuItem on:click={() => updateVisibilities('PUBLIC')}>전체 공개</MenuItem>
-        <MenuItem on:click={() => updateVisibilities('UNLISTED')}>링크 공개</MenuItem>
-        <MenuItem on:click={() => updateVisibilities('SPACE')}>멤버 공개</MenuItem>
-      </Menu>
-      <Menu
-        class={clsx(type === 'space' && '<sm:hidden')}
-        as="div"
-        offset={toolbarMenuOffset}
-        placement="top"
-        preventClose
-      >
-        <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">포스트 옵션 설정</Button>
-        <MenuItem type="div">
-          <Switch
-            class="flex gap-0.63rem body-14-m items-center justify-between"
-            checked={receiveFeedback}
-            on:change={(event) => {
-              receiveFeedback = event.currentTarget.checked;
-
-              updatePostsOptions({ receiveFeedback });
-            }}
-          >
-            피드백
-          </Switch>
-        </MenuItem>
-        <MenuItem type="div">
-          <Switch
-            class="flex gap-0.63rem body-14-m items-center justify-between"
-            checked={receiveTagContribution}
-            on:change={(event) => {
-              receiveTagContribution = event.currentTarget.checked;
-
-              updatePostsOptions({ receiveTagContribution });
-            }}
-          >
-            태그 수정
-          </Switch>
-        </MenuItem>
-        <MenuItem type="div">
-          <Switch
-            class="flex gap-0.63rem body-14-m items-center justify-between"
-            checked={discloseStats}
-            on:change={(event) => {
-              discloseStats = event.currentTarget.checked;
-
-              updatePostsOptions({ discloseStats });
-            }}
-          >
-            통계 공개
-          </Switch>
-        </MenuItem>
-      </Menu>
-    {/if}
-    {#if type === 'space'}
-      <Menu as="div" offset={toolbarMenuOffset}>
-        <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">컬렉션 추가</Button>
-        {#each $collections as collection (collection.id)}
-          <MenuItem
-            class="flex gap-0.62rem group"
-            aria-pressed={selectedCollectionId === collection.id}
-            on:click={async () => {
-              await setSpaceCollectionPosts({
-                collectionId: collection.id,
-                postIds: selectedPosts.map((post) => post.id),
-              });
-
-              toast.success('컬렉션에 추가했어요');
-            }}
-          >
-            {collection.name}
-            <i class="i-lc-check square-4 color-green-50 invisible group-aria-pressed:visible" aria-label="선택됨" />
+              피드백
+            </Switch>
           </MenuItem>
-        {/each}
-        <MenuItem class="flex items-center gap-0.62rem" on:click={() => (openCreateCollection = true)}>
-          <i class="i-lc-plus square-4 text-secondary" />
-          새로 만들기
-        </MenuItem>
-      </Menu>
-    {/if}
-    {#if selectedOwnPosts || $spaceMember?.role === 'ADMIN'}
-      <Button
-        class={clsx('whitespace-nowrap', type === 'space' && '<sm:hidden')}
-        color="red"
-        size="md"
-        on:click={() => {
-          deletePostIds = _selectedPostIds;
-          openDeletePostWaring = true;
-        }}
-      >
-        삭제하기
-      </Button>
-    {/if}
+          <MenuItem type="div">
+            <Switch
+              class="flex gap-0.63rem body-14-m items-center justify-between"
+              checked={receiveTagContribution}
+              on:change={(event) => {
+                receiveTagContribution = event.currentTarget.checked;
+
+                updatePostsOptions({ receiveTagContribution });
+              }}
+            >
+              태그 수정
+            </Switch>
+          </MenuItem>
+          <MenuItem type="div">
+            <Switch
+              class="flex gap-0.63rem body-14-m items-center justify-between"
+              checked={discloseStats}
+              on:change={(event) => {
+                discloseStats = event.currentTarget.checked;
+
+                updatePostsOptions({ discloseStats });
+              }}
+            >
+              통계 공개
+            </Switch>
+          </MenuItem>
+        </Menu>
+      {/if}
+      {#if type === 'space'}
+        <Menu as="div" offset={toolbarMenuOffset}>
+          <Button slot="value" class="whitespace-nowrap" color="secondary" size="md">컬렉션 추가</Button>
+          {#each $collections as collection (collection.id)}
+            <MenuItem
+              class="flex gap-0.62rem group"
+              aria-pressed={selectedCollectionId === collection.id}
+              on:click={async () => {
+                await setSpaceCollectionPosts({
+                  collectionId: collection.id,
+                  postIds: selectedPosts.map((post) => post.id),
+                });
+
+                toast.success('컬렉션에 추가했어요');
+              }}
+            >
+              {collection.name}
+              <i class="i-lc-check square-4 color-green-50 invisible group-aria-pressed:visible" aria-label="선택됨" />
+            </MenuItem>
+          {/each}
+          <MenuItem class="flex items-center gap-0.62rem" on:click={() => (openCreateCollection = true)}>
+            <i class="i-lc-plus square-4 text-secondary" />
+            새로 만들기
+          </MenuItem>
+        </Menu>
+      {/if}
+      {#if selectedOwnPosts || $spaceMember?.role === 'ADMIN'}
+        <Button
+          class={clsx('whitespace-nowrap', type === 'space' && '<sm:hidden')}
+          color="red"
+          size="md"
+          on:click={() => {
+            deletePostIds = _selectedPostIds;
+            openDeletePostWaring = true;
+          }}
+        >
+          삭제하기
+        </Button>
+      {/if}
+    </div>
   </div>
-</div>
+{/if}
 
 <Modal size="sm" bind:open={openDeletePostWaring}>
   <svelte:fragment slot="title">정말 포스트를 삭제하시겠어요?</svelte:fragment>

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/(index)/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/(index)/+page.svelte
@@ -18,10 +18,8 @@
   `);
 </script>
 
-{#if $query.me.likedPosts?.length === 0}
-  <p class="text-secondary text-center body-15-b py-10">아직 좋아요한 포스트가 없어요</p>
-{/if}
-
 {#each $query.me.likedPosts as post (post.id)}
   <PostItem $post={post} />
+{:else}
+  <p class="text-secondary text-center body-16-m py-10">좋아요한 포스트가 없어요</p>
 {/each}

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/+layout.svelte
@@ -89,7 +89,7 @@
     </div>
 
     {#if $query.me.bookmarks.length === 0 || $query.me.bookmarks[0].postCount === 0}
-      <p class="body-15-b text-secondary text-center py-2">아직 북마크가 없어요</p>
+      <p class="body-16-m text-secondary text-center py-2">아직 북마크가 없어요</p>
     {:else}
       {#each $query.me.bookmarks as bookmark (bookmark.id)}
         <Link class="inline-block" href="/me/cabinets/bookmark">

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/FollowSpaceModal.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/FollowSpaceModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import clsx from 'clsx';
   import { fragment, graphql } from '$glitch';
   import { mixpanel } from '$lib/analytics';
   import { Button, Modal } from '$lib/components';
@@ -10,7 +11,7 @@
   export { _user as $user };
   export let open = false;
 
-  let followedSpaces: typeof $user.followedSpaces;
+  let followedSpaces: typeof $user.followedSpaces | undefined;
   let query = '';
 
   const setSpaces = () => {
@@ -59,12 +60,14 @@
       }
     }
   `);
+
+  $: filteredSpaces = followedSpaces?.filter((space) => space.name.includes(query));
 </script>
 
 <Modal size="md" bind:open>
   <svelte:fragment slot="title">관심 스페이스</svelte:fragment>
 
-  <form class="relative h-11.5 w-full mb-4" on:submit|preventDefault>
+  <form class={clsx('relative h-11.5 w-full mb-4', followedSpaces?.length === 0 && 'hidden')} on:submit|preventDefault>
     <input
       class="rounded-2.5 h-11.5 w-full bg-primary py-1.75 pr-3.5 pl-11 w-full border border-bg-primary transition focus-within:border-tertiary!"
       type="text"
@@ -75,8 +78,13 @@
     </div>
   </form>
 
-  <ul class="space-y-4">
-    {#each followedSpaces.filter((space) => space.name.includes(query)) as space (space.id)}
+  <ul
+    class={clsx(
+      'flex flex-col gap-4 min-h-10rem max-h-15rem overflow-y-auto',
+      filteredSpaces?.length === 0 && 'justify-center',
+    )}
+  >
+    {#each filteredSpaces ?? [] as space (space.id)}
       <li class="flex items-center justify-between">
         <div class="flex gap-2 items-center truncate mr-2">
           <Image class="square-10.5 rounded-lg grow-0 shrink-0 border border-secondary" $image={space.icon} />
@@ -114,6 +122,12 @@
           </Button>
         {/if}
       </li>
+    {:else}
+      <article class="text-secondary body-16-m text-center break-keep">
+        {#if followedSpaces}
+          {followedSpaces.length === 0 ? '아직 추가된 관심 스페이스가 없어요' : '일치하는 검색 결과가 없어요'}
+        {/if}
+      </article>
     {/each}
   </ul>
 </Modal>

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/FollowTagModal.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/FollowTagModal.svelte
@@ -53,9 +53,13 @@
   <svelte:fragment slot="title">관심 태그 관리</svelte:fragment>
   <svelte:fragment slot="subtitle">태그를 선택해 관심태그를 해제할 수 있어요</svelte:fragment>
 
-  <ul class="flex flex-wrap gap-2.5">
+  <ul class="flex flex-wrap gap-2.5 min-h-10rem max-h-15rem overflow-y-auto">
     {#each $user.followedTags as tag (tag.id)}
-      <Tag as="label" checked={tags.includes(tag)} on:change={(e) => handleChange(e, tag)}>{tag.name}</Tag>
+      <Tag class="h-fit" as="label" checked={tags.includes(tag)} on:change={(e) => handleChange(e, tag)}>
+        {tag.name}
+      </Tag>
+    {:else}
+      <article class="text-secondary body-16-m self-center m-x-auto break-keep">아직 추가된 관심 태그가 없어요</article>
     {/each}
   </ul>
 

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/purchased/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/purchased/+page.svelte
@@ -45,10 +45,6 @@
   `);
 </script>
 
-{#if $query.me.purchasedPosts?.length === 0}
-  <p class="text-secondary text-center body-15-b py-10">아직 구매한 포스트가 없어요</p>
-{/if}
-
 {#each $query.me.purchasedPosts as post (post.id)}
   <li>
     <div class="flex items-center justify-between gap-3 body-14-m text-secondary mb-2">
@@ -71,4 +67,6 @@
       </div>
     </a>
   </li>
+{:else}
+  <p class="text-secondary text-center body-16-m py-10">구매한 포스트가 없어요</p>
 {/each}

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/recent/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/recent/+page.svelte
@@ -18,10 +18,8 @@
   `);
 </script>
 
-{#if $query.me.recentlyViewedPosts?.length === 0}
-  <p class="text-secondary text-center body-15-b py-10">아직 최근 본 포스트가 없어요</p>
-{/if}
-
 {#each $query.me.recentlyViewedPosts as post (post.id)}
   <PostItem $post={post} />
+{:else}
+  <p class="text-secondary text-center body-16-m py-10">최근 본 포스트가 없어요</p>
 {/each}

--- a/apps/penxle.com/src/routes/(default)/me/revenue/(index)/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/revenue/(index)/+page.svelte
@@ -37,37 +37,40 @@
   `);
 </script>
 
-<div class="flex gap-2 justify-end">
-  <!-- <PopupSearch /> -->
-  <div class="flex gap-2 items-end">
-    <Button href="/me/posts" size="md" type="link">내 포스트 관리하기</Button>
+{#if $query.me.revenues.length > 0}
+  <div class="flex gap-2 justify-end">
+    <!-- <PopupSearch /> -->
+    <div class="flex gap-2 items-end">
+      <Button href="/me/posts" size="md" type="link">내 포스트 관리하기</Button>
+    </div>
   </div>
-</div>
-
-<Table class="mt-4 text-left border-separate border-spacing-y-0.5">
-  <TableRow>
-    <TableHead class="w-50%">포스트명</TableHead>
-    <TableHead class="w-30%">수익 발생일</TableHead>
-    <TableHead class="text-right w-20%">수익금</TableHead>
-  </TableRow>
-  {#each $query.me.revenues as revenue (revenue.id)}
+  <Table class="mt-4 text-left border-separate border-spacing-y-0.5">
     <TableRow>
-      <TableData>
-        <div class="flex flex-col gap-1 truncate max-w-97">
-          <div class="text-primary subtitle-16-b truncate sm:subtitle-18-b">
-            {revenue.post?.publishedRevision?.title}
-          </div>
-          <div class="text-secondary body-13-m truncate">{revenue.post?.space.name}</div>
-        </div>
-      </TableData>
-      <TableData class="text-secondary body-14-m">{dayjs(revenue.createdAt).formatAsDateTime()}</TableData>
-      <TableData class="text-right">
-        <div class="flex flex-col">
-          <div class="text-primary subtitle-16-b sm:subtitle-18-b">{comma(revenue.amount)}원</div>
-        </div>
-      </TableData>
+      <TableHead class="w-50%">포스트명</TableHead>
+      <TableHead class="w-30%">수익 발생일</TableHead>
+      <TableHead class="text-right w-20%">수익금</TableHead>
     </TableRow>
-  {/each}
-</Table>
+    {#each $query.me.revenues as revenue (revenue.id)}
+      <TableRow>
+        <TableData>
+          <div class="flex flex-col gap-1 truncate max-w-97">
+            <div class="text-primary subtitle-16-b truncate sm:subtitle-18-b">
+              {revenue.post?.publishedRevision?.title}
+            </div>
+            <div class="text-secondary body-13-m truncate">{revenue.post?.space.name}</div>
+          </div>
+        </TableData>
+        <TableData class="text-secondary body-14-m">{dayjs(revenue.createdAt).formatAsDateTime()}</TableData>
+        <TableData class="text-right">
+          <div class="flex flex-col">
+            <div class="text-primary subtitle-16-b sm:subtitle-18-b">{comma(revenue.amount)}원</div>
+          </div>
+        </TableData>
+      </TableRow>
+    {/each}
+  </Table>
+{:else}
+  <div class="text-center body-16-m py-10 text-secondary">아직 수익 내역이 없어요</div>
+{/if}
 
 <!-- TODO: Pagination -->

--- a/apps/penxle.com/src/routes/(default)/me/revenue/settlement/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/revenue/settlement/+page.svelte
@@ -1,1 +1,1 @@
-<p class="body-14-b text-secondary text-center">준비 중이에요</p>
+<div class="text-center body-16-m py-10 text-secondary">준비 중이에요</div>

--- a/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/MutedSpaceModal.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/MutedSpaceModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import clsx from 'clsx';
   import { fragment, graphql } from '$glitch';
   import { mixpanel } from '$lib/analytics';
   import { Button, Image, Modal } from '$lib/components';
@@ -9,7 +10,7 @@
   export { _user as $user };
   export let open = false;
 
-  let mutedSpaces: typeof $user.mutedSpaces;
+  let mutedSpaces: typeof $user.mutedSpaces | undefined;
   let query = '';
 
   const setSpaces = () => {
@@ -58,12 +59,14 @@
       }
     }
   `);
+
+  $: filteredSpaces = mutedSpaces?.filter((space) => space.name.includes(query));
 </script>
 
 <Modal size="md" bind:open>
   <svelte:fragment slot="title">숨긴 스페이스</svelte:fragment>
 
-  <form class="relative h-11.5 w-full mb-4" on:submit|preventDefault>
+  <form class={clsx('relative h-11.5 w-full mb-4', mutedSpaces?.length === 0 && 'hidden')} on:submit|preventDefault>
     <input
       class="rounded-2.5 h-11.5 w-full bg-primary py-1.75 pr-3.5 pl-11 w-full border border-bg-primary transition focus-within:border-tertiary!"
       type="text"
@@ -74,8 +77,13 @@
     </div>
   </form>
 
-  <ul class="space-y-4 max-h-15rem overflow-y-auto">
-    {#each mutedSpaces.filter((space) => space.name.includes(query)) as space (space.id)}
+  <ul
+    class={clsx(
+      'flex flex-col gap-4 min-h-10rem max-h-15rem overflow-y-auto',
+      filteredSpaces?.length === 0 && 'justify-center',
+    )}
+  >
+    {#each filteredSpaces ?? [] as space (space.id)}
       <li class="flex items-center justify-between">
         <div class="flex gap-2 items-center truncate mr-2">
           <Image class="square-10.5 rounded-lg grow-0 shrink-0 border border-secondary" $image={space.icon} />
@@ -113,6 +121,12 @@
           </Button>
         {/if}
       </li>
+    {:else}
+      <article class="text-secondary body-16-m text-center break-keep">
+        {#if mutedSpaces}
+          {mutedSpaces.length === 0 ? '숨긴 스페이스가 없어요' : '일치하는 검색 결과가 없어요'}
+        {/if}
+      </article>
     {/each}
   </ul>
 </Modal>

--- a/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/MutedTagModal.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/MutedTagModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import clsx from 'clsx';
   import { fragment, graphql } from '$glitch';
   import { mixpanel } from '$lib/analytics';
   import { Button, Modal, Tag } from '$lib/components';
@@ -51,7 +52,7 @@
   <svelte:fragment slot="title">숨긴 태그</svelte:fragment>
   <svelte:fragment slot="subtitle">태그를 선택하면 해제할 수 있어요</svelte:fragment>
 
-  <form class="relative h-11.5 w-full mb-4" on:submit|preventDefault>
+  <form class={clsx('relative h-11.5 w-full mb-4', $user.mutedTags.length === 0 && 'hidden')} on:submit|preventDefault>
     <input
       class="rounded-2.5 h-11.5 w-full bg-primary py-1.75 pr-3.5 pl-11 w-full border border-bg-primary transition focus-within:border-tertiary!"
       type="text"
@@ -62,9 +63,15 @@
     </div>
   </form>
 
-  <ul class="flex flex-wrap gap-2.5 max-h-15rem overflow-y-auto">
+  <ul class="flex flex-wrap gap-2.5 min-h-10rem max-h-15rem overflow-y-auto">
     {#each $user.mutedTags.filter((tag) => tag.name.includes(query)) as tag (tag.id)}
-      <Tag as="label" checked={tags.includes(tag)} on:change={(e) => handleChange(e, tag)}>{tag.name}</Tag>
+      <Tag class="h-fit" as="label" checked={tags.includes(tag)} on:change={(e) => handleChange(e, tag)}>
+        {tag.name}
+      </Tag>
+    {:else}
+      <article class="text-secondary body-16-m self-center m-x-auto break-keep">
+        {$user.mutedTags.length === 0 ? '숨긴 태그가 없어요' : '일치하는 검색 결과가 없어요'}
+      </article>
     {/each}
   </ul>
 


### PR DESCRIPTION
목업에서 아래와 같은 UI가 새로 추가되어 반영했습니다.

<img src="https://github.com/penxle/penxle/assets/5278201/edd73295-5c35-4086-871f-23c010499ed9" width="400rem"/>

## 추가 작업 사항

1. 검색할 목록이 없는 경우 검색 입력 UI를 숨겼습니다.
2. 보관함 페이지의 엠티스테이트 글꼴 스타일이 body-15-b 에서 body-16-m 으로 변경되었음을 확인하여 반영했습니다.