### PR TITLE
모바일 검색결과에 최신순 정렬 메뉴 추가

### DIFF
--- a/apps/penxle.com/src/routes/(default)/search/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/+layout.svelte
@@ -244,12 +244,12 @@
     <div class="flex items-center justify-between w-full <sm:px-4">
       <h1 class="title-24-eb grow">'{$page.url.searchParams.get('q')}' 검색결과</h1>
 
-      <Button class="sm:hidden" color="tertiary" size="md" variant="outlined" on:click={() => (filterOpen = true)}>
+      <Button class="sm:hidden mx-1" color="tertiary" size="md" variant="outlined" on:click={() => (filterOpen = true)}>
         <i class="i-lc-list-filter square-5" />
         필터
       </Button>
 
-      <Menu class="<sm:hidden" placement="bottom">
+      <Menu placement="bottom">
         <Button slot="value" color="tertiary" size="md" variant="outlined">
           {orderBy === 'LATEST' ? '최신순' : '정확도순'}
           <i class="i-lc-chevron-down square-5" />


### PR DESCRIPTION
ui상 누락되어있던 정렬 메뉴를 추가했습니다.

<img width="447" alt="image" src="https://github.com/penxle/penxle/assets/76952602/39e11063-13d2-421f-a57b-ed7e018b56b1">