### PR TITLE
revisePost시 freeContent가 비어있을 경우 내용 갱신이 안 되던 문제 수정

### DIFF
--- a/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
+++ b/apps/penxle.com/src/lib/server/graphql/schemas/post.ts
@@ -989,7 +989,7 @@ export const postSchema = defineSchema((builder) => {
           kind: input.revisionKind,
           title: input.title?.length ? input.title : null,
           subtitle: input.subtitle?.length ? input.subtitle : null,
-          freeContentId: freeContent?.id,
+          freeContentId: freeContent?.id ?? null,
           paidContentId: paidContent?.id ?? null,
           price,
           paragraphIndent: input.paragraphIndent,


### PR DESCRIPTION
무료 분량이 아예 비어있을 경우 무료 분량이 비어있는 채로 저장이 되는게 아닌 마지막 무료 분량 내용이 계속 유지되던 버그 수정
