### PR TITLE
검색 코드 리팩토링

### DIFF
--- a/apps/penxle.com/src/lib/const/feed.ts
+++ b/apps/penxle.com/src/lib/const/feed.ts
@@ -2,14 +2,14 @@ import type { ContentFilterCategory } from '$glitch';
 
 export const filterToLocaleString: Record<ContentFilterCategory, string> = {
   ADULT: '성인물',
-  CRIME: '약물, 범죄',
+  CRIME: '약물/범죄',
   CRUELTY: '잔인성',
   GAMBLING: '사행성',
-  GROSSNESS: '벌레, 징그러움',
+  GROSSNESS: '벌레/징그러움',
   HORROR: '공포성',
   INSULT: '언어의 부적절성',
   OTHER: '기타',
-  PHOBIA: '정신질환, 공포증',
+  PHOBIA: '정신질환/공포증',
   TRAUMA: '트라우마',
   VIOLENCE: '폭력성',
 };

--- a/apps/penxle.com/src/routes/(default)/search/(index)/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/(index)/+page.svelte
@@ -68,7 +68,7 @@
   `);
 </script>
 
-<Helmet title="{$page.url.searchParams.get('q')} - 검색" />
+<Helmet title="{$page.url.searchParams.get('q')} - 펜슬 검색결과" />
 
 <div class="body-14-m text-secondary py-1 px-3 rounded-lg bg-surface-primary mt-3 <sm:mx-4">
   🔍 약 {$query.searchPosts.count}개의 검색결과가 있어요!
@@ -83,9 +83,16 @@
 
 <div class="my-9 flex gap-9 <sm:flex-col">
   <div class="grow w-50% <sm:(w-full px-4)">
-    <a class="inline-block title-20-b mb-4" href={`/search/space?q=${$page.url.searchParams.get('q')}`}>
-      스페이스 <i class="i-lc-chevron-right square-6 text-secondary" />
-    </a>
+    <svelte:element
+      this={$query.searchSpaces.length === 0 ? 'h2' : 'a'}
+      class="flex title-20-b mb-4 items-center"
+      href={$query.searchSpaces.length === 0 ? undefined : `/search/space?q=${$page.url.searchParams.get('q')}`}
+    >
+      스페이스
+      {#if $query.searchSpaces.length > 0}
+        <i class="i-lc-chevron-right square-6 text-secondary" />
+      {/if}
+    </svelte:element>
 
     {#if $query.searchSpaces.length === 0}
       <div class="text-secondary body-15-b text-center flex center min-h-50">검색 결과가 없어요</div>
@@ -147,9 +154,16 @@
   </div>
 
   <div class="grow w-50% <sm:(w-full px-4)">
-    <a class="inline-block title-20-b mb-4" href={`/search/tag?q=${$page.url.searchParams.get('q')}`}>
-      태그 <i class="i-lc-chevron-right square-6 text-secondary" />
-    </a>
+    <svelte:element
+      this={$query.searchTags.length === 0 ? 'h2' : 'a'}
+      class="flex title-20-b mb-4 items-center"
+      href={$query.searchTags.length === 0 ? undefined : `/search/tag?q=${$page.url.searchParams.get('q')}`}
+    >
+      태그
+      {#if $query.searchTags.length > 0}
+        <i class="i-lc-chevron-right square-6 text-secondary" />
+      {/if}
+    </svelte:element>
 
     {#if $query.searchTags.length === 0}
       <div class="text-secondary body-15-b text-center flex center min-h-50">검색 결과가 없어요</div>
@@ -164,18 +178,18 @@
 </div>
 
 <div>
-  <a class="title-20-b <sm:px-4" href={`/search/post?q=${$page.url.searchParams.get('q')}`}>
-    포스트 <i class="i-lc-chevron-right square-6 text-secondary" />
-  </a>
+  <svelte:element
+    this={$query.searchPosts.count === 0 ? 'h2' : 'a'}
+    class="title-20-b <sm:px-4"
+    href={$query.searchPosts.count === 0 ? undefined : `/search/post?q=${$page.url.searchParams.get('q')}`}
+  >
+    포스트
+    {#if $query.searchPosts.count > 0}
+      <i class="i-lc-chevron-right square-6 text-secondary" />
+    {/if}
+  </svelte:element>
 
-  <!-- <div class="flex gap-3 my-4">
-    <button class="py-2 px-4 border rounded-8 body-15-sb text-blue-50 bg-blue-10 border-blue-50" type="button">
-      글
-    </button>
-    <button class="py-2 px-4 border rounded-8 body-15-sb border-secondary" type="button">그림</button>
-  </div> -->
-
-  {#if $query.searchPosts.posts.length === 0}
+  {#if $query.searchPosts.count === 0}
     <div class="text-secondary body-15-b text-center flex center min-h-50">검색 결과가 없어요</div>
   {:else}
     <div class="<sm:bg-primary">

--- a/apps/penxle.com/src/routes/(default)/search/post/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/post/+page.svelte
@@ -2,12 +2,11 @@
   import { Helmet } from '@penxle/ui';
   import clsx from 'clsx';
   import qs from 'query-string';
-  import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { graphql } from '$glitch';
   import { PostCard } from '$lib/components';
   import { TabHead, TabHeadItem } from '$lib/components/tab';
-  import type { ContentFilterCategory, OrderByKind } from '$glitch';
+  import { initSearchFilter } from '../util';
 
   $: query = graphql(`
     query SearchPostPage_Query(
@@ -38,57 +37,20 @@
     }
   `);
 
-  let includeTags: string[] = [];
-  let excludeTags: string[] = [];
-  let adultFilter: boolean | null = null;
-  let excludeContentFilters: ContentFilterCategory[] = [];
-  let orderBy: OrderByKind = 'ACCURACY';
-  let currentPage = 1;
-  let pagination = 1;
+  let {
+    includeTags,
+    excludeTags,
+    adultFilter,
+    excludeContentFilters,
+    orderBy,
+    page: currentPage,
+  } = initSearchFilter($page.url.search);
+  let pagination = Math.ceil(currentPage / 10);
 
   $: totalPage = Math.ceil($query.searchPosts.count / 10);
 
-  $: if (qs.parseUrl($page.url.search)?.query) {
-    const parsedURL = qs.parseUrl($page.url.search).query;
-
-    adultFilter =
-      $page.url.searchParams.get('adult') === '' ? null : JSON.parse($page.url.searchParams.get('adult') as string);
-
-    if (parsedURL.include_tags) {
-      if (typeof parsedURL.include_tags === 'string') {
-        includeTags = [parsedURL.include_tags];
-      } else if (typeof parsedURL.include_tags === 'object') {
-        includeTags = parsedURL.include_tags as string[];
-      }
-    }
-
-    if (parsedURL.exclude_tags) {
-      if (typeof parsedURL.exclude_tags === 'string') {
-        excludeTags = [parsedURL.exclude_tags];
-      } else if (typeof parsedURL.exclude_tags === 'object') {
-        excludeTags = parsedURL.exclude_tags as string[];
-      }
-    }
-
-    if (parsedURL.exclude_triggers) {
-      if (typeof parsedURL.exclude_triggers === 'string') {
-        excludeContentFilters = [parsedURL.exclude_triggers] as ContentFilterCategory[];
-      } else if (typeof parsedURL.exclude_triggers === 'object') {
-        excludeContentFilters = parsedURL.exclude_triggers as ContentFilterCategory[];
-      }
-    }
-
-    orderBy = parsedURL.order_by === 'LATEST' ? 'LATEST' : 'ACCURACY';
-
-    currentPage = parsedURL.page ? Number(parsedURL.page) : 1;
-
-    if (parsedURL.page) {
-      pagination = Math.ceil(Number(parsedURL.page) / 10);
-    }
-  }
-
-  const addSearchOption = async () => {
-    const url = qs.stringifyUrl(
+  const updateSearchFilter = () => {
+    const stringifiedURL = qs.stringifyUrl(
       {
         url: '/search/post',
         query: {
@@ -105,11 +67,12 @@
         skipNull: false,
       },
     );
-    await goto(url);
+
+    location.href = stringifiedURL;
   };
 </script>
 
-<Helmet title="{$page.url.searchParams.get('q')} - 검색" />
+<Helmet title="{$page.url.searchParams.get('q')} - 펜슬 검색결과" />
 
 <div class="body-14-m text-secondary py-1 px-3 rounded-lg bg-surface-primary mt-3 <sm:mx-4">
   🔍 약 {$query.searchPosts.count}개의 검색결과가 있어요!
@@ -124,7 +87,7 @@
   <TabHeadItem id={3} href={`/search/tag?q=${$page.url.searchParams.get('q')}`}>태그</TabHeadItem>
 </TabHead>
 
-{#if $query.searchPosts.posts.length === 0}
+{#if $query.searchPosts.count === 0}
   <div class="text-secondary body-15-b text-center flex center min-h-50">검색 결과가 없어요</div>
 {:else}
   <div class="<sm:bg-primary">
@@ -140,7 +103,7 @@
           currentPage = (pagination - 1) * 10;
           pagination -= 1;
 
-          addSearchOption();
+          updateSearchFilter();
         }}
       >
         <i class="i-lc-chevron-left square-3.5" />
@@ -155,7 +118,7 @@
           on:click={() => {
             currentPage = pageNum;
 
-            addSearchOption();
+            updateSearchFilter();
           }}
         >
           {pageNum}
@@ -169,7 +132,7 @@
           pagination = Math.ceil((currentPage + 10) / 10);
           currentPage = (pagination - 1) * 10 + 1;
 
-          addSearchOption();
+          updateSearchFilter();
         }}
       >
         <i class="i-lc-chevron-right square-3.5" />

--- a/apps/penxle.com/src/routes/(default)/search/post/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/search/post/+page.ts
@@ -1,47 +1,10 @@
-import qs from 'query-string';
-import type { ContentFilterCategory, OrderByKind } from '$glitch';
+import { initSearchFilter } from '../util';
 import type { PageLoadEvent } from './$types';
 
 export const _SearchPostPage_QueryVariables = (event: PageLoadEvent) => {
-  let includeTags: string[] = [];
-  let excludeTags: string[] = [];
-  const adultFilter =
-    event.url.searchParams.get('adult') === '' ? null : JSON.parse(event.url.searchParams.get('adult') as string);
-  let excludeContentFilters: ContentFilterCategory[] = [];
-  let orderBy: OrderByKind = 'ACCURACY';
-  let currentPage = 1;
-
-  if (qs.parseUrl(event.url.search)?.query) {
-    const parsedURL = qs.parseUrl(event.url.search).query;
-
-    if (parsedURL.include_tags) {
-      if (typeof parsedURL.include_tags === 'string') {
-        includeTags = [parsedURL.include_tags];
-      } else if (typeof parsedURL.include_tags === 'object') {
-        includeTags = parsedURL.include_tags as string[];
-      }
-    }
-
-    if (parsedURL.exclude_tags) {
-      if (typeof parsedURL.exclude_tags === 'string') {
-        excludeTags = [parsedURL.exclude_tags];
-      } else if (typeof parsedURL.exclude_tags === 'object') {
-        excludeTags = parsedURL.exclude_tags as string[];
-      }
-    }
-
-    if (parsedURL.exclude_triggers) {
-      if (typeof parsedURL.exclude_triggers === 'string') {
-        excludeContentFilters = [parsedURL.exclude_triggers] as ContentFilterCategory[];
-      } else if (typeof parsedURL.exclude_triggers === 'object') {
-        excludeContentFilters = parsedURL.exclude_triggers as ContentFilterCategory[];
-      }
-    }
-
-    orderBy = parsedURL.order_by === 'LATEST' ? 'LATEST' : 'ACCURACY';
-
-    currentPage = parsedURL.page ? Number(parsedURL.page) : 1;
-  }
+  const { includeTags, excludeTags, adultFilter, excludeContentFilters, orderBy, page } = initSearchFilter(
+    event.url.search,
+  );
 
   return {
     query: event.url.searchParams.get('q'),
@@ -50,6 +13,6 @@ export const _SearchPostPage_QueryVariables = (event: PageLoadEvent) => {
     adultFilter,
     excludeContentFilters,
     orderBy,
-    page: currentPage,
+    page,
   };
 };

--- a/apps/penxle.com/src/routes/(default)/search/space/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/space/+page.svelte
@@ -54,7 +54,7 @@
   `);
 </script>
 
