### PR TITLE
publishPost 전 revisePost한 revisionId가 반영이 되지 않는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/editor/PublishMenu.svelte
+++ b/apps/penxle.com/src/routes/editor/PublishMenu.svelte
@@ -56,8 +56,9 @@
     `),
     schema: PublishPostInputSchema,
     extra: async () => {
-      await doRevisePost('AUTO_SAVE');
+      const resp = await doRevisePost('AUTO_SAVE');
       return {
+        revisionId: resp?.draftRevision.id,
         spaceId: selectedSpaceId,
         collectionId: selectedCollectionId,
         thumbnailId: thumbnail ? thumbnail.id : undefined,
@@ -179,7 +180,7 @@
 
         draftRevision @_required {
           id
-          createdAt
+          updatedAt
         }
 
         space {
@@ -206,7 +207,7 @@
 
     mixpanel.track('post:revise', { postId: resp.id, revisionKind });
 
-    revisedAt = resp.draftRevision?.createdAt;
+    revisedAt = resp.draftRevision.updatedAt;
     $data.revisionId = resp.draftRevision.id;
 
     return resp;


### PR DESCRIPTION
가끔 저장한 내용 날아가는 버그가 이게 원인인 듯