### PR TITLE
모바일 검색창에 focus시 검색창이 다시 닫히는 문제 수정

### DIFF
--- a/apps/penxle.com/src/routes/(default)/SearchBar.svelte
+++ b/apps/penxle.com/src/routes/(default)/SearchBar.svelte
@@ -46,12 +46,6 @@
   });
 </script>
 
-<svelte:window
-  on:resize={() => {
-    open = window.innerWidth >= 800;
-  }}
-/>
-
 {#if open}
   <div
     class={css({


### PR DESCRIPTION
모바일에서 input 클릭 시 focus되면서 resize 이벤트가 일어난다.. 일단 빼는걸루