### PR TITLE
저장이력 목록 전체가 선택된 것처럼 보이는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/editor/[permalink]/RevisionListModal.svelte
+++ b/apps/penxle.com/src/routes/editor/[permalink]/RevisionListModal.svelte
@@ -77,18 +77,23 @@
       <ul class={css({ size: 'full', overflowY: 'auto' })}>
         {#each $post.revisions as revision (revision.id)}
           <li
-            class={flex({
-              'justify': 'space-between',
-              'align': 'center',
-              'borderRadius': '4px',
-              'paddingX': '8px',
-              'paddingY': '12px',
-              'width': 'full',
-              '_hover': { backgroundColor: 'gray.50' },
-              '_pressed': { backgroundColor: 'gray.50' },
-              '--menu-display': { base: 'none', _pressed: 'block' },
-            })}
-            data-pressed={selectedRevisionId === revision.id}
+            class={css(
+              {
+                'display': 'flex',
+                'justifyContent': 'space-between',
+                'alignItems': 'center',
+                'borderRadius': '4px',
+                'paddingX': '8px',
+                'paddingY': '12px',
+                'width': 'full',
+                '_hover': { backgroundColor: 'gray.50' },
+                '--menu-display': 'none',
+              },
+              selectedRevisionId === revision.id && {
+                'backgroundColor': 'gray.50',
+                '--menu-display': 'block',
+              },
+            )}
           >
             <button
               class={css({ flexGrow: '1' })}


### PR DESCRIPTION
- pandacss의 _pressed가 li 요소의 data-pressed true/false 여부와 상관없이 무조건 적용되는 문제가 있었음 -> li의 data-pressed attribute를 없애고 스타일을 바로 적용함

|before|after|
|--|--|
<img width="263" alt="image" src="https://github.com/penxle/penxle/assets/76952602/04b14320-9171-4017-bf95-1b6978b6f446">|<img width="266" alt="image" src="https://github.com/penxle/penxle/assets/76952602/84285b60-9fd7-41eb-97d7-ac16489767ef">

