### PR TITLE
밑줄 이미지 편집 모달을 열고 해당 컨테이너 세로 너비가 줄어들었다 늘어나는 문제 고치기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/ShareContent.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/ShareContent.svelte
@@ -197,13 +197,11 @@
         borderColor: backgroundColor === '#FFFFFF' ? 'black/10' : 'transparent',
       })}
     >
-      {#if generatedPostShareImage}
-        <img
-          class={css({ width: '398px', maxWidth: 'full', height: '398px', maxHeight: 'full' })}
-          alt="밑줄 이미지 미리보기"
-          src={generatedPostShareImage}
-        />
-      {/if}
+      <img
+        class={css({ width: '398px', maxWidth: 'full', height: '398px', maxHeight: 'full' })}
+        alt="밑줄 이미지 미리보기"
+        src={generatedPostShareImage || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"}
+      />
 
       {#if showSpinner}
         <div class={center({ position: 'absolute', inset: '0', paddingX: '16px', paddingY: '8px' })}>


### PR DESCRIPTION
https://github.com/penxle/penxle/assets/5278201/b286c5ef-e492-45ca-bc7f-a49595dbc953

생성된 공유 이미지가 아직 없는 경우 미리보기 영역이 공간을 차지하지 않아 생기는 문제로 미리보기 이미지 초기 생성 전까지 빈 SVG를 대신 보여주게 수정했습니다.