### PR TITLE
팁탭 access_barrier 보존 로직 개선

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/components/TiptapEditor.svelte
+++ b/apps/penxle.com/src/lib/tiptap/components/TiptapEditor.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { Editor } from '@tiptap/core';
-  import { Fragment, Node, Slice } from '@tiptap/pm/model';
   import { createEventDispatcher, onMount } from 'svelte';
   import { dev } from '$app/environment';
   import { extensions } from '$lib/tiptap';
   import type { JSONContent } from '@tiptap/core';
-  import type { EditorProps } from '@tiptap/pm/view';
   import type { TiptapContentOptions } from '../types';
 
   let _class: string;
@@ -20,21 +18,6 @@
 
   let element: HTMLDivElement;
 
-  const clipboardTextParser: EditorProps['clipboardTextParser'] = (text, context) => {
-    const lines = text.split(/\r\n?|\n/);
-
-    const nodes = lines.map((line) => {
-      const content: JSONContent = {
-        type: 'paragraph',
-        ...(line.length > 0 ? { content: [{ type: 'text', text: line }] } : {}),
-      };
-      return Node.fromJSON(context.doc.type.schema, content);
-    });
-
-    const fragment = Fragment.fromArray(nodes);
-    return Slice.maxOpen(fragment);
-  };
-
   onMount(() => {
     editor = new Editor({
       element,
@@ -42,17 +25,16 @@
       extensions,
       injectCSS: false,
       editorProps: {
-        clipboardTextParser,
         attributes: { class: _class },
         scrollMargin: { top: 150, bottom: 50, left: 0, right: 0 },
         scrollThreshold: { top: 150, bottom: 50, left: 0, right: 0 },
-        handleKeyDown: (_, event) => {
-          // 맥 구름입력기에서 엔터키 입력시 마지막 글자 잘리는 문제 workaround
-          if (editor && event.key === 'Enter') {
-            const s = editor.view.state.selection;
-            editor.commands.setTextSelection(s.to);
-          }
-        },
+        // handleKeyDown: (_, event) => {
+        //   // 맥 구름입력기에서 엔터키 입력시 마지막 글자 잘리는 문제 workaround
+        //   if (editor && event.key === 'Enter') {
+        //     const s = editor.view.state.selection;
+        //     editor.commands.setTextSelection(s.to);
+        //   }
+        // },
       },
       onTransaction: ({ editor: editor_, transaction }) => {
         editor = editor_;


### PR DESCRIPTION
결제선 보존 로직 개선함

결제선을 포함해서 글을 복사하거나 삭제할 때 아무 동작을 하지 않는 대신 결제선을 제외한 컨텐츠 대상으로만 동작하도록 개선됨
