### PR TITLE
검색 입력 전송 이후에 이동한 검색 결과 페이지에서 검색 텍스트 초기화되는 버그 고치기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/SearchBar.svelte
+++ b/apps/penxle.com/src/routes/(default)/SearchBar.svelte
@@ -7,15 +7,20 @@
   let _class: string | undefined = undefined;
   export { _class as class };
 
-  let value: string;
-  if ($page.url.pathname === '/search') {
-    value = $page.url.searchParams.get('q') ?? '';
-  }
+  let value = ($page.url.pathname === '/search' && $page.url.searchParams.get('q')) || '';
 
   afterNavigate(({ from, to }) => {
     if (!from || !to) return;
 
-    if (from.url.pathname.startsWith('/search') && !to.url.pathname.startsWith('/search')) {
+    const fromStartsWithSearch = from.url.pathname.startsWith('/search');
+    const toStartsWithSearch = to.url.pathname.startsWith('/search');
+
+    if (!fromStartsWithSearch && toStartsWithSearch) {
+      value = to.url.searchParams.get('q') ?? '';
+      return;
+    }
+
+    if (fromStartsWithSearch && !toStartsWithSearch) {
       value = '';
     }
   });


### PR DESCRIPTION
재현 방법

1. 메인 페이지 등 아무 페이지에서 검색 입력 후 전송
2. 검색 결과 페이지에서 검색 입력 박스 내 텍스트가 빈 값으로 초기화 되는 문제가 있었음