### PR TITLE
저장 이력 및 미리보기 주소 변경

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/preview/[post]/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/[space]/preview/[post]/+page.ts
@@ -1,5 +1,0 @@
-import type { PageLoadEvent } from './$types';
-
-export const _SpacePreviewPostPage_QueryVariables = (event: PageLoadEvent) => {
-  return { permalink: event.params.post, revisionId: event.url.searchParams.get('revisionId') ?? undefined };
-};

--- a/apps/penxle.com/src/routes/editor/Header.svelte
+++ b/apps/penxle.com/src/routes/editor/Header.svelte
@@ -218,8 +218,6 @@
     selectedSpaceId = $post?.space?.id;
   }
 
-  $: selectedSpace = $query.me.spaces.find((space) => space.id === selectedSpaceId);
-
   $: permalink = ($post || draftPost)?.permalink;
 
   $: if ($post) {
@@ -409,7 +407,7 @@
           저장이력
         </MenuItem>
 
-        <MenuItem external href={`/${selectedSpace?.slug}/preview/${permalink}`} type="link">미리보기</MenuItem>
+        <MenuItem external href={`/editor/${permalink}/preview`} type="link">미리보기</MenuItem>
       </Menu>
     </div>
   </div>

--- a/apps/penxle.com/src/routes/editor/RevisionListModal.svelte
+++ b/apps/penxle.com/src/routes/editor/RevisionListModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import dayjs from 'dayjs';
-  import queryString from 'query-string';
+  import qs from 'query-string';
   import { getContext } from 'svelte';
   import { fragment, graphql } from '$glitch';
   import { Badge, Modal } from '$lib/components';
@@ -21,11 +21,6 @@
       fragment EditorPage_RevisionListModal_Post on Post {
         id
         permalink
-
-        space @_required {
-          id
-          slug
-        }
 
         revisions {
           id
@@ -60,7 +55,7 @@
   $: selectedRevisionId = $post.revisions[0].id;
   $: disabled = $post.revisions.length === 1;
 
-  $: previewSource = `/${$post.space.slug}/preview/${$post.permalink}/`;
+  $: previewSource = `/editor/${$post.permalink}/preview`;
 </script>
 
 <Modal size="lg" bind:open>
@@ -69,10 +64,13 @@
   <article class="flex gap-xs h-32rem">
     <iframe
       class="w-28.625rem"
-      src={`${previewSource}?${queryString.stringify({
-        revisionId: selectedRevisionId,
-        hideHeader: true,
-      })}`}
+      src={qs.stringifyUrl({
+        url: previewSource,
+        query: {
+          revisionId: selectedRevisionId,
+          hideHeader: true,
+        },
+      })}
       title="미리보기"
     />
     <aside class="flex-grow">
@@ -126,7 +124,12 @@
               </MenuItem>
               <MenuItem
                 external
-                href={`${previewSource}?${queryString.stringify({ revisionId: revision.id })}`}
+                href={qs.stringifyUrl({
+                  url: previewSource,
+                  query: {
+                    revisionId: selectedRevisionId,
+                  },
+                })}
                 type="link"
               >
                 새 창으로 보기

--- a/apps/penxle.com/src/routes/editor/[permalink]/preview/+page.ts
+++ b/apps/penxle.com/src/routes/editor/[permalink]/preview/+page.ts
@@ -1,0 +1,5 @@
+import type { PageLoadEvent } from './$types';
+
+export const _EditorPermalinkPreviewPage_QueryVariables = (event: PageLoadEvent) => {
+  return { permalink: event.params.permalink, revisionId: event.url.searchParams.get('revisionId') ?? undefined };
+};

--- a/apps/penxle.com/src/routes/editor/[permalink]/preview/+page@.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/preview/+page@.svelte
@@ -3,8 +3,8 @@
   import Wordmark from '$assets/icons/wordmark.svg?component';
   import { graphql } from '$glitch';
   import { Logo } from '$lib/components/branding';
-  import Footer from '../../../Footer.svelte';
-  import Post from '../../Post.svelte';
+  import Post from '../../../(default)/[space]/Post.svelte';
+  import Footer from '../../../(default)/Footer.svelte';
 
   let mode: 'desktop' | 'mobile' = 'desktop';
 
@@ -13,7 +13,7 @@
   $: hideHeader = $page.url.searchParams.get('hideHeader') === 'true';
 
   $: query = graphql(`
-    query SpacePreviewPostPage_Query($permalink: String!, $revisionId: ID) {
+    query EditorPermalinkPreviewPage_Query($permalink: String!, $revisionId: ID) {
       post(permalink: $permalink) {
         id
 


### PR DESCRIPTION
기존 저장 이력/미리보기 url에는 스페이스 slug가 포함되어야 해 해당 부분 스페이스 slug 없이도 미리보기 가능하도록 수정함
