### PR TITLE
node v20.11에서 수정된 import hook 실행 순서 버그를 반영함

### DIFF
--- a/apps/penxle.com/package.json
+++ b/apps/penxle.com/package.json
@@ -15,7 +15,7 @@
     "lint:typecheck": "tsc",
     "migrate": "doppler run -- prisma migrate dev",
     "migrate:new": "doppler run -- prisma migrate dev --create-only",
-    "run:script": "doppler run -- tsx --import ./scripts/loader/register.js",
+    "run:script": "doppler run -- node --import ./scripts/loader/register.js --import tsx",
     "test": "playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
https://github.com/nodejs/node/pull/50474 로 수정된 nodejs `--import` 실행 순서 버그를 코드베이스에 반영함
