### PR TITLE
helm 차트 배포할 때 Release 대신 Chart 리소스 이용하도록 함

### DIFF
--- a/apps/bedrock/pulumi/k8s/kube-system/argo-rollouts.ts
+++ b/apps/bedrock/pulumi/k8s/kube-system/argo-rollouts.ts
@@ -1,11 +1,9 @@
 import * as k8s from '@pulumi/kubernetes';
 
-new k8s.helm.v3.Release('argo-rollouts', {
-  name: 'argo-rollouts',
-  namespace: 'kube-system',
-
+new k8s.helm.v3.Chart('argo-rollouts', {
   chart: 'argo-rollouts',
-  repositoryOpts: {
+  namespace: 'kube-system',
+  fetchOpts: {
     repo: 'https://argoproj.github.io/argo-helm',
   },
 

--- a/apps/bedrock/pulumi/k8s/kube-system/aws-load-balancer-controller.ts
+++ b/apps/bedrock/pulumi/k8s/kube-system/aws-load-balancer-controller.ts
@@ -247,28 +247,23 @@ const serviceAccount = new k8s.core.v1.ServiceAccount('aws-load-balancer-control
   },
 });
 
-new k8s.helm.v3.Release(
-  'aws-load-balancer-controller',
-  {
-    name: 'aws-load-balancer-controller',
-    namespace: 'kube-system',
+new k8s.helm.v3.Chart('aws-load-balancer-controller', {
+  chart: 'aws-load-balancer-controller',
+  namespace: 'kube-system',
+  fetchOpts: { repo: 'https://aws.github.io/eks-charts' },
 
-    chart: 'aws-load-balancer-controller',
-    repositoryOpts: { repo: 'https://aws.github.io/eks-charts' },
+  values: {
+    region: 'ap-northeast-2',
+    vpcId: vpc.id,
 
-    values: {
-      region: 'ap-northeast-2',
-      vpcId: vpc.id,
-
-      clusterName: cluster.name,
-      serviceAccount: {
-        create: false,
-        name: serviceAccount.metadata.name,
-      },
-
-      enableBackendSecurityGroup: false,
-      defaultSSLPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06',
+    clusterName: cluster.name,
+    serviceAccount: {
+      create: false,
+      name: serviceAccount.metadata.name,
     },
+
+    enableCertManager: true,
+    enableBackendSecurityGroup: false,
+    defaultSSLPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06',
   },
-  { ignoreChanges: ['checksum'] },
-);
+});

--- a/apps/bedrock/pulumi/k8s/kube-system/cert-manager.ts
+++ b/apps/bedrock/pulumi/k8s/kube-system/cert-manager.ts
@@ -1,0 +1,17 @@
+import * as k8s from '@pulumi/kubernetes';
+
+new k8s.helm.v3.Chart('cert-manager', {
+  chart: 'cert-manager',
+  namespace: 'kube-system',
+  fetchOpts: {
+    repo: 'https://charts.jetstack.io',
+  },
+
+  values: {
+    installCRDs: true,
+
+    startupapicheck: {
+      enabled: false,
+    },
+  },
+});

--- a/apps/bedrock/pulumi/k8s/kube-system/external-dns.ts
+++ b/apps/bedrock/pulumi/k8s/kube-system/external-dns.ts
@@ -51,12 +51,10 @@ const serviceAccount = new k8s.core.v1.ServiceAccount('external-dns', {
   },
 });
 
-new k8s.helm.v3.Release('external-dns', {
-  name: 'external-dns',
-  namespace: 'kube-system',
-
+new k8s.helm.v3.Chart('external-dns', {
   chart: 'external-dns',
-  repositoryOpts: { repo: 'https://kubernetes-sigs.github.io/external-dns' },
+  namespace: 'kube-system',
+  fetchOpts: { repo: 'https://kubernetes-sigs.github.io/external-dns' },
 
   values: {
     serviceAccount: {

--- a/apps/bedrock/pulumi/k8s/kube-system/external-secrets.ts
+++ b/apps/bedrock/pulumi/k8s/kube-system/external-secrets.ts
@@ -1,11 +1,9 @@
 import * as k8s from '@pulumi/kubernetes';
 
-new k8s.helm.v3.Release('external-secrets', {
-  name: 'external-secrets',
-  namespace: 'kube-system',
-
+new k8s.helm.v3.Chart('external-secrets', {
   chart: 'external-secrets',
-  repositoryOpts: {
+  namespace: 'kube-system',
+  fetchOpts: {
     repo: 'https://charts.external-secrets.io',
   },
 });

--- a/apps/bedrock/pulumi/k8s/kube-system/metrics-server.ts
+++ b/apps/bedrock/pulumi/k8s/kube-system/metrics-server.ts
@@ -1,9 +1,7 @@
 import * as k8s from '@pulumi/kubernetes';
 
-new k8s.helm.v3.Release('metrics-server', {
-  name: 'metrics-server',
-  namespace: 'kube-system',
-
+new k8s.helm.v3.Chart('metrics-server', {
   chart: 'metrics-server',
-  repositoryOpts: { repo: 'https://kubernetes-sigs.github.io/metrics-server' },
+  namespace: 'kube-system',
+  fetchOpts: { repo: 'https://kubernetes-sigs.github.io/metrics-server' },
 });

--- a/apps/bedrock/pulumi/k8s/monitoring/datadog.ts
+++ b/apps/bedrock/pulumi/k8s/monitoring/datadog.ts
@@ -2,12 +2,12 @@ import * as penxle from '@penxle/pulumi/components';
 import * as k8s from '@pulumi/kubernetes';
 import { namespace } from '$k8s/monitoring';
 
-new k8s.helm.v3.Release('datadog-operator', {
-  name: 'datadog-operator',
-  namespace: namespace.metadata.name,
-
+new k8s.helm.v3.Chart('datadog-operator', {
   chart: 'datadog-operator',
-  repositoryOpts: { repo: 'https://helm.datadoghq.com' },
+  namespace: namespace.metadata.name,
+  fetchOpts: {
+    repo: 'https://helm.datadoghq.com',
+  },
 });
 
 const secret = new penxle.DopplerSecret('datadog', {
@@ -33,6 +33,7 @@ new k8s.apiextensions.CustomResource('datadog', {
     global: {
       site: 'ap1.datadoghq.com',
       clusterName: 'eks',
+
       credentials: {
         appSecret: {
           secretName: secret.metadata.name,
@@ -44,16 +45,20 @@ new k8s.apiextensions.CustomResource('datadog', {
         },
       },
     },
+
     features: {
       apm: {
         enabled: true,
       },
+
       clusterChecks: {
         useClusterChecksRunners: true,
       },
+
       prometheusScrape: {
         enabled: true,
       },
+
       otlp: {
         receiver: {
           protocols: {


### PR DESCRIPTION
`Release` 리소스와는 다르게 `Chart` 리소스는 차트의 하위 리소스들을 pulumi가 직접 관리해서 diff를 더 잘 볼 수 있음!
