### PR TITLE
에디터 툴바 드롭다운 메뉴 버튼 가로 너비 고정하기

### DIFF
--- a/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
@@ -254,7 +254,7 @@
           <Menu class="h-8.5" offset={menuOffset} placement="bottom" rounded={false}>
             <div
               slot="value"
-              class="flex pl-4px pr-2px items-center gap-1 whitespace-nowrap h-full hover:(bg-gray-100 rounded)"
+              class="flex justify-between pl-4px pr-2px items-center gap-1 whitespace-nowrap h-full hover:(bg-gray-100 rounded) w-36"
               let:open
             >
               <div>
@@ -299,7 +299,11 @@
             placement="bottom"
             rounded={false}
           >
-            <div slot="value" class="flex center pl-4px pr-2px gap-1 h-full hover:(bg-gray-100 rounded)" let:open>
+            <div
+              slot="value"
+              class="flex justify-between items-center pl-4px pr-2px gap-1 h-full hover:(bg-gray-100 rounded) w-16"
+              let:open
+            >
               {values.fontSize.find(({ value }) => editor?.getAttributes('font_size').fontSize === value)?.label ??
                 values.fontSize[4].label}
               <i class={clsx('i-tb-chevron-down square-4.5 text-gray-300', open && 'rotate-180')} />


### PR DESCRIPTION
폰트 종류 및 크기를 바꿀 때마다 해당 메뉴 너비가 가변적이라 툴바 위치가 미세하게 늘어났다 줄어드는 문제가 있어 수정합니다.