### PR TITLE
폼 전송 이후에 유효성 검사 결과 표시하기

### DIFF
--- a/apps/penxle.com/src/lib/components/forms/FormValidationMessage.svelte
+++ b/apps/penxle.com/src/lib/components/forms/FormValidationMessage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getFormContext } from '$lib/form';
+  import type { Writable } from 'svelte/store';
 
   let errorFor: string;
   export { errorFor as for };
@@ -9,9 +10,16 @@
   if (!form) {
     throw new Error('Validation must be used within a Form');
   }
+  const isSubmitting: Writable<boolean> = form.isSubmitting;
+
+  let isSubmitted = false;
+
+  $: if ($isSubmitting && !isSubmitted) {
+    isSubmitted = true;
+  }
 
   $: store = type === 'error' ? form.errors : form.warnings;
-  $: message = $store[errorFor]?.[0];
+  $: message = isSubmitted && $store[errorFor]?.[0];
 </script>
 
 {#if message}


### PR DESCRIPTION
access-barrier 노드 뷰와 FormValidationMessage 컴포넌트를 수정하여 해당 코드 리소스를 사용하는 많은 페이지의 경험이 조금 더 나아지는 것을 기대합니다.