### PR TITLE
pencil.so 도메인 병렬적으로 추가

### DIFF
--- a/apps/bedrock/pulumi/aws/acm.ts
+++ b/apps/bedrock/pulumi/aws/acm.ts
@@ -34,6 +34,7 @@ const createCertificate = (domain: string) => {
 };
 
 export const certificates = {
+  pencil_so: createCertificate('pencil.so'),
   penxle_com: createCertificate('penxle.com'),
   penxle_io: createCertificate('penxle.io'),
   pnxl_cc: createCertificate('pnxl.cc'),
@@ -44,6 +45,7 @@ export const certificates = {
 };
 
 export const outputs = {
+  AWS_ACM_PENCIL_SO_CERTIFICATE_ARN: certificates.pencil_so.arn,
   AWS_ACM_PENXLE_COM_CERTIFICATE_ARN: certificates.penxle_com.arn,
   AWS_ACM_PENXLE_IO_CERTIFICATE_ARN: certificates.penxle_io.arn,
   AWS_ACM_PNXL_CC_CERTIFICATE_ARN: certificates.pnxl_cc.arn,

--- a/apps/bedrock/pulumi/aws/cloudfront.ts
+++ b/apps/bedrock/pulumi/aws/cloudfront.ts
@@ -19,6 +19,7 @@ const createCertificate = (domain: string) => {
 };
 
 export const certificates = {
+  pencil_so: createCertificate('pencil.so'),
   penxle_com: createCertificate('penxle.com'),
   penxle_io: createCertificate('penxle.io'),
   pnxl_cc: createCertificate('pnxl.cc'),
@@ -203,6 +204,7 @@ new aws.route53.Record('pnxl.net', {
 });
 
 export const outputs = {
+  AWS_ACM_CLOUDFRONT_PENCIL_SO_CERTIFICATE_ARN: certificates.pencil_so.arn,
   AWS_ACM_CLOUDFRONT_PENXLE_COM_CERTIFICATE_ARN: certificates.penxle_com.arn,
   AWS_ACM_CLOUDFRONT_PENXLE_IO_CERTIFICATE_ARN: certificates.penxle_io.arn,
   AWS_ACM_CLOUDFRONT_PNXL_CC_CERTIFICATE_ARN: certificates.pnxl_cc.arn,

--- a/apps/bedrock/pulumi/aws/route53.ts
+++ b/apps/bedrock/pulumi/aws/route53.ts
@@ -9,6 +9,7 @@ const createZone = (domain: string) => {
 };
 
 export const zones = {
+  pencil_so: createZone('pencil.so'),
   penxle_com: createZone('penxle.com'),
   penxle_io: createZone('penxle.io'),
   pnxl_cc: createZone('pnxl.cc'),
@@ -17,6 +18,15 @@ export const zones = {
   pnxl_net: createZone('pnxl.net'),
   pnxl_site: createZone('pnxl.site'),
 };
+
+new aws.route53.Record('pencil.so|txt', {
+  zoneId: zones.pencil_so.zoneId,
+  type: 'TXT',
+  name: 'pencil.so',
+  // spell-checker:disable-next-line
+  records: ['google-site-verification=7lMNJhce63je2LK5iw8ZzBFh34dMrjjS2IfRDd06Sm0'],
+  ttl: 300,
+});
 
 new aws.route53.Record('penxle.com|txt', {
   zoneId: zones.penxle_com.zoneId,

--- a/apps/penxle.com/pulumi/index.ts
+++ b/apps/penxle.com/pulumi/index.ts
@@ -59,6 +59,59 @@ const site = new penxle.Site('penxle.com', {
   },
 });
 
+new penxle.Site('pencil.so', {
+  name: 'pencil',
+
+  domain: {
+    production: 'pencil.so',
+  },
+
+  image: {
+    name: '721144421085.dkr.ecr.ap-northeast-2.amazonaws.com/penxle.com',
+    digest: config.require('image.digest'),
+  },
+
+  resources: {
+    cpu: '1000m',
+    memory: '2000Mi',
+  },
+
+  autoscale: {
+    minCount: 2,
+    maxCount: 20,
+  },
+
+  iam: {
+    policy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: ['s3:GetObject', 's3:PutObject'],
+          Resource: [
+            pulumi.concat(bedrockRef('AWS_S3_BUCKET_DATA_ARN'), '/*'),
+            pulumi.concat(bedrockRef('AWS_S3_BUCKET_UPLOADS_ARN'), '/*'),
+          ],
+        },
+        {
+          Effect: 'Allow',
+          Action: ['s3:DeleteObject'],
+          Resource: [pulumi.concat(bedrockRef('AWS_S3_BUCKET_UPLOADS_ARN'), '/*')],
+        },
+        {
+          Effect: 'Allow',
+          Action: ['ses:SendEmail'],
+          Resource: ['*'],
+        },
+      ],
+    },
+  },
+
+  secret: {
+    project: 'penxle-com',
+  },
+});
+
 if (pulumi.getStack() === 'prod') {
   new penxle.Redirect('www.penxle.com', {
     name: 'www-penxle-com',


### PR DESCRIPTION
seo 테스트용으로 이용할 `pencil.so` 도메인을 기존 `penxle.com` 도메인과 병렬적으로 지원함
며칠 정도 테스트 후에 seo 체크할 예정
