### PR TITLE
TabHeadItem 에서 Trailing Slash 를 색인하지 못하는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/tab/TabHeadItem.svelte
+++ b/apps/penxle.com/src/lib/components/tab/TabHeadItem.svelte
@@ -6,14 +6,17 @@
   export let id: number;
   export let activeTabValue: number | undefined = undefined;
   export let variant: 'primary' | 'secondary' = getContext('variant');
-  export let href: string | undefined = undefined;
+  export let pathname: string | undefined = undefined;
 
   let _class: string | undefined = undefined;
   export { _class as class };
 
   let element: 'a' | 'button';
-  $: element = href ? 'a' : 'button';
-  $: props = element === 'a' ? { href } : { type: 'button' };
+  $: element = pathname ? 'a' : 'button';
+  $: props = element === 'a' ? { href: pathname + $page.url.search } : { type: 'button' };
+
+  $: pathnameRegex = pathname ? new RegExp(`^${pathname}/?$`) : null;
+  $: selected = activeTabValue === id || pathnameRegex?.test($page.url.pathname);
 </script>
 
 <li class="grow sm:grow-0" role="presentation">
@@ -22,29 +25,13 @@
     id="{id}-tabhead"
     class={clsx(
       'block w-full grow sm:grow-0',
-      variant === 'primary' && 'title-20-eb border-b-10 leading-5 transition hover:(text-black border-brand-50)',
       variant === 'primary' &&
-        (activeTabValue === id || decodeURI($page.url.pathname) === href) &&
-        'text-black border-brand-50',
-      variant === 'primary' &&
-        activeTabValue !== id &&
-        decodeURI($page.url.pathname) !== href &&
-        'border-transparent text-disabled',
+        'title-20-eb border-b-10 leading-5 transition border-transparent text-disabled hover:(text-black border-brand-50) aria-selected:(text-black border-brand-50)',
       variant === 'secondary' &&
-        'bg-white p-3 text-center sm:bg-transparent transition border-b-2 border-white hover:(text-black! border-black!)',
-      variant === 'secondary' &&
-        (activeTabValue === id ||
-          ($page.url.search === ''
-            ? decodeURI($page.url.pathname)
-            : decodeURI($page.url.pathname + $page.url.search)) === href) &&
-        'text-black body-16-b border-b-2 border-black!',
-      variant === 'secondary' &&
-        activeTabValue !== id &&
-        ($page.url.search === '' ? decodeURI($page.url.pathname) : decodeURI($page.url.pathname + $page.url.search)) !==
-          href &&
-        'border-secondary body-16-sb text-disabled',
+        'bg-white p-3 text-center sm:bg-transparent transition border-b-2 border-white body-16-sb text-disabled hover:(text-black border-black) aria-selected:(text-black font-bold border-b-2 border-black)',
       _class,
     )}
+    aria-selected={selected}
     role="tab"
     tabindex="-1"
     on:click

--- a/apps/penxle.com/src/routes/(default)/(feed)/+layout@.svelte
+++ b/apps/penxle.com/src/routes/(default)/(feed)/+layout@.svelte
@@ -90,10 +90,10 @@
     <div class="flex flex-col w-full truncate">
       <div class="<sm:(pt-6 px-4 bg-cardprimary border-b border-secondary sticky top-0)">
         <TabHead class="gap-3! <sm:(bg-cardprimary pb-4) sm:(mb-8 mt-3)">
