### PR TITLE
게시 옵션 메뉴 좌측 탭 체크박스 오동작 수정

### DIFF
--- a/apps/penxle.com/src/routes/editor/PublishMenu.svelte
+++ b/apps/penxle.com/src/routes/editor/PublishMenu.svelte
@@ -359,7 +359,7 @@
         type="button"
         on:click={() => (tabIndex = 1)}
       >
-        {#if thumbnail}
+        {#if $data.tags?.length > 0}
           <i class="i-px2-checkmark square-6 text-teal-500" />
         {:else}
           <i class="i-px2-checkmark square-6 text-gray-300" />
@@ -371,7 +371,7 @@
         type="button"
         on:click={() => (tabIndex = 2)}
       >
-        {#if $data.tags?.length > 0}
+        {#if currentThumbnail}
           <i class="i-px2-checkmark square-6 text-teal-500" />
         {:else}
           <i class="i-px2-checkmark square-6 text-gray-300" />


### PR DESCRIPTION
썸네일과 태그 체크마크 표시 조건이 서로 바뀌어 있었음
