### PR TITLE
array 타입 내부에 @_required 를 이용할 경우 타입이 제대로 강제되지 않는 문제 수정

### DIFF
--- a/packages/glitch/src/types.ts
+++ b/packages/glitch/src/types.ts
@@ -2,11 +2,13 @@ import graphql from 'graphql';
 import type { Client } from '@urql/core';
 import type { Readable } from 'svelte/store';
 
-export type MakeRequired<T, K extends string> = T & {
-  [P in keyof T as P extends (K extends `${infer K0}.${string}` ? K0 : K) ? P : never]-?: P extends K
-    ? NonNullable<T[P]>
-    : MakeRequired<T[P], K extends `${Exclude<P, symbol>}.${infer R}` ? R : never>;
-};
+export type MakeRequired<T, K extends string> = T extends (infer T0)[]
+  ? MakeRequired<T0, K>[]
+  : T & {
+      [P in keyof T as P extends (K extends `${infer K0}.${string}` ? K0 : K) ? P : never]-?: P extends K
+        ? NonNullable<T[P]>
+        : MakeRequired<T[P], K extends `${Exclude<P, symbol>}.${infer R}` ? R : never>;
+    };
 
 export type FragmentType<T extends { ' $fragmentType'?: unknown }> = Omit<
   NonNullable<T[' $fragmentType']>,


### PR DESCRIPTION
```graphql
query {
  recommendFeed {
    id

    publishedRevision @_required {
      id
      title
    }
  }
}
```

위와 같이 `[Post!]!` 를 리턴하는 `recommendFeed` 등 array 타입 내부의 값에 `@_required` 를 적용했음에도 glitch가 해당 타입을 계속해서 nullable로 생성하는 문제를 수정함
