### PR TITLE
이미지 드래그 시 자동 스크롤이 더 쉽게 되도록 함

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/gallery/Editor.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/gallery/Editor.svelte
@@ -51,42 +51,35 @@
     return arr;
   };
 
+  let sortableOptions: Sortable.Options = {
+    scroll: true,
+    handle: '.image',
+    animation: 150,
+    delay: 50,
+    forceAutoScrollFallback: true,
+    scrollSensitivity: 60,
+    scrollSpeed: 10,
+    bubbleScroll: true,
+    onMove: (evt) => {
+      if (evt.related.className.includes('prevent-dragging')) {
+        return false;
+      }
+    },
+    onEnd: ({ newIndex, oldIndex }) => {
+      if (newIndex === undefined || oldIndex === undefined) return;
+
+      const reorderedData = reorderArray(node.attrs.__data, newIndex, oldIndex);
+
+      updateAttributes({ __data: reorderedData });
+    },
+  };
+
   $: if (sortableContainer) {
-    sortable = Sortable.create(sortableContainer, {
-      handle: '.image',
-      dataIdAttr: 'data-id',
-      onMove: (evt) => {
-        if (evt.related.className.includes('prevent-dragging')) {
-          return false;
-        }
-      },
-      onEnd: ({ newIndex, oldIndex }) => {
-        if (newIndex === undefined || oldIndex === undefined) return;
-
-        const reorderedData = reorderArray(node.attrs.__data, newIndex, oldIndex);
-
-        updateAttributes({ __data: reorderedData });
-      },
-    });
+    sortable = Sortable.create(sortableContainer, sortableOptions);
   }
 
   $: if (sortableGallery) {
-    sortable = Sortable.create(sortableGallery, {
-      handle: '.image',
-      dataIdAttr: 'data-id',
-      onMove: (evt) => {
-        if (evt.related.className.includes('prevent-dragging')) {
-          return false;
-        }
-      },
-      onEnd: ({ newIndex, oldIndex }) => {
-        if (newIndex === undefined || oldIndex === undefined) return;
-
-        const reorderedData = reorderArray(node.attrs.__data, newIndex, oldIndex);
-
-        updateAttributes({ __data: reorderedData });
-      },
-    });
+    sortable = Sortable.create(sortableGallery, sortableOptions);
   }
 
   const prepareImageUpload = graphql(`


### PR DESCRIPTION
sortable js에 기본으로 auto scroll이 적용되어 있으나, 이 영역이 너무 좁아서 자동 스크롤이 안되는 것 처럼 보였음.
sortable js의 AutoScroll 플러그인 옵션을 설정해 이 문제를 해결함