### PR TITLE
스크립트 실행을 위한 esm loader 구현

### DIFF
--- a/apps/penxle.com/package.json
+++ b/apps/penxle.com/package.json
@@ -15,6 +15,7 @@
     "lint:typecheck": "tsc",
     "migrate": "doppler run -- prisma migrate dev",
     "migrate:new": "doppler run -- prisma migrate dev --create-only",
+    "run:script": "doppler run -- tsx --import ./scripts/loader/register.js",
     "test": "playwright test"
   },
   "dependencies": {

--- a/apps/penxle.com/scripts/loader/hooks.js
+++ b/apps/penxle.com/scripts/loader/hooks.js
@@ -1,0 +1,37 @@
+export const resolve = async (specifier, context, nextResolve) => {
+  if (specifier.startsWith('$')) {
+    return {
+      url: `virtual://${specifier}`,
+      shortCircuit: true,
+    };
+  }
+
+  return nextResolve(specifier, context);
+};
+
+export const load = (url, context, nextLoad) => {
+  if (url.startsWith('virtual://')) {
+    const mod = url.replace(/^virtual:\/\//, '');
+    let source;
+
+    switch (mod) {
+      case '$env/dynamic/public':
+      case '$env/dynamic/private':
+        source = `export const env = process.env;`;
+        break;
+      case '$app/environment':
+        source = `export const building = false; export const dev = true; export const browser = false;`;
+        break;
+      default:
+        throw new Error(`Unknown virtual module: ${mod}`);
+    }
+
+    return {
+      format: 'module',
+      source,
+      shortCircuit: true,
+    };
+  }
+
+  return nextLoad(url, context);
+};

--- a/apps/penxle.com/scripts/loader/register.js
+++ b/apps/penxle.com/scripts/loader/register.js
@@ -1,0 +1,4 @@
+import { register } from 'node:module';
+
+register('./hooks.js', import.meta.url);
+process.env.SCRIPTS = 'true';

--- a/apps/penxle.com/src/lib/server/logging.ts
+++ b/apps/penxle.com/src/lib/server/logging.ts
@@ -2,7 +2,7 @@ import { stack } from '@penxle/lib/environment';
 import pino from 'pino';
 
 export const logger = pino({
-  level: 'trace',
+  level: process.env.SCRIPTS ? 'error' : 'trace',
   base: {
     env: stack,
   },

--- a/apps/penxle.com/svelte.config.js
+++ b/apps/penxle.com/svelte.config.js
@@ -24,7 +24,7 @@ export default {
     typescript: {
       config: (config) => ({
         ...config,
-        include: [...config.include, '../pulumi/**/*.ts'],
+        include: [...config.include, '../pulumi/**/*.ts', '../scripts/**/*.ts'],
       }),
     },
     version: { pollInterval: 60 * 1000 },


### PR DESCRIPTION
운영용 스크립트에서 코드 재사용을 위해 `$lib/server` 안에 있는 파일을 import 해올 수 있도록 [esm loader hooks](https://nodejs.org/api/module.html#customization-hooks) 구현함.

이제 `pnpm run:script ./scripts/asdf.ts` 와 같은 식으로 로컬에서 스크립트를 실행할 수 있음
