### PR TITLE
모바일 레이아웃을 고려해서 검색결과 페이지 개선함

### DIFF
--- a/apps/penxle.com/src/routes/(default)/Header.svelte
+++ b/apps/penxle.com/src/routes/(default)/Header.svelte
@@ -8,7 +8,6 @@
   import { fragment, graphql } from '$glitch';
   import { mixpanel } from '$lib/analytics';
   import { Button, Modal } from '$lib/components';
-  import { outsideClickEvent } from '$lib/svelte/actions';
   import GotoSpaceModal from './GotoSpaceModal.svelte';
   // import Notification from './Notification.svelte';
   import SearchBar from './SearchBar.svelte';
@@ -19,7 +18,6 @@
   let _query: DefaultLayout_Header_query;
   export { _query as $query };
 
-  let isOpen = false;
   let sideBarOpen = false;
   let openGotoSpace = false;
   let comingSoonOpen = false;
@@ -60,42 +58,32 @@
         <Wordmark class="<sm:hidden h-5.25 color-icon-primary" />
       </Link>
 
-      <div
-        class={clsx('flex items-center grow justify-end', isOpen && 'justify-between')}
-        on:outsideClick={() => (isOpen = false)}
-        use:outsideClickEvent
-      >
-        <SearchBar class={clsx('<sm:hidden', isOpen && 'block!')} />
+      <div class="flex flex-1 items-center justify-between">
+        <SearchBar class="flex-1 max-w-80 <sm:focus-within:max-w-full peer" />
 
-        <div class={clsx('flex center square-10 sm:hidden', isOpen && 'hidden!')}>
-          <button type="button" on:click={() => (isOpen = true)}>
-            <i class="i-lc-search square-6" />
-          </button>
+        <div class="flex sm:hidden grow-0 peer-focus-within:hidden">
+          <div class={clsx('flex center square-10')}>
+            <button type="button" on:click={() => (sideBarOpen = true)}>
+              <i class="i-lc-menu square-6" />
+            </button>
+          </div>
         </div>
-      </div>
 
