### PR TITLE
pandacss 잘못 옮겨진 부분 수정

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/gallery/Editor.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/gallery/Editor.svelte
@@ -309,7 +309,7 @@
     </Tooltip>
   </svelte:fragment>
 
-  <div class={flex({ height: '511px' })}>
+  <div class={flex({ height: '490px' })}>
     <div class={flex({ flexDirection: 'column', width: '562px' })}>
       <div
         class={flex({
@@ -351,7 +351,7 @@
 
       <button
         bind:this={onboardingAnchorElements[1]}
-        class={css({
+        class={flex({
           zIndex: '1',
           flexShrink: '1',
           alignSelf: 'flex-end',
@@ -466,14 +466,13 @@
     <div
       class={flex({
         flexDirection: 'column',
-        flex: 'none',
+        flexGrow: '1',
         gap: '16px',
         borderLeftWidth: '1px',
         borderColor: 'gray.200',
         paddingY: '20px',
         paddingLeft: '20px',
         paddingRight: '24px',
-        width: '150px',
       })}
     >
       <div>
@@ -574,7 +573,7 @@
   </svelte:fragment>
 </Modal>
 
-<Modal bind:open={imageListOpen}>
+<Modal size="lg" bind:open={imageListOpen}>
   <svelte:fragment slot="title">
     <button class={css({ marginRight: '4px' })} type="button" on:click={() => (imageListOpen = false)}>
       <Icon style={css.raw({ size: '24px' })} icon={IconChevronLeft} />

--- a/apps/penxle.com/src/lib/tiptap/node-views/gallery/Slide.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/gallery/Slide.svelte
@@ -64,16 +64,19 @@
 >
   <button
     bind:this={swiperPrevElem}
-    class={css({
-      position: 'absolute',
-      top: '[50%]',
-      left: '[-40%]',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      color: { base: 'gray.500', _disabled: 'gray.300' },
-      hideBelow: 'sm',
-    })}
+    class={css(
+      {
+        position: 'absolute',
+        top: '[50%]',
+        left: '[-40px]',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: { base: 'gray.500', _disabled: 'gray.300' },
+        hideBelow: 'sm',
+      },
+      isomorphicImages.length === 0 && { display: 'none' },
+    )}
     type="button"
   >
     <Icon style={css.raw({ size: '24px' })} icon={IconChevronLeft} />
@@ -112,7 +115,7 @@
       {
         position: 'absolute',
         top: '[50%]',
-        right: '[-40%]',
+        right: '[-40px]',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/apps/penxle.com/src/routes/(default)/NotificationMenu.svelte
+++ b/apps/penxle.com/src/routes/(default)/NotificationMenu.svelte
@@ -297,9 +297,11 @@
           <a
             class={css({
               display: 'inline-block',
+              paddingY: '16px',
               width: 'full',
               textAlign: 'center',
               fontSize: '14px',
+              fontWeight: 'medium',
               color: 'gray.400',
             })}
             href="/me/notifications"

--- a/apps/penxle.com/src/routes/(default)/[space]/(space)/+layout.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/(space)/+layout.svelte
@@ -177,13 +177,14 @@
 
           {#if $query.space.visibility === 'PRIVATE'}
             <span
-              class={css({
+              class={center({
                 borderRadius: '16px',
                 paddingX: '6px',
                 paddingY: '4px',
                 fontSize: '12px',
                 fontWeight: 'bold',
-                color: 'gray.100',
+                color: 'gray.500',
+                backgroundColor: 'gray.100',
                 textWrap: 'nowrap',
               })}
             >

--- a/apps/penxle.com/src/routes/(default)/[space]/(space)/collections/+page.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/(space)/collections/+page.svelte
@@ -102,7 +102,7 @@
 
     {#if $query.space.meAsMember}
       <Button
-        style={flex.raw({ gap: '8px' })}
+        style={flex.raw({ gap: '8px', marginX: '8px', marginBottom: '8px', backgroundColor: 'white' })}
         color="tertiary"
         size="lg"
         variant="outlined"

--- a/apps/penxle.com/src/routes/editor/[permalink]/DraftListModal.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/DraftListModal.svelte
@@ -88,7 +88,7 @@
         >
           <p
             class={css(
-              { marginBottom: '4px', fontWeight: 'bold', truncate: true },
+              { marginBottom: '4px', textAlign: 'left', fontWeight: 'bold', truncate: true },
               _post.draftRevision?.title?.trim().length === 0 && { color: 'gray.500' },
             )}
           >


### PR DESCRIPTION
- `이미지 에디터 모달`
  - 전체 보기 버튼 레이아웃 깨지는 문제 수정
  - 슬라이드 버튼 위치 잘못 옮긴 문제 수정
  - 전체 보기 모달 사이즈 다른 문제 수정
- 알림 더보기 버튼 사이즈 조정
- `스페이스 상세 페이지`: 비공개 스페이스 표시 레이아웃 깨지는 문제 수정
- `컬렉션 페이지`: 모바일에서 새 커렉션 생성 버튼 양옆에 간격 추가, backgroundColor 지정
- `임시저장글 목록 모달`: 제목 중앙정렬 -> 왼쪽 정렬로 수정