### PR TITLE
팁탭 컨텐츠 렌더링되었을 때 텍스트 선택 불가능한 문제 해결

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/access-barrier/index.ts
+++ b/apps/penxle.com/src/lib/tiptap/node-views/access-barrier/index.ts
@@ -23,6 +23,10 @@ export const AccessBarrier = createNodeView(Component, {
           transformCopied: () => Slice.empty,
         },
         filterTransaction: (tr) => {
+          if (!this.editor.isEditable) {
+            return true;
+          }
+
           const nodes = findChildren(tr.doc, (node) => node.type.name === this.name);
           return nodes.length === 1;
         },


### PR DESCRIPTION
access barrier가 컨텐츠에 없을 경우 filterTransaction이 발생해서 발생하던 문제였음
