### PR TITLE
TiptapRenderer 컨텐츠 바뀔 경우 렌더링 다시 함

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/components/TiptapRenderer.svelte
+++ b/apps/penxle.com/src/lib/tiptap/components/TiptapRenderer.svelte
@@ -25,7 +25,6 @@
   let loaded = false;
 
   $: html = generateHTML(content, extensions);
-  $: editor?.commands.setContent(content);
 
   onMount(() => {
     editor = new Editor({

--- a/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
@@ -532,14 +532,16 @@
                 </Button>
               </header>
             {:else}
-              <TiptapRenderer
-                class=""
-                content={$postRevision.content}
-                paragraphIndent={$postRevision.paragraphIndent}
-                paragraphSpacing={$postRevision.paragraphSpacing}
-                protectContent={$query.post.protectContent}
-                bind:editor
-              />
+              {#key $postRevision.content}
+                <TiptapRenderer
+                  class=""
+                  content={$postRevision.content}
+                  paragraphIndent={$postRevision.paragraphIndent}
+                  paragraphSpacing={$postRevision.paragraphSpacing}
+                  protectContent={$query.post.protectContent}
+                  bind:editor
+                />
+              {/key}
             {/if}
           {:else}
             <GalleryPost {$query} {mode} revision={$postRevision} />


### PR DESCRIPTION
`{#key}` 블럭 이용해 팁탭 컨텐츠 바뀔 경우 에디터 인스턴스 재생성하도록 함

추천글이나 이전글/다음글로 넘어갈 때 본문 갱신 안 되는 이슈에 따른 수정
