### PR TITLE
tsx에서 ~icons 경로를 찾지 못하는 문제 수정

### DIFF
--- a/apps/penxle.com/scripts/loader/hooks.js
+++ b/apps/penxle.com/scripts/loader/hooks.js
@@ -1,7 +1,9 @@
+const specialPrefixes = ['$app/', '$env/', '~icons/'];
+
 export const resolve = async (specifier, context, nextResolve) => {
-  if (specifier.startsWith('$app/') || specifier.startsWith('$env/')) {
+  if (specialPrefixes.some((prefix) => specifier.startsWith(prefix))) {
     return {
-      url: `virtual://${specifier}`,
+      url: `special://${specifier}`,
       shortCircuit: true,
     };
   }
@@ -10,9 +12,17 @@ export const resolve = async (specifier, context, nextResolve) => {
 };
 
 export const load = (url, context, nextLoad) => {
-  if (url.startsWith('virtual://')) {
-    const mod = url.replace(/^virtual:\/\//, '');
+  if (url.startsWith('special://')) {
+    const mod = url.replace(/^special:\/\//, '');
     let source;
+
+    if (mod.startsWith('~icons/')) {
+      return {
+        format: 'module',
+        source: 'export default {};',
+        shortCircuit: true,
+      };
+    }
 
     switch (mod) {
       case '$env/dynamic/public':


### PR DESCRIPTION
`pnpm run:script` 를 이용한 스크립트 실행에서 `~icons` 참조가 있을 경우 스크립트 실행이 안 되는 이슈 수정
