### PR TITLE
팁탭 gap_cursor 모양 가로에서 세로로 변경

### DIFF
--- a/apps/penxle.com/src/styles/prose.css
+++ b/apps/penxle.com/src/styles/prose.css
@@ -23,13 +23,9 @@
   --uno: bg-teal-500;
 }
 
-.ProseMirror-gapcursor {
-  --uno: border-t border-t-black w-full my-1;
-  animation: cursor-blink 1s steps(2, start) infinite;
-}
-
 .ProseMirror-focused .ProseMirror-gapcursor {
-  --uno: block;
+  --uno: border-l border-l-black w-0 h-20px my-1;
+  animation: cursor-blink 1s steps(2, start) infinite;
 }
 
 /*


### PR DESCRIPTION
가로보다 세로 모양 커서가 좀 더 유저들에게 친숙할 것으로 생각
