### PR TITLE
루트 레이아웃 min-height 100vh에서 100dvh로 변경

### DIFF
--- a/apps/penxle.com/src/routes/+layout.svelte
+++ b/apps/penxle.com/src/routes/+layout.svelte
@@ -53,7 +53,7 @@
   <script data-domain="penxle.com" defer src="https://plausible.io/js/script.js"></script>
 </svelte:head>
 
-<div class="min-h-screen flex flex-col">
+<div class="min-h-100dvh flex flex-col">
   <slot />
 </div>
 


### PR DESCRIPTION
ios에서 추가 스크롤 생기는 현상 방지
