### PR TITLE
포스트 OG 이미지 썸네일 가끔 안 들어가던 문제 해결

### DIFF
--- a/apps/penxle.com/src/lib/server/rest/routes/opengraph.ts
+++ b/apps/penxle.com/src/lib/server/rest/routes/opengraph.ts
@@ -3,6 +3,7 @@ import { renderAsync } from '@resvg/resvg-js';
 import got from 'got';
 import { png } from 'itty-router';
 import satori from 'satori';
+import sharp from 'sharp';
 import twemoji from 'twemoji';
 import { s3 } from '$lib/server/external-api/aws';
 import { createRouter } from '../router';
@@ -134,7 +135,7 @@ opengraph.get('/opengraph/post/:postId', async (request, { db }) => {
               style: {
                 display: 'flex',
                 flexDirection: 'column',
-                width: '620px',
+                width: post.thumbnail ? '620px' : '100%',
                 height: '100%',
               },
             },
@@ -219,7 +220,8 @@ opengraph.get('/opengraph/post/:postId', async (request, { db }) => {
 const getS3ImageSrc = async (key: string) => {
   const object = await s3.send(new GetObjectCommand({ Bucket: 'penxle-data', Key: key }));
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const buffer = await object.Body!.transformToByteArray();
+  const source = await object.Body!.transformToByteArray();
+  const buffer = await sharp(source, { failOn: 'none' }).png().toBuffer();
 
-  return `data:image/png;base64,${Buffer.from(buffer).toString('base64')}`;
+  return `data:image/png;base64,${buffer.toString('base64')}`;
 };


### PR DESCRIPTION
이미지 리소스를 `data:image/png;base64,` 로 하드코딩해 넣고 있어서 썸네일 원본이 jpg 등일 경우 썸네일이 최종 이미지에 제대로 삽입되지 않던 문제를 해결함

또한 썸네일이 없을 경우 제목 등이 전체 너비를 차지하도록 수정함
