### PR TITLE
포스트 페이지에서 다른 포스트 페이지로 갈 때 포스트 조회수가 기록되지 않는 문제 해결

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/[post]/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/[post]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
@@ -40,10 +39,10 @@
     }
   `);
 
-  onMount(async () => {
+  $: if (browser && $query.post.id) {
     mixpanel.track('post:view', { postId: $query.post.id });
-    await updatePostView({ postId: $query.post.id });
-  });
+    updatePostView({ postId: $query.post.id });
+  }
 
   $: if ($query.post.space?.slug && $query.post.space?.slug !== $page.params.space && browser) {
     const url = new URL(location.href);


### PR DESCRIPTION
같은 페이지 내 이동할 시 `onMount`가 호출되지 않아 `$query.post.id` 에 디펜던시가 걸려있는 reactive statement로 전환함
