### PR TITLE
게시글 신규 작성하기를 누른 뒤 아무 변경 없이 저장할 경우 임시저장 목록에 포함시키지 않음

### DIFF
--- a/apps/penxle.com/prisma/migrations/20240204102223_make_post_revision_free_content_nullable/migration.sql
+++ b/apps/penxle.com/prisma/migrations/20240204102223_make_post_revision_free_content_nullable/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The `pairs` column on the `posts` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterEnum
+ALTER TYPE "_post_state" ADD VALUE 'EPHEMERAL';
+
+-- DropForeignKey
+ALTER TABLE "post_revisions" DROP CONSTRAINT "post_revisions_paid_content_id_fkey";
+
+-- AlterTable
+ALTER TABLE "post_revisions" ALTER COLUMN "free_content_id" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "post_revisions" ADD CONSTRAINT "post_revisions_paid_content_id_fkey" FOREIGN KEY ("paid_content_id") REFERENCES "post_revision_contents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/penxle.com/prisma/schema.prisma
+++ b/apps/penxle.com/prisma/schema.prisma
@@ -232,10 +232,10 @@ model PostRevision {
   post          Post                 @relation(fields: [postId], references: [id])
   userId        String               @map("user_id")
   user          User                 @relation(fields: [userId], references: [id])
-  freeContentId String               @map("free_content_id")
-  freeContent   PostRevisionContent  @relation(name: "free_content", fields: [freeContentId], references: [id])
+  freeContentId String?              @map("free_content_id")
+  freeContent   PostRevisionContent? @relation(name: "free_content", fields: [freeContentId], references: [id], onDelete: Restrict)
   paidContentId String?              @map("paid_content_id")
-  paidContent   PostRevisionContent? @relation(name: "paid_content", fields: [paidContentId], references: [id])
+  paidContent   PostRevisionContent? @relation(name: "paid_content", fields: [paidContentId], references: [id], onDelete: Restrict)
 
   paragraphIndent  Int @default(100) @map("paragraph_indent")
   paragraphSpacing Int @default(100) @map("paragraph_spacing")
@@ -840,6 +840,7 @@ enum PostRevisionContentKind {
 }
 
 enum PostState {
+  EPHEMERAL
   DRAFT
   PUBLISHED
   DELETED

--- a/apps/penxle.com/schema.graphql
+++ b/apps/penxle.com/schema.graphql
@@ -431,6 +431,7 @@ enum PostRevisionKind {
 enum PostState {
   DELETED
   DRAFT
+  EPHEMERAL
   PUBLISHED
 }
 

--- a/apps/penxle.com/src/lib/server/graphql/schemas/image.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/image.ts
@@ -63,7 +63,7 @@ export const imageSchema = defineSchema((builder) => {
               where: { id: 'authlayout_bg' },
             });
 
-            if (!post?.publishedRevision) {
+            if (!post?.publishedRevision?.freeContent) {
               return null;
             }
 

--- a/apps/penxle.com/src/lib/server/utils/tiptap.ts
+++ b/apps/penxle.com/src/lib/server/utils/tiptap.ts
@@ -23,6 +23,18 @@ export const revisionContentToText = async (revisionContent: RevisionContent): P
   return '';
 };
 
+export const isEmptyContent = (content: JSONContent[]): boolean => {
+  if (content.length === 0) {
+    return true;
+  }
+
+  if (content.length === 1 && content[0].type === 'paragraph' && !content[0].content?.length) {
+    return true;
+  }
+
+  return false;
+};
+
 export const sanitizeContent = async (content: JSONContent[]): Promise<JSONContent[]> => {
   traverse(content, ({ key, value, parent }) => {
     if (parent && key === 'attrs' && typeof value === 'object') {


### PR DESCRIPTION
게시글 신규 작성하기를 누른 뒤 아무것도 하지 않고 나갈 경우에도 임시저장 목록에 빈 게시글이 추가되는 이슈가 있음
이를 방지하기 위해 다음 절차를 추가함

- `Post.state`에 `EPHEMERAL` 상태를 추가함
- `PostRevision.freeContentId` 를 nullable로 만들고, `freeContent`가 비어있을 경우 해당 필드를 null로 세팅함
- `revisePost`시에 `Post.state`가 `EPHEMERAL`이고, `title`, `subtitle`, `freeContent`, `paidContent` 중 하나라도 세팅되었을 때만 `Post.state`를 `DRAFT`로 변경함
- 실제 DB에 `Post`는 내용이 비어있더라도 계속해서 생성되긴 하지만 적어도 유저에게 보이진 않음
