### PR TITLE
피드 페이지에서 오버플로우 되는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/(index)/PostCard.svelte
+++ b/apps/penxle.com/src/routes/(default)/(index)/PostCard.svelte
@@ -129,7 +129,7 @@
           {$post.publishedRevision.subtitle}
         </div>
       {/if}
-      <div class="text-14-r text-gray-700 mt-12px break-words line-clamp-2">
+      <div class="text-14-r text-gray-700 mt-12px break-words line-clamp-2 break-all">
         {$post.publishedRevision.previewText}
       </div>
     </div>


### PR DESCRIPTION
포스트 카드 미리보기 텍스트가 줄바꿈이 안되고 있어 발생하고 있었습니다.