### PR TITLE
모바일 에디터 발행 버튼 패딩값 수정

### DIFF
--- a/apps/penxle.com/src/routes/editor/[permalink]/PublishMenu.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/PublishMenu.svelte
@@ -764,7 +764,7 @@
       placement="top"
     >
       <button
-        class="w-24 py-2 px-8 text-14-m text-white bg-gray-950 rounded text-center <sm:(w-full text-16-sb)"
+        class="w-24 py-2 px-8 text-14-m text-white bg-gray-950 rounded text-center <sm:(w-full text-16-sb py-2.5)"
         disabled={!selectedSpaceId}
         type="button"
         on:click={handleSubmit}


### PR DESCRIPTION
모바일 에디터 게시옵션의 발행 버튼 위아래 패딩값 8 -> 10으로 수정

|수정 전|수정 후|
|--|--|
<img width="346" alt="image" src="https://github.com/penxle/penxle/assets/76952602/98a51c8b-b69c-4c45-a807-332020836120">|<img width="346" alt="image" src="https://github.com/penxle/penxle/assets/76952602/8933b4b4-ec1d-441e-bfe2-14b432366b45">
