### PR TITLE
텍스트 선택 영역에서 가장 먼저 설정된 글자 색상으로 일괄 변경되는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/lib/components/ColorPicker.svelte
+++ b/apps/penxle.com/src/lib/components/ColorPicker.svelte
@@ -12,20 +12,16 @@
   let gradientSliderInputEl: HTMLInputElement | undefined;
 
   export let hex = '#000000';
-  let initialize = false;
   const dispatch = createEventDispatcher<{ input: { hex: string } }>();
+  const dispatchInput = (color: Color) => {
+    hex = color.hex().toString().toUpperCase();
+    dispatch('input', { hex });
+  };
 
   let rgb = Color(hex).rgb();
 
   $: if (hexInputEl) {
-    hex = rgb.hex().toString().toUpperCase();
     hexInputEl.value = hex;
-  }
-
-  $: if (initialize) {
-    dispatch('input', { hex });
-  } else {
-    initialize = true;
   }
 
   $: if (gradientSliderInputEl) {
@@ -79,10 +75,12 @@
     const imageData = colorCtx.getImageData(x, y, 1, 1).data;
 
     rgb = Color([imageData[0], imageData[1], imageData[2]]);
+    dispatchInput(rgb);
   };
 
   const updateColor = (color: Color) => {
     rgb = color.rgb();
+    dispatchInput(rgb);
 
     fillGradient();
     updatePosition();
@@ -173,6 +171,7 @@
 
           const imageData = colorCtx.getImageData(x, y, 1, 1).data;
           rgb = Color([imageData[0], imageData[1], imageData[2]]);
+          dispatchInput(rgb);
         }}
       />
       <canvas


### PR DESCRIPTION
## 재현 방법

https://github.com/penxle/penxle/assets/5278201/58db85de-8a29-4931-adbe-d3d668c3d846

> 왼쪽에서 오른쪽 방향으로 텍스트 선택 시에는 일어나지 않습니다.

1. 한 두 문단에 여러 색상을 지정함
2. 오른쪽에서 왼쪽 방향으로 텍스트 선택 하기

에디터 Header 컴포넌트에서 현재 커서에 위치한 텍스트 색상을 `hex` prop 을 통해 단방향으로 전달하고 있고 이렇게 새로 받은 값을 리엑티브로 input event 를 발생하고 있어 색상이 텍스트를 선택만 해도 일괄 변경이 벌어지는 것으로 파악을 했습니다.

리엑티브로 이벤트를 발생하지 않고 UI 상에서 직접 입력이 들어올 때만 이벤트를 발생하게 수정하여 해결을 했습니다.

---

평소와 다르게 새벽 중에 올려 죄송합니다.. 잠 안오는 밤중에 문제를 파악하고 너무 신경 쓰여서 보게 되었습니다.