### PR TITLE
새로운 팁탭 Paragraph 노드에 입력시 마지막 Paragraph 노드의 마지막 텍스트 마크를 그대로 유지함

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/nodes/paragraph.ts
+++ b/apps/penxle.com/src/lib/tiptap/nodes/paragraph.ts
@@ -1,4 +1,5 @@
-import { Node } from '@tiptap/core';
+import { findChildren, Node } from '@tiptap/core';
+import { Plugin } from '@tiptap/pm/state';
 import clsx from 'clsx';
 import { values } from '$lib/tiptap/values';
 import { closest } from '$lib/utils';
@@ -124,5 +125,37 @@ export const Paragraph = Node.create({
           return commands.updateAttributes(this.name, { letterSpacing });
         },
     };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        appendTransaction: (_, __, newState) => {
+          const { doc, selection, storedMarks, tr } = newState;
+          const { $from, empty } = selection;
+
+          if (
+            $from.parent.type.name !== this.name ||
+            !empty ||
+            $from.parentOffset !== 0 ||
+            $from.parent.childCount !== 0 ||
+            storedMarks?.length
+          ) {
+            return;
+          }
+
+          const lastNode = findChildren(doc, (node) => node.type.name === this.name).findLast(
+            ({ node, pos }) => node.childCount > 0 && pos < $from.pos,
+          );
+
+          const lastChild = lastNode?.node.lastChild;
+          if (!lastChild) {
+            return;
+          }
+
+          return tr.setStoredMarks(lastChild.marks);
+        },
+      }),
+    ];
   },
 });


### PR DESCRIPTION
엔터 두번 칠 시 텍스트 포맷이 초기화되거나, 중간에 구분선 등 기타 노드를 입력할 시 텍스트 포맷이 초기화되는 이슈 해결함

개선할 여지 꽤 있으나 일단 이 정도로 만족하기로
