### PR TITLE
Tiptap Image node-view에서 __data 없을 시 아무것도 렌더링하지 않음

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/image/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/image/Component.svelte
@@ -72,7 +72,7 @@
         <Image class="max-w-full" $image={node.attrs.__data} draggable intrinsic />
       {/if}
     </div>
-  {:else}
+  {:else if node.attrs.__data}
     <div class="contents" role="presentation" on:click={() => (open = true)}>
       <Image class="max-w-full" $image={node.attrs.__data} intrinsic />
     </div>


### PR DESCRIPTION
이미지 업로드 와중에 revise 혹은 publish 할 경우 글 내용이 깨져 아무것도 하지 못하는 이슈를 일단 회피함

완전한 해결법은 아니지만 일단 글 수정과 확인은 가능하게 만들 수 있음
