### PR TITLE
CSS 파일에서 일부 unocss 클래스네임 사용이 안되는 문제 해결하기

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/gallery/driver.css
+++ b/apps/penxle.com/src/lib/tiptap/node-views/gallery/driver.css
@@ -20,9 +20,8 @@
 
   .driver-popover-progress-text {
     display: inline-flex !important;
-    border-radius: 1.875rem;
     /* prettier-ignore */
-    --uno: m-y-0.22rem absolute leading-150% top-0.875rem p-x-0.25rem p-y-0.09rem color-white bg-teal-500 text-10-b font-800 text-opacity-70 gap-0.125rem items-center;
+    --uno: m-y-0.22rem absolute leading-150% rounded-1.875rem top-0.875rem p-x-0.25rem p-y-0.03rem color-white bg-teal-500 text-10-b font-800 text-opacity-70 gap-0.125rem items-center;
 
     mark {
       --uno: color-white text-opacity-100;
@@ -43,8 +42,7 @@
   }
 
   button {
-    padding: 0.38rem 0.88rem;
-    --uno: text-11-sb leading-150% text-shadow-none;
+    --uno: text-11-sb leading-150% p-x-0.88rem p-y-0.38rem text-shadow-none;
   }
 
   .driver-popover-prev-btn {

--- a/apps/penxle.com/uno.config.ts
+++ b/apps/penxle.com/uno.config.ts
@@ -2,7 +2,7 @@ import { presetPenxle } from '@penxle/lib/unocss';
 import { defineConfig, transformerDirectives, transformerVariantGroup } from 'unocss';
 
 export default defineConfig({
-  content: { pipeline: { include: ['**/*.{svelte,ts}'] } },
+  content: { pipeline: { include: ['**/*.{svelte,ts,css}'] } },
   presets: [presetPenxle()],
   transformers: [transformerDirectives(), transformerVariantGroup()],
 });


### PR DESCRIPTION
CSS 파일에서 일부 unocss 클래스네임 사용이 안되는 문제 해결하기

Revert "이미지 에디터 온보딩 스타일 적용안되는 문제 수정 (#1361)"

This reverts commit 38f4bf7d98b1d6c496f74059a855c770d70af3b2.