### PR TITLE
태그 페이지 로드 안 되는 버그 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/tag/[name]/(index)/+page.ts
+++ b/apps/penxle.com/src/routes/(default)/tag/[name]/(index)/+page.ts
@@ -1,1 +1,5 @@
-// eslint-disable-next-line unicorn/no-empty-file
+import type { PageLoadEvent } from './$types';
+
+export const _TagPage_QueryVariables = (event: PageLoadEvent) => {
+  return { name: event.params.name };
+};


### PR DESCRIPTION
`+page.ts` 에서 operation variable 주입을 깜빡함
