### PR TITLE
팁탭 노드뷰 버블메뉴 active 스타일 미적용 문제 수정

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/embed/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/embed/Component.svelte
@@ -127,7 +127,7 @@
           <i
             class={clsx(
               'i-px2-embed-full text-gray-600 square-18px block <sm:square-20px',
-              node.attrs.mode === 'embed-full' && 'text-teal-500',
+              node.attrs.mode === 'embed-full' && 'text-teal-500!',
             )}
           />
         </button>
@@ -142,7 +142,7 @@
           <i
             class={clsx(
               'i-px2-embed-compact text-gray-600 square-18px block <sm:square-20px',
-              node.attrs.mode === 'embed-compact' && 'text-teal-500',
+              node.attrs.mode === 'embed-compact' && 'text-teal-500!',
             )}
           />
         </button>
@@ -157,7 +157,7 @@
           <i
             class={clsx(
               'i-px2-opengraph text-gray-600 square-18px block <sm:square-20px',
-              node.attrs.mode === 'opengraph' && 'text-teal-500',
+              node.attrs.mode === 'opengraph' && 'text-teal-500!',
             )}
           />
         </button>

--- a/apps/penxle.com/src/lib/tiptap/node-views/gallery/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/gallery/Component.svelte
@@ -87,7 +87,7 @@
         <i
           class={clsx(
             'i-tb-align-left text-gray-600 square-18px block <sm:square-20px',
-            node.attrs.align === 'left' && 'text-teal-500',
+            node.attrs.align === 'left' && 'text-teal-500!',
           )}
         />
       </button>
@@ -103,7 +103,7 @@
         <i
           class={clsx(
             'i-tb-align-center text-gray-600 square-18px block <sm:square-20px',
-            node.attrs.align === 'center' && 'text-teal-500',
+            node.attrs.align === 'center' && 'text-teal-500!',
           )}
         />
       </button>
@@ -119,7 +119,7 @@
         <i
           class={clsx(
             'i-tb-align-right text-gray-600 square-18px block <sm:square-20px',
-            node.attrs.align === 'right' && 'text-teal-500',
+            node.attrs.align === 'right' && 'text-teal-500!',
           )}
         />
       </button>
@@ -138,7 +138,7 @@
       <i
         class={clsx(
           'i-px2-embed-full text-gray-600 square-18px block <sm:square-20px',
-          node.attrs.size === 'full' && 'text-teal-500',
+          node.attrs.size === 'full' && 'text-teal-500!',
         )}
       />
     </button>
@@ -153,7 +153,7 @@
       <i
         class={clsx(
           'i-px2-embed-compact text-gray-600 square-18px block <sm:square-20px',
-          node.attrs.size === 'compact' && 'text-teal-500',
+          node.attrs.size === 'compact' && 'text-teal-500!',
         )}
       />
     </button>


### PR DESCRIPTION
적용 상태일 때 아이콘 색상 바뀌어야 하는데 프로덕션에서만 안 바뀌고 있었음
