### PR TITLE
/api/shortlink/ 경로는 robots.txt에서 허용

### DIFF
--- a/apps/penxle.com/src/routes/(static)/robots.txt/+server.ts
+++ b/apps/penxle.com/src/routes/(static)/robots.txt/+server.ts
@@ -4,7 +4,9 @@ import type { RequestHandler } from './$types';
 export const GET: RequestHandler = async () => {
   const lines = ['User-agent: *', 'Disallow: /api/', 'Disallow: /_internal/', 'Disallow: /_playground/'];
 
-  if (!production) {
+  if (production) {
+    lines.push('Allow: /api/shortlink/');
+  } else {
     lines.push('Disallow: /');
   }
 


### PR DESCRIPTION
트위터 OG 카드 안 뜨는 문제 해결함
트위터가 긁어갈 때 robots.txt를 존중함 (!)

https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#crawling
