### PR TITLE
포스트 갯수보다 페이지네이션이 더 많이 생기는 오류 수정

### DIFF
--- a/apps/penxle.com/src/lib/components/Pagination.svelte
+++ b/apps/penxle.com/src/lib/components/Pagination.svelte
@@ -1,32 +1,33 @@
 <script lang="ts">
-  export let initialIndex: number;
-  let currentIndex = initialIndex;
-  export let count: number;
-  export let itemsPerPage = 10;
+  export let initialPage: number;
+  export let totalItems: number;
+  export let displayPage = 10;
   export let onChange: (page: number) => void;
 
-  $: currentPage = Math.ceil(currentIndex / itemsPerPage);
-  $: remainingItems = count - (currentPage - 1) * itemsPerPage;
+  let currentPage = initialPage;
 
-  $: range = [...Array.from({ length: remainingItems < itemsPerPage ? remainingItems : itemsPerPage }).keys()].map(
-    (index) => (currentPage - 1) * itemsPerPage + (index + 1),
+  $: maxPage = Math.ceil(totalItems / displayPage);
+  $: currentPageGroup = Math.ceil(currentPage / displayPage);
+  $: totalPageGroup = Math.ceil(maxPage / 10);
+  $: remainingItems = maxPage - (currentPageGroup - 1) * displayPage;
+
+  $: range = [...Array.from({ length: remainingItems < displayPage ? remainingItems : displayPage }).keys()].map(
+    (index) => (currentPageGroup - 1) * displayPage + (index + 1),
   );
 
-  $: maxPage = Math.ceil(count / itemsPerPage);
-
-  $: if (initialIndex !== currentIndex) {
-    onChange(currentIndex);
+  $: if (initialPage !== currentPage) {
+    onChange(currentPage);
   }
 </script>
 
 <div class="flex center mt-9 gap-1 pb-4" role="group">
   <button
     class="square-7 flex center disabled:(text-disabled cursor-not-allowed)"
-    disabled={currentIndex <= itemsPerPage}
+    disabled={currentPage <= displayPage}
     type="button"
     on:click={() => {
-      const previousPage = currentPage - 1;
-      currentIndex = previousPage * itemsPerPage;
+      const previousPage = currentPageGroup - 1;
+      currentPage = previousPage * displayPage;
     }}
   >
     <i class="i-lc-chevron-left square-3.5" aria-label="왼쪽 화살표 아이콘" />
@@ -34,10 +35,10 @@
   {#each range as index (index)}
     <button
       class="square-8 p-2 rounded-lg border border-alphagray-10 flex center body-13-b transition bg-cardprimary hover:(bg-gray-90 text-darkprimary) focus-visible:(bg-gray-90 text-darkprimary) aria-pressed:(bg-gray-90 text-darkprimary)"
-      aria-pressed={currentIndex === index}
+      aria-pressed={currentPage === index}
       type="button"
       on:click={() => {
-        currentIndex = index;
+        currentPage = index;
       }}
     >
       {index}
@@ -45,11 +46,11 @@
   {/each}
   <button
     class="square-7 flex center disabled:(text-disabled cursor-not-allowed)"
-    disabled={currentPage === maxPage}
+    disabled={maxPage <= displayPage || currentPageGroup === totalPageGroup}
     type="button"
     on:click={() => {
-      const nextPage = currentPage + 1;
-      currentIndex = nextPage * itemsPerPage - (itemsPerPage - 1);
+      const nextPage = currentPageGroup + 1;
+      currentPage = nextPage * displayPage - (displayPage - 1);
     }}
   >
     <i class="i-lc-chevron-right square-3.5" aria-label="오른쪽 화살표 아이콘" />

--- a/apps/penxle.com/src/routes/(default)/search/post/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/post/+page.svelte
@@ -42,7 +42,7 @@
     adultFilter,
     excludeContentFilters,
     orderBy,
-    page: initialIndex,
+    page: initialPage,
   } = initSearchFilter($page.url.search);
 
   const updateSearchFilter = (currentPage: number) => {
@@ -90,6 +90,6 @@
     {#each $query.searchPosts.posts as post (post.id)}
       <PostCard class="mt-4 first:mt-0" $post={post} />
     {/each}
-    <Pagination count={$query.searchPosts.count} {initialIndex} onChange={updateSearchFilter} />
+    <Pagination {initialPage} onChange={updateSearchFilter} totalItems={$query.searchPosts.count} />
   </div>
 {/if}


### PR DESCRIPTION
- 페이지 계산 로직의 오류로 검색 결과의 포스트 갯수보다 페이지가 더 많이 생기는 문제 수정
- 기타 변수명 수정

<img width="500" alt="image" src="https://github.com/penxle/penxle/assets/76952602/9cfa3c97-ccdc-4030-81fe-c62f33605c72">