### PR TITLE
유저 탈퇴시 UserSession 전체 삭제 / 세션 가져올 때 유저 state 체크

### DIFF
--- a/apps/penxle.com/src/lib/server/context.ts
+++ b/apps/penxle.com/src/lib/server/context.ts
@@ -74,7 +74,12 @@ export const createContext = async (event: RequestEvent): Promise<Context> => {
 
     if (sessionId) {
       const session = await db.userSession.findUnique({
-        where: { id: sessionId },
+        where: {
+          id: sessionId,
+          user: {
+            state: 'ACTIVE',
+          },
+        },
       });
 
       if (session) {

--- a/apps/penxle.com/src/lib/server/graphql/schemas/user.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/user.ts
@@ -923,6 +923,9 @@ export const userSchema = defineSchema((builder) => {
           where: { id: context.session.userId },
           data: {
             state: 'INACTIVE',
+            sessions: {
+              deleteMany: {},
+            },
             singleSignOns: {
               deleteMany: {},
             },


### PR DESCRIPTION
- 유저 탈퇴시에 세션이 계속 유지되고 있어 해당 문제 수정함
- 유저 세션 가져올 때 유저 `state`가 `ACTIVE`인지 체크하고 있지 않아 해당 문제 수정함
