### PR TITLE
ElasticSearch 토크나이저 최적화

### DIFF
--- a/apps/penxle.com/scripts/create-search-index.js
+++ b/apps/penxle.com/scripts/create-search-index.js
@@ -72,6 +72,7 @@ await createIndex('posts', {
       tokenizer: {
         ngram_23: {
           type: 'ngram',
+          token_chars: ['letter', 'digit'],
           min_gram: 2,
           max_gram: 3,
         },
@@ -113,6 +114,7 @@ await createIndex('spaces', {
       tokenizer: {
         ngram_23: {
           type: 'ngram',
+          token_chars: ['letter', 'digit'],
           min_gram: 2,
           max_gram: 3,
         },
@@ -142,6 +144,7 @@ await createIndex('tags', {
         tokenizer: {
           ngram_23: {
             type: 'ngram',
+            token_chars: ['letter', 'digit'],
             min_gram: 2,
             max_gram: 3,
           },


### PR DESCRIPTION
문자와 숫자가 아닌 글자들(공백, 특수기호 등등)은 ngram에 포함하지 않도록 수정
> ElasticSearch 인덱스 재생성(create-search-index.js) & reindex가 필요해요! 