### PR TITLE
포스트 로드시 컨텐츠 깜빡이는 문제 해결을 위해 stable serialization을 사용함

### DIFF
--- a/apps/penxle.com/package.json
+++ b/apps/penxle.com/package.json
@@ -63,6 +63,7 @@
     "dataloader": "^2.2.2",
     "dayjs": "^1.11.10",
     "emoji-mart": "^5.5.2",
+    "fast-json-stable-stringify": "^2.1.0",
     "felte": "^1.2.14",
     "google-auth-library": "^9.6.1",
     "got": "^14.1.0",

--- a/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/Post.svelte
@@ -2,6 +2,7 @@
   import { Helmet } from '@penxle/ui';
   import clsx from 'clsx';
   import dayjs from 'dayjs';
+  import stringify from 'fast-json-stable-stringify';
   import { afterNavigate, goto } from '$app/navigation';
   import { fragment, graphql } from '$glitch';
   import { mixpanel } from '$lib/analytics';
@@ -535,7 +536,7 @@
                 </Button>
               </header>
             {:else}
-              {#key $postRevision.content}
+              {#key stringify($postRevision.content)}
                 <TiptapRenderer
                   class=""
                   content={$postRevision.content}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
       emoji-mart:
         specifier: ^5.5.2
         version: 5.5.2
+      fast-json-stable-stringify:
+        specifier: ^2.1.0
+        version: 2.1.0
       felte:
         specifier: ^1.2.14
         version: 1.2.14(svelte@4.2.9)


### PR DESCRIPTION
`$postRevision.content`가 object라서 그냥 바로 `{#key}` 의 인자로 쓰면 매번 리렌더를 하게 됨.

그에 따라 stable serialization을 통해 안정된 문자열을 `{#key}` 의 인자로 사용해야 원하는 동작을 이룰 수 있다
