### PR TITLE
추천피드 알고리즘 수정

### DIFF
--- a/apps/penxle.com/src/lib/server/utils/search.ts
+++ b/apps/penxle.com/src/lib/server/utils/search.ts
@@ -215,9 +215,12 @@ type IndexPostTrendingScoreParams = {
 export const indexPostTrendingScore = async ({ db, postId }: IndexPostTrendingScoreParams) => {
   const trendingScoreCache = await redis.get(`Post:${postId}:trendingScore`);
   if (!trendingScoreCache) {
-    const viewCount = await getPostViewCount({ db, postId });
+    const [viewCount, purchasedCount] = await Promise.all([
+      getPostViewCount({ db, postId }),
+      db.postPurchase.count({ where: { postId } }),
+    ]);
     // 앞으로 점수에 영향을 미치는 요소들을 추가할지도?
-    const score = viewCount;
+    const score = viewCount + purchasedCount * 20;
 
     await elasticSearch
       .update({


### PR DESCRIPTION
- 인기 점수에 구매된 횟수 추가
- 최신 점수 기준 완화 (1d/7d -> 7d/30d)
- 연령제한에 맞게 추천