### PR TITLE
임시저장 목록 UX 개선

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
@@ -905,7 +905,10 @@ export const postSchema = defineSchema((builder) => {
       args: { input: t.arg({ type: RevisePostInput }) },
       resolve: async (query, _, { input }, { db, ...context }) => {
         const post = await db.post.findUniqueOrThrow({
-          where: { id: input.postId },
+          where: {
+            id: input.postId,
+            state: { not: 'DELETED' },
+          },
         });
 
         if (post.userId !== context.session.userId) {

--- a/apps/penxle.com/src/routes/editor/[permalink]/DraftListModal.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/DraftListModal.svelte
@@ -4,12 +4,13 @@
   import { goto } from '$app/navigation';
   import { fragment, graphql } from '$glitch';
   import { mixpanel } from '$lib/analytics';
-  import { Button, Modal } from '$lib/components';
+  import { Badge, Button, Modal } from '$lib/components';
   import { toast } from '$lib/notification';
-  import type { EditorPage_DraftListModal_user } from '$glitch';
+  import type { EditorPage_DraftListModal_post, EditorPage_DraftListModal_user } from '$glitch';
 
   let _user: EditorPage_DraftListModal_user;
-  export { _user as $user };
+  let _post: EditorPage_DraftListModal_post;
+  export { _post as $post, _user as $user };
   export let open = false;
 
   let deletePostId: string | undefined;
@@ -28,9 +29,19 @@
           draftRevision {
             id
             title
+            characterCount
             updatedAt
           }
         }
+      }
+    `),
+  );
+
+  $: post = fragment(
+    _post,
+    graphql(`
+      fragment EditorPage_DraftListModal_post on Post {
+        id
       }
     `),
   );
@@ -49,33 +60,48 @@
   <svelte:fragment slot="subtitle">{$user.posts?.length ?? 0}개의 포스트</svelte:fragment>
 
   <ul class="sm:(overflow-y-auto max-h-15rem)">
-    {#each $user.posts as post (post.id)}
+    {#each $user.posts as _post (_post.id)}
       <li class="py-3 border-t border-secondary flex items-center justify-between gap-2 [&>button]:hover:block">
         <button
           class="truncate w-full"
           type="button"
           on:click={async () => {
             open = false;
-            await goto(`/editor/${post.permalink}`);
+            await goto(`/editor/${_post.permalink}`);
           }}
         >
           <p
-            class={clsx('body-16-b mb-1 truncate', post.draftRevision?.title?.trim().length === 0 && 'text-secondary')}
+            class={clsx('body-16-b mb-1 truncate', _post.draftRevision?.title?.trim().length === 0 && 'text-secondary')}
           >
-            {post.draftRevision?.title?.trim().length === 0
+            {_post.draftRevision?.title?.trim().length === 0
               ? '(제목 없음)'
-              : post.draftRevision?.title ?? '(제목 없음)'}
+              : _post.draftRevision?.title ?? '(제목 없음)'}
           </p>
-          <time class="body-13-m text-secondary">{dayjs(post.draftRevision?.updatedAt).formatAsDate()}</time>
+          <div class="body-13-m text-secondary flex gap-8px items-center">
+            <div class="flex gap-2px items-center">
+              <i class="i-tb-calendar" />
+              {dayjs(_post.draftRevision?.updatedAt).formatAsDateTime()}
+            </div>
+
+            <div class="flex gap-2px items-center">
+              <i class="i-tb-text-recognition" />
+              {_post.draftRevision.characterCount}자
+            </div>
+          </div>
         </button>
         <button
           class="i-lc-trash hidden square-5 color-text-disabled"
           type="button"
           on:click={() => {
             deletePostOpen = true;
-            deletePostId = post.id;
+            deletePostId = _post.id;
           }}
         />
+        {#if _post.id === $post.id}
+          <div class="mb-1 flex-none">
+            <Badge color="green">현재 포스트</Badge>
+          </div>
+        {/if}
       </li>
     {/each}
   </ul>
@@ -95,6 +121,10 @@
           mixpanel.track('post:delete', { postId: deletePostId, via: 'editor' });
           toast.success('임시저장 포스트를 삭제했어요');
           deletePostOpen = false;
+
+          if (deletePostId === $post.id) {
+            await goto('/');
+          }
         }
       }}
     >

--- a/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/Header.svelte
@@ -79,6 +79,7 @@
         }
 
         ...EditorPage_PublishMenu_post
+        ...EditorPage_DraftListModal_post
         ...EditorPage_RevisionListModal_Post
       }
     `),
@@ -754,7 +755,7 @@
   </div>
 </header>
 
-<DraftListModal $user={$query.me} bind:open={draftListOpen} />
+<DraftListModal {$post} $user={$query.me} bind:open={draftListOpen} />
 <RevisionListModal {$post} bind:open={revisionListOpen} />
 
 <style>


### PR DESCRIPTION
- 임시저장 목록에서 현재 포스트에 배지 추가
- 임시저장 목록에 마지막으로 저장된 시간 추가 (기존에는 날짜만 표시)
- 임시저장 목록에 해당 포스트의 글자수 표시
- 현재 수정중인 임시저장 글을 삭제할 경우 메인 페이지로 보내는 기능도 추가
- 삭제된 글은 revisePost 불가능하게 수정
