### PR TITLE
graphql yoga가 일부 상황에서 context를 이상하게 생성하는 버그 수정

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/handler.ts
+++ b/apps/penxle.com/src/lib/server/graphql/handler.ts
@@ -5,7 +5,7 @@ import { useContextFinalizer, useErrorHandling, useLogging, useTelemetry } from 
 import { schema } from './schemas';
 import type { RequestEvent } from '@sveltejs/kit';
 
-export const handler = createYoga<RequestEvent>({
+const yoga = createYoga<RequestEvent>({
   schema,
   context: createContext,
   fetchAPI: { Response },
@@ -14,3 +14,7 @@ export const handler = createYoga<RequestEvent>({
   maskedErrors: false,
   plugins: [useGraphQlJit(), useErrorHandling(), useLogging(), useTelemetry(), useContextFinalizer()],
 });
+
+export const handler = async (event: RequestEvent) => {
+  return await yoga.handleRequest(event.request, event);
+};


### PR DESCRIPTION
`/api/graphql`에서 볼 수 있는 graphiql에서 쿼리 실행이 안 되던 버그 해결함 (드디어!)
