### PR TITLE
팁탭 gallery 노드뷰 비어있을 경우 자동으로 삭제

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/gallery/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/gallery/Component.svelte
@@ -16,19 +16,44 @@
   export let deleteNode: NodeViewProps['deleteNode'];
   export let updateAttributes: NodeViewProps['updateAttributes'];
 
-  let open = false;
+  let open = node.attrs.layout === 'initial';
+  let onClose: (() => void) | null;
+
+  const handleClose = () => {
+    if (node.attrs.layout !== 'initial' && node.attrs.__data.length === 0) {
+      deleteNode();
+      return;
+    }
+
+    if (editor && node.attrs.layout === 'standalone' && node.attrs.__data.length > 0) {
+      let chain = editor.chain();
+      for (const image of node.attrs.__data) {
+        chain = chain.setStandaloneGallery(image);
+      }
+      chain.run();
+      deleteNode();
+      return;
+    }
+  };
+
+  $: if (open) {
+    onClose = handleClose;
+  } else {
+    onClose?.();
+    onClose = null;
+  }
 </script>
 
-<NodeView
-  class={clsx(
-    'flex center',
-    node.attrs.ids.length === 0 && 'bg-#d9d9d9 w-394px h-221px mx-auto',
-    selected && 'ring-3 ring-teal-500',
-  )}
-  data-drag-handle
-  draggable
->
-  <Display {node} {updateAttributes} />
+<NodeView class="flex center pointer-events-none py-4px" data-drag-handle draggable>
+  <div
+    class={clsx(
+      'pointer-events-auto',
+      node.attrs.ids.length === 0 && 'bg-#d9d9d9 w-400px h-200px',
+      selected && 'ring-2 ring-teal-500',
+    )}
+  >
+    <Display {node} {updateAttributes} />
+  </div>
 </NodeView>
 
 {#if editor && selected}
@@ -44,5 +69,5 @@
     </button>
   </TiptapNodeViewBubbleMenu>
 
-  <Editor {deleteNode} {editor} {node} {updateAttributes} bind:open />
+  <Editor {node} {updateAttributes} bind:open />
 {/if}

--- a/apps/penxle.com/src/lib/tiptap/node-views/gallery/Editor.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/gallery/Editor.svelte
@@ -22,10 +22,12 @@
 
   export let open = false;
 
-  export let editor: NodeViewProps['editor'] | undefined;
   export let node: NodeViewProps['node'];
   export let updateAttributes: NodeViewProps['updateAttributes'];
-  export let deleteNode: NodeViewProps['deleteNode'];
+
+  if (node.attrs.layout === 'initial') {
+    updateAttributes({ layout: 'standalone' });
+  }
 
   let sortable: Sortable;
 
@@ -271,19 +273,6 @@
     }));
     selectedImages = selectedImages.filter((i) => !ids.includes(i));
   };
-
-  const handleInsert = () => {
-    if (editor && node.attrs.layout === 'standalone') {
-      let chain = editor.chain();
-      for (const image of node.attrs.__data) {
-        chain = chain.setStandaloneGallery(image);
-      }
-      chain.run();
-      deleteNode();
-    }
-
-    open = false;
-  };
 </script>
 
 <Modal on:close={() => (open = false)} bind:open>
@@ -470,7 +459,7 @@
     <button
       class="px-4 py-2.5 text-15-sb rounded bg-gray-950 text-white w-95px text-center border border-gray-950"
       type="button"
-      on:click={handleInsert}
+      on:click={() => (open = false)}
     >
       삽입
     </button>

--- a/apps/penxle.com/src/lib/tiptap/node-views/gallery/index.ts
+++ b/apps/penxle.com/src/lib/tiptap/node-views/gallery/index.ts
@@ -19,7 +19,7 @@ export const Gallery = createNodeView(Component, {
 
   addAttributes() {
     return {
-      layout: { default: 'standalone' },
+      layout: { default: 'initial' },
       gridColumns: { default: 2 },
       slidesPerPage: { default: 1 },
       spacing: { default: false },


### PR DESCRIPTION
갤러리 노드뷰에 이미지가 하나도 없는 상태로 에디터 창이 닫힐 시 노드뷰 자체를 삭제함
