### PR TITLE
관심 스페이스 목록의 비공개 뱃지 레이아웃 깨지는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/me/cabinets/FollowSpaceModal.svelte
+++ b/apps/penxle.com/src/routes/(default)/me/cabinets/FollowSpaceModal.svelte
@@ -114,14 +114,15 @@
               </p>
               {#if space.visibility === 'PRIVATE'}
                 <span
-                  class={css({
+                  class={flex({
+                    align: 'center',
                     borderRadius: 'full',
                     paddingX: '4px',
                     fontSize: '12px',
                     fontWeight: 'bold',
                     color: 'gray.500',
                     textWrap: 'nowrap',
-                    backgroundColor: 'white',
+                    backgroundColor: 'gray.100',
                   })}
                 >
                   비공개


### PR DESCRIPTION
|before|after|
|--|--|
<img width="414" alt="image" src="https://github.com/penxle/penxle/assets/76952602/a2fd6c2e-998b-4cb0-9e92-cea7e188e47b">|<img width="413" alt="image" src="https://github.com/penxle/penxle/assets/76952602/7b7a063f-4869-427d-8f98-317fff34670e">