-      <div class="flex sm:hidden grow-0">
-        <div class={clsx('flex center square-10')}>
-          <button type="button" on:click={() => (sideBarOpen = true)}>
-            <i class="i-lc-menu square-6" />
-          </button>
+        <div class="flex items-center <sm:hidden relative">
+          {#if $query.me}
+            <a
+              class="relative flex items-center gap-2 rounded-lg py-1 pr-2 pl-1 m-r-2 transition hover:bg-surface-primary <sm:hidden"
+              href="/editor"
+            >
+              <PenFancy class="square-8 mb-1" />
+              <span class="subtitle-17-b text-gray-70">포스트 작성하기</span>
+            </a>
+            <!-- <Notification $user={$query.me} /> -->
+            <UserMenu $user={$query.me} />
+          {:else}
+            <Button href="/login" size="md" type="link">펜슬과 함께하기</Button>
+          {/if}
         </div>
-      </div>
-
-      <div class="flex items-center <sm:hidden relative">
-        {#if $query.me}
-          <a
-            class="relative flex items-center gap-2 rounded-lg py-1 pr-2 pl-1 m-r-2 transition hover:bg-surface-primary <sm:hidden"
-            href="/editor"
-          >
-            <PenFancy class="square-8 mb-1" />
-            <span class="subtitle-17-b text-gray-70">포스트 작성하기</span>
-          </a>
-          <!-- <Notification $user={$query.me} /> -->
-          <UserMenu $user={$query.me} />
-        {:else}
-          <Button href="/login" size="md" type="link">펜슬과 함께하기</Button>
-        {/if}
       </div>
     </section>
   </nav>

--- a/apps/penxle.com/src/routes/(default)/SearchBar.svelte
+++ b/apps/penxle.com/src/routes/(default)/SearchBar.svelte
@@ -27,14 +27,14 @@
 </script>
 
 <form
-  class={clsx('relative w-full mr-4 h-10 ', _class)}
+  class={clsx('relative', _class)}
   on:submit|preventDefault={async () => {
     await goto(qs.stringifyUrl({ url: '/search', query: { q: value } }));
   }}
 >
   <input
-    class="transition-width ease-in-out rounded-9 bg-primary py-2 pl-11 pr-4 text-sm border border-bg-primary focus-within:border-primary next:focus:text-icon-primary h-10 <sm:(w-full max-w-80) sm:(w-80 focus-within:w-full!)"
-    placeholder="#검색어를 입력해 태그를 검색해 보세요"
+    class="transition-all rounded-9 bg-primary py-2 pl-11 pr-4 text-sm border border-bg-primary focus-within:border-primary next:focus:text-icon-primary w-full"
+    placeholder="검색어를 입력하세요"
     type="text"
     bind:value
   />

--- a/apps/penxle.com/src/routes/(default)/search/(index)/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/(index)/+page.svelte
@@ -70,8 +70,8 @@
 
 <Helmet title="{$page.url.searchParams.get('q')} - 펜슬 검색결과" />
 
-<div class="body-14-m text-secondary py-1 px-3 rounded-lg bg-surface-primary mt-3 <sm:mx-4">
-  🔍 약 {$query.searchPosts.count}개의 검색결과가 있어요!
+<div class="body-14-m text-secondary mt-3 <sm:m-l-4">
+  약 {$query.searchPosts.count}개의 검색결과가 있어요!
 </div>
 
 <TabHead class="mt-9 mb-4 w-full <sm:(sticky top-61px z-1)" variant="secondary">

--- a/apps/penxle.com/src/routes/(default)/search/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/+layout.svelte
@@ -242,15 +242,21 @@
 
   <div class="sm:max-w-185">
     <div class="flex items-center justify-between w-full <sm:px-4">
-      <h1 class="title-24-eb grow">'{$page.url.searchParams.get('q')}' 검색결과</h1>
+      <h1 class="title-24-eb grow">검색결과</h1>
 
-      <Button class="sm:hidden mx-1" color="tertiary" size="md" variant="outlined" on:click={() => (filterOpen = true)}>
+      <Button
+        class="sm:hidden mx-1 shrink-0"
+        color="tertiary"
+        size="md"
+        variant="outlined"
+        on:click={() => (filterOpen = true)}
+      >
         <i class="i-lc-list-filter square-5" />
         필터
       </Button>
 
-      <Menu placement="bottom">
-        <Button slot="value" color="tertiary" size="md" variant="outlined">
+      <Menu as="div" placement="bottom">
+        <Button slot="value" class="shrink-0" color="tertiary" size="md" variant="outlined">
           {orderBy === 'LATEST' ? '최신순' : '정확도순'}
           <i class="i-lc-chevron-down square-5" />
         </Button>

--- a/apps/penxle.com/src/routes/(default)/search/post/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/post/+page.svelte
@@ -70,8 +70,8 @@
 
 <Helmet title="{$page.url.searchParams.get('q')} - 펜슬 검색결과" />
 
-<div class="body-14-m text-secondary py-1 px-3 rounded-lg bg-surface-primary mt-3 <sm:mx-4">
-  🔍 약 {$query.searchPosts.count}개의 검색결과가 있어요!
+<div class="body-14-m text-secondary mt-3 <sm:m-l-4">
+  약 {$query.searchPosts.count}개의 검색결과가 있어요!
 </div>
 
 <TabHead class="mt-9 w-full <sm:(sticky top-61px z-1) sm:mb-4" variant="secondary">

--- a/apps/penxle.com/src/routes/(default)/search/space/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/space/+page.svelte
@@ -56,8 +56,8 @@
 
 <Helmet title="{$page.url.searchParams.get('q')} - 펜슬 검색결과" />
 
-<div class="body-14-m text-secondary py-1 px-3 rounded-lg bg-surface-primary mt-3 <sm:mx-4">
-  🔍 약 {$query.searchSpaces.length ?? 0}개의 검색결과가 있어요!
+<div class="body-14-m text-secondary mt-3 <sm:m-l-4">
+  약 {$query.searchSpaces.length ?? 0}개의 검색결과가 있어요!
 </div>
 
 <TabHead class="mt-9 mb-4 w-full <sm:(sticky top-61px z-1)" variant="secondary">

--- a/apps/penxle.com/src/routes/(default)/search/tag/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/search/tag/+page.svelte
@@ -17,8 +17,8 @@
 
 <Helmet title="{$page.url.searchParams.get('q')} - 펜슬 검색결과" />
 
-<div class="body-14-m text-secondary py-1 px-3 rounded-lg bg-surface-primary mt-3 <sm:mx-4">
-  🔍 약 {$query.searchTags.length ?? 0}개의 검색결과가 있어요!
+<div class="body-14-m text-secondary mt-3 <sm:m-l-4">
+  약 {$query.searchTags.length ?? 0}개의 검색결과가 있어요!
 </div>
 
 <TabHead class="mt-9 mb-4 w-full <sm:(sticky top-61px z-1)" variant="secondary">


### PR DESCRIPTION
| 수정 전 | 수정 후 |
| - | - |
| ![스크린샷 2024-01-12 17 22 31](https://github.com/penxle/penxle/assets/5278201/16e44b89-3dd3-450c-9400-4fa21cc379bf) | ![스크린샷 2024-01-12 17 22 10](https://github.com/penxle/penxle/assets/5278201/532cfe96-e78c-40fe-8f06-adb50db09a13) |

- 검색 쿼리 텍스트를 헤딩에 표시하는 대신에 데스크탑 너비에서 보여주던 검색 입력 박스를 그대로 보여주기
- 검색 결과 갯수 UI 의 아이콘 및 배경색이 인풋 박스 UI 와 유사하여 헷갈림. 별도의 박스 스타일 없이 텍스트만 보여주게 수정함
- (추가) 모바일에서 검색 입력 초첨 맞추면 메뉴 버튼 숨기면서 너비 확장하기

위 두가지 사항 @Seohyun-Roh 님과 구두로 협의해서 피그마에도 반영해두었습니다.