### PR TITLE
form.submit 대신 form.requestSubmit 이용하기

### DIFF
--- a/apps/penxle.com/src/routes/editor/[permalink]/PublishMenuSearch.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/PublishMenuSearch.svelte
@@ -66,7 +66,7 @@
       bind:value={query}
       on:blur={() => {
         if (query.length > 0) {
-          formEl.submit();
+          formEl.requestSubmit();
         }
       }}
     />


### PR DESCRIPTION
form.submit() 함수는 onsubmit 핸들러를 무시한다
