### PR TITLE
Safari 에서 세로 방향으로 긴 이미지의 하단 일부분이 숨겨지는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/Image.svelte
+++ b/apps/penxle.com/src/lib/components/Image.svelte
@@ -14,9 +14,9 @@
   let _class: string | undefined = undefined;
   export { _image as $image, _class as class };
   export let quality: number | undefined = undefined;
-  export let fit: 'cover' | 'contain' = 'cover';
   export let fade = true;
   export let intrinsic = false;
+  export let fit: 'cover' | 'contain' | null = intrinsic ? null : 'cover';
   export let draggable = false;
   export let alt: string | undefined = undefined;
 
@@ -67,7 +67,7 @@
 
 <div
   style:width={intrinsic ? `${$image.width}px` : undefined}
-  style:aspect-ratio={intrinsic ? `${$image.width} / ${$image.height}` : undefined}
+  style:aspect-ratio={intrinsic && !visible ? `${$image.width} / ${$image.height}` : undefined}
   class={clsx('overflow-hidden', _class)}
   role="img"
   on:contextmenu|preventDefault
@@ -77,7 +77,14 @@
 >
   <div class="square-full relative">
     {#if visible}
-      <img bind:this={imgEl} style:object-fit={fit} class="square-full" {alt} {src} on:load={() => (loaded = true)} />
+      <img
+        bind:this={imgEl}
+        style:object-fit={fit}
+        class={intrinsic ? 'w-full' : 'square-full'}
+        {alt}
+        {src}
+        on:load={() => (loaded = true)}
+      />
     {/if}
 
     {#if !loaded}


### PR DESCRIPTION
포스트 본문 외에 아바타 사진 등 다양하게 활용되고 있는 컴포넌트라 다른 곳과 호환 되게 신경을 쓰며 수정을 했습니다.

## 수정 전 문제 보기

<img width="1713" alt="스크린샷 2024-01-11 오후 4 47 25" src="https://github.com/penxle/penxle/assets/5278201/a5edc572-c2fc-4911-8759-382fb6817790">

왼쪽 파이어폭스, 오른쪽 사파리

ref: https://penxle.com/yinmang/1042485298