### PR TITLE
모바일에서 팁탭 노드뷰 터치 스크롤 안 되는 이슈 수정

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/lib/NodeView.svelte
+++ b/apps/penxle.com/src/lib/tiptap/lib/NodeView.svelte
@@ -1,19 +1,10 @@
 <script lang="ts">
-  import clsx from 'clsx';
   import { getContext } from 'svelte';
   import type { DragEventHandler } from 'svelte/elements';
 
   const onDragStart = getContext<DragEventHandler<HTMLDivElement>>('onDragStart');
 </script>
 
-<div
-  {...$$restProps}
-  class={clsx('touch-none', $$restProps.class)}
-  data-node-view
-  role="presentation"
-  on:dragstart={onDragStart}
-  on:touchmove|nonpassive|preventDefault
-  on:contextmenu|preventDefault
->
+<div {...$$restProps} data-node-view role="presentation" on:dragstart={onDragStart}>
   <slot />
 </div>


### PR DESCRIPTION
안드로이드에서 노드뷰 이동 구현하려고 넣었던거라 빼도 무관함 (동작 안했음)
이거때매 모바일에서 웹툰같은거 스크롤이 안 되는 중
