### PR TITLE
dangling contents 삭제 스크립트 퍼포먼스 개선

### DIFF
--- a/apps/penxle.com/package.json
+++ b/apps/penxle.com/package.json
@@ -16,6 +16,7 @@
     "migrate": "doppler run -- prisma migrate dev",
     "migrate:new": "doppler run -- prisma migrate dev --create-only",
     "run:script": "doppler run -- node --import ./scripts/loader/register.js --import tsx",
+    "run:script:prod": "doppler -c prod_direct run -- node --import ./scripts/loader/register.js --import tsx",
     "test": "playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
foreign key check로 인해 delete from 퍼포먼스가 너무 느려서 스크립트 실행시에 잠시 foreign key check를 비활성화함
