### PR TITLE
컬러 피커 Hue 슬라이더 범위가 실제 색상과 맞지 않은 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/ColorPicker.svelte
+++ b/apps/penxle.com/src/lib/components/ColorPicker.svelte
@@ -197,7 +197,7 @@
       bind:this={gradientSliderInputEl}
       style={`--thumb-color: ${rgb.toString()}`}
       class="appearance-none rounded-0.125rem w-full h-2 gradient-slider m-b-xs"
-      max="360"
+      max="300"
       min="0"
       type="range"
       on:change={(event) => {
@@ -286,7 +286,15 @@
 
 <style>
   .gradient-slider {
-    background: linear-gradient(to right, red, orange, yellow, green, blue, indigo, violet);
+    background: linear-gradient(
+      to right,
+      hsl(0, 100%, 50%) 0%,
+      hsl(60, 100%, 50%) 20%,
+      hsl(120, 100%, 50%) 40%,
+      hsl(180, 100%, 50%) 60%,
+      hsl(240, 100%, 50%) 80%,
+      hsl(300, 100%, 50%) 100%
+    );
     &::-webkit-slider-thumb {
       -webkit-appearance: none;
     }


### PR DESCRIPTION
아래 위키피디아 문서를 참고해서 바로 고쳤습니다.

hue 시작과 끝 값이 빨간색으로 동일해서 빨간색 `0` 에서 마젠타 색상 위치 `300` 까지로 수정했습니다.

![Hue in the HSL/HSV encodings of RGB](https://upload.wikimedia.org/wikipedia/commons/thumb/a/ad/HueScale.svg/1662px-HueScale.svg.png)

https://en.wikipedia.org/wiki/Hue#Defining_hue_in_terms_of_RGB