### PR TITLE
기본 문단 간격 제거

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/nodes/paragraph.ts
+++ b/apps/penxle.com/src/lib/tiptap/nodes/paragraph.ts
@@ -1,4 +1,4 @@
-import { mergeAttributes, Node } from '@tiptap/core';
+import { Node } from '@tiptap/core';
 import clsx from 'clsx';
 import { values } from '$lib/tiptap/values';
 import { closest } from '$lib/utils';
@@ -83,11 +83,7 @@ export const Paragraph = Node.create({
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    return [
-      'p',
-      mergeAttributes(HTMLAttributes, { class: 'py-0.5' }),
-      !this.editor?.isEditable && node.childCount === 0 ? ['br'] : 0,
-    ];
+    return ['p', HTMLAttributes, !this.editor?.isEditable && node.childCount === 0 ? ['br'] : 0];
   },
 
   addCommands() {


### PR DESCRIPTION
이제 유저가 직접 문단 간격을 설정 가능하기에 기본적으로 주고 있던 `py-0.5`의 문단 간격을 제외함