-          <TabHeadItem id={1} class="title-20-b! leading-3!" href="/">추천 게시물</TabHeadItem>
+          <TabHeadItem id={1} class="title-20-b! leading-3!" pathname="/">추천 게시물</TabHeadItem>
           {#if $query.me}
-            <TabHeadItem id={2} class="title-20-b! leading-3!" href="/followTags">관심 태그</TabHeadItem>
-            <TabHeadItem id={3} class="title-20-b! leading-3!" href="/followSpaces">관심 스페이스</TabHeadItem>
+            <TabHeadItem id={2} class="title-20-b! leading-3!" pathname="/followTags">관심 태그</TabHeadItem>
+            <TabHeadItem id={3} class="title-20-b! leading-3!" pathname="/followSpaces">관심 스페이스</TabHeadItem>
           {:else}
             <button
               class="title-20-b w-fit border-b-10 leading-3 border-transparent transition hover:border-brand-50"

--- a/apps/penxle.com/src/routes/(default)/[space]/(space)/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/(space)/+layout.svelte
@@ -306,13 +306,13 @@
   </div>
 
   <TabHead class="w-full max-w-200 border-none" variant="secondary">
-    <TabHeadItem id={1} href="/{$query.space.slug}">
+    <TabHeadItem id={1} pathname="/{$query.space.slug}">
       <span>홈</span>
     </TabHeadItem>
-    <TabHeadItem id={2} href="/{$query.space.slug}/collections">
+    <TabHeadItem id={2} pathname="/{$query.space.slug}/collections">
       <span>컬렉션</span>
     </TabHeadItem>
-    <TabHeadItem id={3} href="/{$query.space.slug}/about">
+    <TabHeadItem id={3} pathname="/{$query.space.slug}/about">
       <span>소개</span>
     </TabHeadItem>
   </TabHead>

--- a/apps/penxle.com/src/routes/(default)/[space]/dashboard/posts/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/dashboard/posts/+layout.svelte
@@ -13,8 +13,8 @@
   <h1 class="title-20-eb">포스트 관리</h1>
   <div>
     <TabHead class="border-none" variant="secondary">
-      <TabHeadItem id={0} href="/{$page.params.space}/dashboard/posts">포스트</TabHeadItem>
-      <TabHeadItem id={1} href="/{$page.params.space}/dashboard/posts/collections">컬렉션</TabHeadItem>
+      <TabHeadItem id={0} pathname="/{$page.params.space}/dashboard/posts">포스트</TabHeadItem>
+      <TabHeadItem id={1} pathname="/{$page.params.space}/dashboard/posts/collections">컬렉션</TabHeadItem>
     </TabHead>
     <hr class="w-full border-color-alphagray-10" />
   </div>

--- a/apps/penxle.com/src/routes/(default)/me/cabinets/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/+layout.svelte
@@ -119,9 +119,9 @@
     <h2 class="title-20-b px-4 sm:px-8">포스트 목록</h2>
 
     <TabHead class="w-full px-4 mt-4 mb-6 sm:px-8" variant="secondary">
-      <TabHeadItem id={1} href="/me/cabinets">좋아요</TabHeadItem>
-      <TabHeadItem id={2} href="/me/cabinets/recent">최근</TabHeadItem>
-      <TabHeadItem id={3} href="/me/cabinets/purchased">구매</TabHeadItem>
+      <TabHeadItem id={1} pathname="/me/cabinets">좋아요</TabHeadItem>
+      <TabHeadItem id={2} pathname="/me/cabinets/recent">최근</TabHeadItem>
+      <TabHeadItem id={3} pathname="/me/cabinets/purchased">구매</TabHeadItem>
     </TabHead>
 
     <div class="px-4 sm:px-8">

--- a/apps/penxle.com/src/routes/(default)/me/revenue/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/revenue/+layout.svelte
@@ -63,8 +63,8 @@
 <div class="mt-6 flex flex-col gap-4 py-8 bg-white border border-secondary rounded-2xl <sm:(mx-5 mb-4)">
   <h2 class="title-20-b px-6">수익/정산 내역</h2>
   <TabHead class="w-full px-6" variant="secondary">
-    <TabHeadItem id={1} href="/me/revenue">수익</TabHeadItem>
-    <TabHeadItem id={2} href="/me/revenue/settlement">정산</TabHeadItem>
+    <TabHeadItem id={1} pathname="/me/revenue">수익</TabHeadItem>
+    <TabHeadItem id={2} pathname="/me/revenue/settlement">정산</TabHeadItem>
   </TabHead>
   <div class="px-6">
     <slot />

--- a/apps/penxle.com/src/routes/(default)/me/settings/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/settings/+layout.svelte
@@ -7,9 +7,9 @@
   <h2 class="title-20-eb mt-8 mb-4 <sm:hidden px-8">설정</h2>
 
   <TabHead class="w-full sm:px-8" variant="secondary">
-    <TabHeadItem id={1} href="/me/settings">계정</TabHeadItem>
-    <TabHeadItem id={2} href="/me/settings/notifications">알림</TabHeadItem>
-    <TabHeadItem id={3} href="/me/settings/contentfilters">필터링</TabHeadItem>
+    <TabHeadItem id={1} pathname="/me/settings">계정</TabHeadItem>
+    <TabHeadItem id={2} pathname="/me/settings/notifications">알림</TabHeadItem>
+    <TabHeadItem id={3} pathname="/me/settings/contentfilters">필터링</TabHeadItem>
   </TabHead>
 
   <slot />

--- a/apps/penxle.com/src/routes/(default)/search/(index)/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/(index)/+page.svelte
@@ -75,10 +75,10 @@
 </div>
 
 <TabHead class="mt-9 mb-4 w-full <sm:(sticky top-61px z-1)" variant="secondary">
-  <TabHeadItem id={0} href={`/search?q=${$page.url.searchParams.get('q')}`}>전체</TabHeadItem>
-  <TabHeadItem id={1} href={`/search/post?q=${$page.url.searchParams.get('q')}`}>포스트</TabHeadItem>
-  <TabHeadItem id={2} href={`/search/space?q=${$page.url.searchParams.get('q')}`}>스페이스</TabHeadItem>
-  <TabHeadItem id={3} href={`/search/tag?q=${$page.url.searchParams.get('q')}`}>태그</TabHeadItem>
+  <TabHeadItem id={0} pathname="/search">전체</TabHeadItem>
+  <TabHeadItem id={1} pathname="/search/post">포스트</TabHeadItem>
+  <TabHeadItem id={2} pathname="/search/space">스페이스</TabHeadItem>
+  <TabHeadItem id={3} pathname="/search/tag">태그</TabHeadItem>
 </TabHead>
 
 <div class="my-9 flex gap-9 <sm:flex-col">

--- a/apps/penxle.com/src/routes/(default)/search/post/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/post/+page.svelte
@@ -75,12 +75,10 @@
 </div>
 
 <TabHead class="mt-9 w-full <sm:(sticky top-61px z-1) sm:mb-4" variant="secondary">
-  <TabHeadItem id={0} href={`/search?q=${$page.url.searchParams.get('q')}`}>전체</TabHeadItem>
-  <TabHeadItem id={1} class="text-black! border-black!" href={`/search/post?q=${$page.url.searchParams.get('q')}`}>
-    포스트
-  </TabHeadItem>
-  <TabHeadItem id={2} href={`/search/space?q=${$page.url.searchParams.get('q')}`}>스페이스</TabHeadItem>
-  <TabHeadItem id={3} href={`/search/tag?q=${$page.url.searchParams.get('q')}`}>태그</TabHeadItem>
+  <TabHeadItem id={0} pathname="/search">전체</TabHeadItem>
+  <TabHeadItem id={1} class="text-black! border-black!" pathname="/search/post">포스트</TabHeadItem>
+  <TabHeadItem id={2} pathname="/search/space">스페이스</TabHeadItem>
+  <TabHeadItem id={3} pathname="/search/tag">태그</TabHeadItem>
 </TabHead>
 
 {#if $query.searchPosts.count === 0}

--- a/apps/penxle.com/src/routes/(default)/search/space/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/space/+page.svelte
@@ -61,10 +61,10 @@
 </div>
 
 <TabHead class="mt-9 mb-4 w-full <sm:(sticky top-61px z-1)" variant="secondary">
-  <TabHeadItem id={0} href={`/search?q=${$page.url.searchParams.get('q')}`}>전체</TabHeadItem>
-  <TabHeadItem id={1} href={`/search/post?q=${$page.url.searchParams.get('q')}`}>포스트</TabHeadItem>
-  <TabHeadItem id={2} href={`/search/space?q=${$page.url.searchParams.get('q')}`}>스페이스</TabHeadItem>
-  <TabHeadItem id={3} href={`/search/tag?q=${$page.url.searchParams.get('q')}`}>태그</TabHeadItem>
+  <TabHeadItem id={0} pathname="/search">전체</TabHeadItem>
+  <TabHeadItem id={1} pathname="/search/post">포스트</TabHeadItem>
+  <TabHeadItem id={2} pathname="/search/space">스페이스</TabHeadItem>
+  <TabHeadItem id={3} pathname="/search/tag">태그</TabHeadItem>
 </TabHead>
 
 {#if $query.searchSpaces.length === 0}

--- a/apps/penxle.com/src/routes/(default)/search/tag/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/tag/+page.svelte
@@ -22,10 +22,10 @@
 </div>
 
 <TabHead class="mt-9 mb-4 w-full <sm:(sticky top-61px z-1)" variant="secondary">
-  <TabHeadItem id={0} href={`/search?q=${$page.url.searchParams.get('q')}`}>전체</TabHeadItem>
-  <TabHeadItem id={1} href={`/search/post?q=${$page.url.searchParams.get('q')}`}>포스트</TabHeadItem>
-  <TabHeadItem id={2} href={`/search/space?q=${$page.url.searchParams.get('q')}`}>스페이스</TabHeadItem>
-  <TabHeadItem id={3} href={`/search/tag?q=${$page.url.searchParams.get('q')}`}>태그</TabHeadItem>
+  <TabHeadItem id={0} pathname="/search">전체</TabHeadItem>
+  <TabHeadItem id={1} pathname="/search/post">포스트</TabHeadItem>
+  <TabHeadItem id={2} pathname="/search/space">스페이스</TabHeadItem>
+  <TabHeadItem id={3} pathname="/search/tag">태그</TabHeadItem>
 </TabHead>
 
 {#if $query.searchTags.length === 0}

--- a/apps/penxle.com/src/routes/(default)/tag/[name]/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/tag/[name]/+layout.svelte
@@ -148,8 +148,8 @@
 
   <div class="py-4 px-6 rounded-xl bg-cardprimary space-y-4 -mt-3 grow">
     <TabHead class="w-full" variant="secondary">
-      <TabHeadItem id={1} href={`/tag/${$page.params.name}`}>위키</TabHeadItem>
-      <TabHeadItem id={2} href={`/tag/${$page.params.name}/post`}>포스트</TabHeadItem>
+      <TabHeadItem id={1} pathname={`/tag/${$page.params.name}`}>위키</TabHeadItem>
+      <TabHeadItem id={2} pathname={`/tag/${$page.params.name}/post`}>포스트</TabHeadItem>
       <!-- <TabHeadItem id={3}>스페이스</TabHeadItem> -->
     </TabHead>
 


### PR DESCRIPTION
pathname 맨 끝에 해당 문자를 옵셔널로 탐색하는 정규식 패턴 `\/?$` 으로 색인을 하여 해결을 했습니다.  처음 안 사실인데 RegExp 생성자 인자로 넣는 문자열 중간에 있는 슬래시를 알아서 `\/` 로 이스케이핑 변환을 해주네요.

색인 방식을 정규식으로 바꾸면서 기존 href 값에 포함될 수 있는 `?` 쿼리 스트링 시작 문자를 정규식으로 매칭하기 어려워 pathname 기준 색인으로 방식을 변경했습니다.