### PR TITLE
ToggleButton group prop 미 할당 시 나오는 런타임 타입 오류 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/ToggleButton.svelte
+++ b/apps/penxle.com/src/lib/components/ToggleButton.svelte
@@ -6,10 +6,9 @@
     change: Event & { currentTarget: HTMLInputElement };
   };
 
-  type $$Props = HTMLInputAttributes & { group?: unknown };
+  type $$Props = HTMLInputAttributes;
 
   export let checked: $$Props['checked'] = undefined;
-  export let group: $$Props['group'] = undefined;
 
   let _class: $$Props['class'] = undefined;
   export { _class as class };
@@ -27,7 +26,6 @@
     type="checkbox"
     on:change
     bind:checked
-    bind:group
     {...$$restProps}
   />
   <slot />

--- a/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/ContentFilterButton.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/settings/contentfilters/ContentFilterButton.svelte
@@ -47,7 +47,6 @@
 
 <ToggleButton
   checked={preferences[category] === 'EXPOSE'}
-  bind:group={category}
   on:change={async (e) => {
     const action = e.currentTarget.checked ? 'EXPOSE' : 'WARN';
 

--- a/apps/penxle.com/src/routes/editor/PublishMenu.svelte
+++ b/apps/penxle.com/src/routes/editor/PublishMenu.svelte
@@ -788,10 +788,20 @@
           </p>
 
           <SegmentButtonGroup>
-            <ToggleButton checked={$data.externalSearchable} type="radio" bind:group={$data.externalSearchable}>
+            <ToggleButton
+              checked={$data.externalSearchable}
+              on:change={(event) => {
+                $data.externalSearchable = event.currentTarget.checked;
+              }}
+            >
               외부검색허용
             </ToggleButton>
-            <ToggleButton checked={!$data.externalSearchable} type="radio" bind:group={$data.externalSearchable}>
+            <ToggleButton
+              checked={!$data.externalSearchable}
+              on:change={(event) => {
+                $data.externalSearchable = !event.currentTarget.checked;
+              }}
+            >
               비허용
             </ToggleButton>
           </SegmentButtonGroup>


### PR DESCRIPTION
```
Uncaught (in promise) TypeError: (intermediate value).indexOf is not a function
    update ToggleButton.svelte:137
```

1. input type="radio" 버튼이 쓰이지 말아야 할 곳을 checkbox 로 변경
2. 나머지 라디오 인풋에서 group prop 을 제거하고 name 어트리뷰트로만 관리