### PR TITLE
팁탭 html 노드뷰에 브라우져 에이전트 기본 스타일 적용되도록 함

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/html/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/html/Component.svelte
@@ -21,11 +21,7 @@
 
   let preview = false;
 
-  $: content = DOMPurify.isSupported
-    ? DOMPurify.sanitize(node.attrs.content, {
-        USE_PROFILES: { html: true },
-      })
-    : '';
+  $: content = DOMPurify.isSupported ? DOMPurify.sanitize(node.attrs.content) : '';
 
   onMount(() => {
     if (!editor?.isEditable) {
@@ -89,13 +85,27 @@
 
       {#if preview}
         <div class="relative overflow-hidden isolate">
-          {@html content}
+          <div class="html-content">
+            {@html content}
+          </div>
         </div>
       {/if}
     </div>
   {:else}
     <div class="relative overflow-hidden isolate px-8px py-4px">
-      {@html content}
+      <div class="html-content">
+        {@html content}
+      </div>
     </div>
   {/if}
 </NodeView>
+
+<style>
+  .html-content {
+    all: initial;
+
+    & :global(:where(:not(svg, svg *))) {
+      all: revert;
+    }
+  }
+</style>


### PR DESCRIPTION
지금은 상단 스타일 리셋 때문에 `<b>` 같은 태그가 적용되지 않는 문제가 있었음
