### PR TITLE
불필요한 @ts-expect-error 제거

### DIFF
--- a/apps/penxle.com/src/routes/(default)/(feed)/(index)/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/(feed)/(index)/+page.svelte
@@ -23,7 +23,6 @@
     }
   `);
 
-  // @ts-expect-error TODO: fix this
   $: posts = R.unique($query.recommendFeed, (post) => post.space.id).slice(0, 5);
 </script>
 


### PR DESCRIPTION
#1272 로 버그가 수정되어 더 이상 필요하지 않은 `@ts-expect-error` 구문 삭제
