### PR TITLE
ui 폰트 SUIT로 변경

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/components/TiptapEditor.svelte
+++ b/apps/penxle.com/src/lib/tiptap/components/TiptapEditor.svelte
@@ -54,7 +54,10 @@
 
 <div
   bind:this={element}
-  class={cx('tiptap tiptap-editor', css({ display: 'contents', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }))}
+  class={cx(
+    'tiptap tiptap-editor',
+    css({ display: 'contents', fontFamily: 'prose', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }),
+  )}
   autocapitalize="off"
   autocorrect="off"
   data-indent={options.paragraphIndent}

--- a/apps/penxle.com/src/lib/tiptap/components/TiptapRenderer.svelte
+++ b/apps/penxle.com/src/lib/tiptap/components/TiptapRenderer.svelte
@@ -53,7 +53,10 @@
 
 <article
   bind:this={element}
-  class={cx('tiptap', css({ display: 'contents', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }))}
+  class={cx(
+    'tiptap',
+    css({ display: 'contents', fontFamily: 'prose', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }),
+  )}
   data-indent={options.paragraphIndent}
   data-spacing={options.paragraphSpacing}
   on:copy|capture={handleContentProtection}

--- a/apps/penxle.com/src/service-worker.ts
+++ b/apps/penxle.com/src/service-worker.ts
@@ -9,11 +9,7 @@ const sw = self as unknown as ServiceWorkerGlobalScope;
 
 const cacheKey = `cache-${version}`;
 const assets = [...build, ...files];
-const remoteAssets = [
-  'https://pnxl.net/assets/fonts/Pretendard.woff2',
-  'https://pnxl.net/assets/fonts/RIDIBatang.woff2',
-  'https://pnxl.net/assets/fonts/FiraCode.woff2',
-];
+const remoteAssets = ['https://pnxl.net/assets/fonts/SUIT.woff2'];
 
 sw.addEventListener('install', (event) => {
   event.waitUntil(

--- a/apps/penxle.com/src/styles/fonts.css
+++ b/apps/penxle.com/src/styles/fonts.css
@@ -1,4 +1,12 @@
 @font-face {
+  font-family: 'PNXL_SUIT';
+  src: url('https://pnxl.net/assets/fonts/SUIT.woff2') format('woff2-variations');
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: block;
+}
+
+@font-face {
   font-family: 'PNXL_Pretendard';
   src: url('https://pnxl.net/assets/fonts/Pretendard.woff2') format('woff2-variations');
   font-style: normal;

--- a/apps/penxle.com/src/styles/fonts.ts
+++ b/apps/penxle.com/src/styles/fonts.ts
@@ -1,6 +1,7 @@
 import { defineTokens } from '@pandacss/dev';
 
 export const fonts = defineTokens.fonts({
-  sans: { value: 'PNXL_Pretendard' },
+  ui: { value: 'PNXL_SUIT' },
+  prose: { value: 'PNXL_Pretendard' },
   mono: { value: 'PNXL_FiraCode' },
 });

--- a/apps/penxle.com/src/styles/global.ts
+++ b/apps/penxle.com/src/styles/global.ts
@@ -16,9 +16,7 @@ export const globalCss = defineGlobalStyles({
   },
 
   'html': {
-    fontFamily: 'sans',
-    // spell-checker:disable-next-line
-    fontFeatureSettings: '"calt" 0, "ss01" 1, "ss05" 1, "ss07" 1',
+    fontFamily: 'ui',
     textSizeAdjust: '100%',
 
     WebkitFontSmoothing: 'auto',


### PR DESCRIPTION
팁탭 에디터 등 유저 컨텐츠에는 Pretendard를 기본 폰트로 렌더링해야 하기에 Pretendard를 `prose` 폰트 패밀리로 별도로 지정함.
Pretendard를 더 이상 이용하지 않아 마찬가지로 불필요한 `fontFeatureSettings` 설정 또한 제거함