### PR TITLE
공유 이미지 편집 미리보기 이미지 중앙정렬 하기

### DIFF
--- a/apps/penxle.com/src/routes/(default)/[space]/ShareContent.svelte
+++ b/apps/penxle.com/src/routes/(default)/[space]/ShareContent.svelte
@@ -194,11 +194,15 @@
         marginTop: '20px',
         marginBottom: '16px',
         borderWidth: '1px',
-        borderColor: backgroundColor === '#FFFFFF' ? 'black/10' : 'transparent',
+        borderColor: backgroundColor === '#FFFFFF' ? '[black/10]' : 'transparent',
+        alignSelf: 'center',
+        size: 'full',
+        maxSize: '398px',
+        aspectRatio: '[1/1]',
       })}
     >
       <img
-        class={css({ width: '398px', maxWidth: 'full', height: '398px', maxHeight: 'full' })}
+        class={css({ size: 'full' })}
         alt="밑줄 이미지 미리보기"
         src={generatedPostShareImage || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E"}
       />

--- a/apps/penxle.com/src/styles/utilities.ts
+++ b/apps/penxle.com/src/styles/utilities.ts
@@ -8,4 +8,11 @@ export const utilities = {
       height: value,
     }),
   }),
+  maxSize: defineUtility({
+    values: 'sizes',
+    transform: (value) => ({
+      maxWidth: value,
+      maxHeight: value,
+    }),
+  }),
 };


### PR DESCRIPTION

<img width="746" alt="스크린샷 2024-03-15 오후 4 35 48" src="https://github.com/penxle/penxle/assets/5278201/c2f7f0e5-b386-43c3-b89d-21922098ab97">

Panda CSS 로 스타일 시트를 옮기는 과정에서 해당 레이아웃 설정이 빠진 것 같아 수정했습니다.