### PR TITLE
댓글 관련 mixpanel 이벤트 이름 전체적으로 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/Comment.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/Comment.svelte
@@ -246,10 +246,10 @@
               on:click={async () => {
                 if ($postComment.pinned) {
                   await unpinComment({ commentId: $postComment.id });
-                  mixpanel.track('unpin:comment', { commentId: $postComment.id });
+                  mixpanel.track('comment:unpin', { commentId: $postComment.id });
                 } else {
                   await pinComment({ commentId: $postComment.id });
-                  mixpanel.track('unpin:comment', { commentId: $postComment.id });
+                  mixpanel.track('comment:pin', { commentId: $postComment.id });
                 }
               }}
             >
@@ -265,7 +265,7 @@
                 if (!$postComment.masquerade) return;
 
                 await blockMasquerade({ masqueradeId: $postComment.masquerade.id, spaceId: $query.post.space.id });
-                mixpanel.track('block:masquerade', {
+                mixpanel.track('space:masquerade:block', {
                   masqueradeId: $postComment.masquerade?.id,
                   spaceId: $query.post.space.id,
                 });
@@ -281,7 +281,7 @@
 
                 if (!$postComment.masquerade) return;
 
-                mixpanel.track('delete:comment', {
+                mixpanel.track('comment:delete', {
                   masqueradeId: $postComment.masquerade.id,
                   spaceId: $query.post.space.id,
                 });
@@ -310,10 +310,10 @@
               on:click={async () => {
                 if ($postComment.likedByMe) {
                   await unlikeComment({ commentId: $postComment.id });
-                  mixpanel.track('unlike:comment', { postId: $query.post.id, commentId: $postComment.id });
+                  mixpanel.track('comment:unlike', { postId: $query.post.id, commentId: $postComment.id });
                 } else {
                   await likeComment({ commentId: $postComment.id });
-                  mixpanel.track('like:comment', { postId: $query.post.id, commentId: $postComment.id });
+                  mixpanel.track('comment:like', { postId: $query.post.id, commentId: $postComment.id });
                 }
               }}
             >

--- a/apps/penxle.com/src/routes/(default)/[space]/dashboard/subscribers/blocked/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/dashboard/subscribers/blocked/+page.svelte
@@ -83,7 +83,7 @@
                 type="button"
                 on:click={async () => {
                   await unblockMasquerade({ spaceId: $query.space.id, masqueradeId: masquerade.id });
-                  mixpanel.track('unblock:masquerade', { masqueradeId: masquerade.id, spaceId: $query.space.id });
+                  mixpanel.track('space:masquerade:unblock', { masqueradeId: masquerade.id, spaceId: $query.space.id });
                 }}
               >
                 차단해제


### PR DESCRIPTION
타 이벤트와 유사하게 `[scope]:[action]` 형식으로 믹스패널 이벤트 이름 맞춤
