### PR TITLE
컬러피커 hex 변수값 대문자로 유지하기

### DIFF
--- a/apps/penxle.com/src/lib/components/ColorPicker.svelte
+++ b/apps/penxle.com/src/lib/components/ColorPicker.svelte
@@ -17,14 +17,15 @@
 
   let rgb = Color(hex).rgb();
 
-  $: hex = rgb.hex().toString();
+  $: if (hexInputEl) {
+    hex = rgb.hex().toString().toUpperCase();
+    hexInputEl.value = hex;
+  }
+
   $: if (initialize) {
     dispatch('input', { hex });
   } else {
     initialize = true;
-  }
-  $: if (hexInputEl) {
-    hexInputEl.value = hex;
   }
 
   $: if (gradientSliderInputEl) {


### PR DESCRIPTION
현재 컬러가 프리셋 목록 중 동일한 컬러가 있어도 대문자와 소문자가 달라
매칭이 안되는 문제가 있어서 수정하게 되었습니다.