### PR TITLE
Post.externalSearchable이 실제로 동작하도록 수정함

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/[post]/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/[post]/+page.svelte
@@ -15,6 +15,7 @@
 
       post(permalink: $permalink) {
         id
+        externalSearchable
         publishedAt
 
         space {
@@ -89,6 +90,9 @@
 />
 
 <svelte:head>
+  {#if !$query.post.externalSearchable}
+    <meta name="robots" content="noindex" />
+  {/if}
   <meta content={dayjs($query.post.publishedAt).toISOString()} property="article:published_time" />
   <meta content={dayjs($query.post.publishedRevision.createdAt).toISOString()} property="article:modified_time" />
   <meta content={$query.post.member?.profile.name} property="article:author" />

--- a/apps/penxle.com/src/routes/(static)/sitemap.xml/+server.ts
+++ b/apps/penxle.com/src/routes/(static)/sitemap.xml/+server.ts
@@ -22,6 +22,7 @@ export const GET: RequestHandler = async (event) => {
         state: 'PUBLISHED',
         visibility: 'PUBLIC',
         password: null,
+        externalSearchable: true,
         space: { state: 'ACTIVE', visibility: 'PUBLIC' },
       },
       orderBy: { id: 'asc' },


### PR DESCRIPTION
지금까지는 `externalSearchable`이 실제로 동작하고 있지 않았음 (!)

- 포스트 페이지에서 `externalSearchable`이 `false`일 경우 헤드에 `<meta name="robots" content="noindex" />` 추가함
- `sitemap.xml` 생성시 `externalSearchable`이 `true`인 포스트만 포함하도록 함
