### PR TITLE
팁탭 gapcursor 보이지 않는 이슈 수정

### DIFF
--- a/apps/penxle.com/src/styles/prose.css
+++ b/apps/penxle.com/src/styles/prose.css
@@ -61,14 +61,14 @@
     --uno: cursor-grab;
   }
 
-  & .ProseMirror-dropcursor {
-    --uno: bg-teal-500;
-  }
-
   & .ProseMirror-focused .ProseMirror-gapcursor {
     --uno: border-l border-l-black w-0 h-20px my-1;
     animation: cursor-blink 1s steps(2, start) infinite;
   }
+}
+
+& .ProseMirror-dropcursor {
+  --uno: bg-teal-500;
 }
 
 /*


### PR DESCRIPTION
gapcursor는 포탈로 렌더링되어서 css 적용이 안 됨
