### PR TITLE
RadioGroup 컴포넌트에서 중복된 id 지정하는 문제 해결

### DIFF
--- a/apps/penxle.com/src/routes/editor/[permalink]/RadioGroup.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/RadioGroup.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import clsx from 'clsx';
+  import { nanoid } from 'nanoid';
 
   export let name: string;
   export let items: { label: string; value: string; icon?: string; checked: boolean; text?: string }[];
@@ -9,7 +10,7 @@
 
 <fieldset class={clsx('flex gap-xs', _class)}>
   {#each items as item (item.value)}
-    {@const id = `${name}-${item.value}`}
+    {@const id = nanoid()}
     <div class="flex flex-col justify-center relative">
       <div
         class="relative m-b-0.375rem square-16 flex center bg-gray-50 border-(1px gray-100) rounded-0.625rem has-[:checked]:(border-teal-500 bg-teal-50)"


### PR DESCRIPTION
모바일 들어가면서 반응형으로 인해 RadioGroup을 2개씩 만들면서 ID 중복으로 둘 중 한 쪽에서 라디오 버튼이 동작하지 않는 문제 해결함

svelte component 내에서 state는 보존되기 때문에 랜덤한 ID를 지정하더라도 안전함
