### PR TITLE
컬러피커 색상 조정 시 슬라이더 입력 고정하기

### DIFF
--- a/apps/penxle.com/src/lib/components/ColorPicker.svelte
+++ b/apps/penxle.com/src/lib/components/ColorPicker.svelte
@@ -15,6 +15,7 @@
   const dispatch = createEventDispatcher<{ input: { hex: string } }>();
   const dispatchInput = (color: Color) => {
     hex = color.hex().toString().toUpperCase();
+
     dispatch('input', { hex });
   };
 
@@ -22,10 +23,6 @@
 
   $: if (hexInputEl) {
     hexInputEl.value = hex;
-  }
-
-  $: if (gradientSliderInputEl) {
-    gradientSliderInputEl.value = rgb.hue().toString();
   }
 
   let x = 0;
@@ -84,6 +81,9 @@
 
     fillGradient();
     updatePosition();
+
+    if (!gradientSliderInputEl) throw new Error('gradientSliderInputEl is undefined');
+    gradientSliderInputEl.value = rgb.hue().toString();
   };
 
   const updateHistory = async () => {


### PR DESCRIPTION
입력 값 수시로 바뀌는 경우에는 좌우로 움직이지 않도록 수정합니다.