### PR TITLE
모든 pulumi github action에 refresh/upsert 플래그 추가

### DIFF
--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -101,6 +101,7 @@ jobs:
           command: up
           work-dir: apps/${{ matrix.app }}
           stack-name: penxle/pr-${{ github.event.pull_request.number }}
+          refresh: true
           upsert: true
           config-map: |
             { "penxle:image.digest": { "value": "${{ steps.build.outputs.digest }}" } }

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -103,6 +103,8 @@ jobs:
           command: up
           work-dir: apps/${{ matrix.app }}
           stack-name: penxle/prod
+          refresh: true
+          upsert: true
           config-map: |
             { "penxle:image.digest": { "value": "${{ steps.build.outputs.digest }}" } }
         env:

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -101,6 +101,8 @@ jobs:
           command: up
           work-dir: apps/${{ matrix.app }}
           stack-name: penxle/staging
+          refresh: true
+          upsert: true
           config-map: |
             { "penxle:image.digest": { "value": "${{ steps.build.outputs.digest }}" } }
         env:

--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -51,6 +51,7 @@ jobs:
           command: destroy
           work-dir: apps/${{ matrix.app }}
           stack-name: penxle/pr-${{ github.event.pull_request.number }}
+          refresh: true
           remove: true
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}


### PR DESCRIPTION
stack drift 복구를 위해 github actions로 돌아가는 workflow에서 pulumi action을 실행할 때 `refresh` 및 `upsert` 동작을 수행하도록 플래그 추가함