-<Helmet title="{$page.url.searchParams.get('q')} - 검색" />
+<Helmet title="{$page.url.searchParams.get('q')} - 펜슬 검색결과" />
 
 <div class="body-14-m text-secondary py-1 px-3 rounded-lg bg-surface-primary mt-3 <sm:mx-4">
   🔍 약 {$query.searchSpaces.length ?? 0}개의 검색결과가 있어요!

--- a/apps/penxle.com/src/routes/(default)/search/tag/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/tag/+page.svelte
@@ -15,7 +15,7 @@
   `);
 </script>
 
-<Helmet title="{$page.url.searchParams.get('q')} - 검색" />
+<Helmet title="{$page.url.searchParams.get('q')} - 펜슬 검색결과" />
 
 <div class="body-14-m text-secondary py-1 px-3 rounded-lg bg-surface-primary mt-3 <sm:mx-4">
   🔍 약 {$query.searchTags.length ?? 0}개의 검색결과가 있어요!

--- a/apps/penxle.com/src/routes/(default)/search/util.ts
+++ b/apps/penxle.com/src/routes/(default)/search/util.ts
@@ -1,0 +1,45 @@
+import qs from 'query-string';
+import type { ContentFilterCategory, OrderByKind } from '$glitch';
+
+export const initSearchFilter = (param: string) => {
+  let includeTags: string[] = [];
+  let excludeTags: string[] = [];
+  let adultFilter: boolean | null = null;
+  let excludeContentFilters: ContentFilterCategory[] = [];
+  let orderBy: OrderByKind = 'ACCURACY';
+  let page = 1;
+
+  const parsedURL = qs.parseUrl(param).query;
+
+  if (parsedURL.include_tags) {
+    if (typeof parsedURL.include_tags === 'string') {
+      includeTags = [parsedURL.include_tags];
+    } else if (typeof parsedURL.include_tags === 'object') {
+      includeTags = parsedURL.include_tags as string[];
+    }
+  }
+
+  if (parsedURL.exclude_tags) {
+    if (typeof parsedURL.exclude_tags === 'string') {
+      excludeTags = [parsedURL.exclude_tags];
+    } else if (typeof parsedURL.exclude_tags === 'object') {
+      excludeTags = parsedURL.exclude_tags as string[];
+    }
+  }
+
+  adultFilter = parsedURL.adult ? JSON.parse(parsedURL.adult.toString()) : null;
+
+  if (parsedURL.exclude_triggers) {
+    if (typeof parsedURL.exclude_triggers === 'string') {
+      excludeContentFilters = [parsedURL.exclude_triggers] as ContentFilterCategory[];
+    } else if (typeof parsedURL.exclude_triggers === 'object') {
+      excludeContentFilters = parsedURL.exclude_triggers as ContentFilterCategory[];
+    }
+  }
+
+  orderBy = parsedURL.order_by === 'LATEST' ? 'LATEST' : 'ACCURACY';
+
+  page = parsedURL.page ? Number(parsedURL.page) : 1;
+
+  return { includeTags, excludeTags, adultFilter, excludeContentFilters, orderBy, page };
+};


### PR DESCRIPTION
- 검색 필터 초기화하는 코드 함수로 합침
- 페이지 title `검색어 - 펜슬 검색결과`로 수정
- 포함 태그, 제외 태그 중복으로 입력할 경우 페이지 이동하지 않도록 수정
- 검색 결과가 없을 경우 해당 탭으로 이동하는 버튼 없앰
- 기타 변수명 수정