### PR TITLE
팁탭 일부 문장부호 자동 치환 기능 구현

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/extensions/index.ts
+++ b/apps/penxle.com/src/lib/tiptap/extensions/index.ts
@@ -2,3 +2,4 @@ export * from './drop-cursor';
 export * from './gap-cursor';
 export * from './history';
 export * from './placeholder';
+export * from './typography';

--- a/apps/penxle.com/src/lib/tiptap/extensions/typography.ts
+++ b/apps/penxle.com/src/lib/tiptap/extensions/typography.ts
@@ -1,0 +1,37 @@
+import { Extension, textInputRule } from '@tiptap/core';
+
+export const Typography = Extension.create({
+  name: 'typography',
+
+  addInputRules() {
+    return [
+      textInputRule({
+        find: /--$/,
+        replace: '—',
+      }),
+
+      textInputRule({
+        find: /\.{3}$/,
+        replace: '…',
+      }),
+
+      textInputRule({
+        find: /\u201C[^\u201D]*(")$/,
+        replace: '”',
+      }),
+      textInputRule({
+        find: /(?:^|[^\u201C])(")$/,
+        replace: '“',
+      }),
+
+      textInputRule({
+        find: /\u2018[^\u2019]*(')$/,
+        replace: '’',
+      }),
+      textInputRule({
+        find: /(?:^|[^\u2018])(')$/,
+        replace: '‘',
+      }),
+    ];
+  },
+});

--- a/apps/penxle.com/src/lib/tiptap/preset.ts
+++ b/apps/penxle.com/src/lib/tiptap/preset.ts
@@ -1,4 +1,4 @@
-import { DropCursor, GapCursor, History, Placeholder } from '$lib/tiptap/extensions';
+import { DropCursor, GapCursor, History, Placeholder, Typography } from '$lib/tiptap/extensions';
 import { Bold, FontColor, FontFamily, FontSize, Italic, Link, Ruby, Strike, Underline } from '$lib/tiptap/marks';
 import { AccessBarrier, Embed, File, Image } from '$lib/tiptap/node-views';
 import {
@@ -43,6 +43,7 @@ export const extensions = [
   GapCursor,
   History,
   Placeholder,
+  Typography,
 
   // node views
   AccessBarrier,


### PR DESCRIPTION
- `--` 를 `—` 로 치환
- `...` 을  `…` 로 치환
- `''` 를 `‘’` 로 치환
- `""` 를 `“”` 로 치환