### PR TITLE
검색옵션의 트리거 워닝 메뉴를 접으면 레이아웃이 움직이는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/search/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/+layout.svelte
@@ -57,7 +57,7 @@
 <Helmet title="{$page.url.searchParams.get('q')} - 검색" />
 
 <div class="max-w-300 grow <sm:(w-full bg-cardprimary pt-5) sm:(grid grid-cols-[2fr_7fr] mx-10 gap-11.5 my-9.5)">
-  <aside class="min-w-38 <sm:hidden">
+  <aside class="min-w-38 max-w-61 <sm:hidden">
     <div class="bg-cardprimary border border-secondary rounded-2xl px-3 py-4">
       <button
         class="w-full flex items-center justify-between py-3 gap-2.5"


### PR DESCRIPTION
검색 옵션의 트리거 워닝 메뉴가 열려있을 때는 안의 요소들 때문에 width가 늘어났다가, 접으면 원래 너비로 돌아와 페이지 레이아웃이 움직이는 문제를 수정함