### PR TITLE
폰트 시스템 변경사항 반영

### DIFF
--- a/packages/lib/src/unocss/preset.ts
+++ b/packages/lib/src/unocss/preset.ts
@@ -45,6 +45,20 @@ export const presetPenxle = (): Preset<Theme> => ({
         return `text-[${d}px] font-${fontWeight}`;
       },
     ],
+    [
+      /^(text)-(\d+)-(b|sb|m|r)$/,
+      // eslint-disable-next-line unicorn/no-unreadable-array-destructuring
+      ([, , d, w]) => {
+        const fontWeight = {
+          sb: 'semibold',
+          b: 'bold',
+          m: 'medium',
+          r: 'regular',
+        }[w];
+
+        return `text-[${d}px] font-${fontWeight}`;
+      },
+    ],
   ],
   extendTheme: (theme) => ({
     ...theme,


### PR DESCRIPTION
기존처럼 따로 폰트 마다 이름을 붙이지 않고(title, subtitle 등) `text-32-b`와 같이 사용