### PR TITLE
컬렉션이 없는 포스트를 삭제할 때 발생하는 오류 긴급 수정

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
@@ -1237,13 +1237,16 @@ export const postSchema = defineSchema((builder) => {
           }
         }
 
+        await db.spaceCollectionPost.deleteMany({
+          where: { postId: post.id },
+        });
+
         return await db.post.update({
           ...query,
           where: { id: post.id },
           data: {
             state: 'DELETED',
             publishedRevision: post.publishedRevisionId ? { update: { kind: 'ARCHIVED' } } : undefined,
-            collectionPost: { delete: true },
           },
         });
       },


### PR DESCRIPTION
컬렉션을 그냥 delete 시도해서 컬렉션이 없을 시에는 오류 발생 -> deleteMany로 삭제하도록 변경