### PR TITLE
에디터에서 연회색 사용이 안되는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/routes/editor/formats.svelte
+++ b/apps/penxle.com/src/routes/editor/formats.svelte
@@ -8,7 +8,7 @@
   export const colors = [
     { label: '검정색', value: null },
     { label: '회색', value: 'text-post-gray' },
-    { label: '연회색', value: 'text-post-gray2' },
+    { label: '연회색', value: 'text-post-lightgray' },
     { label: '빨간색', value: 'text-post-red' },
     { label: '파란색', value: 'text-post-blue' },
     { label: '갈색', value: 'text-post-brown' },

--- a/apps/penxle.com/src/styles/prose.css
+++ b/apps/penxle.com/src/styles/prose.css
@@ -137,8 +137,9 @@
   }
 
   & [data-text-color='text-gray-40'],
-  [data-text-color='text-post-gray2'] {
-    --uno: text-post-gray2;
+  & [data-text-color='text-post-gray2'],
+  & [data-text-color='text-post-lightgray'] {
+    --uno: color-post-lightgray;
   }
 
   & [data-text-color='text-red-60'],

--- a/packages/lib/src/unocss/colors.ts
+++ b/packages/lib/src/unocss/colors.ts
@@ -150,7 +150,7 @@ export const designColors = {
   },
   post: {
     gray: shadedColors.gray[50],
-    gray2: shadedColors.gray[40],
+    lightgray: shadedColors.gray[40],
     red: '#EA4335',
     blue: '#4285F4',
     brown: shadedColors.orange[60],


### PR DESCRIPTION
색상 토큰 명에 숫자가 포함된 경우 인식이 되지 않아 이름을 post-gray2 에서 post-lightgray 로 변경하여 해결했습니다.