### PR TITLE
유료선 해제 후에도 가격 정보가 남아있는 버그 고치기

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/access-barrier/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/access-barrier/Component.svelte
@@ -32,8 +32,6 @@
   export let editor: NodeViewProps['editor'] | undefined;
   export let updateAttributes: NodeViewProps['updateAttributes'];
 
-  $: isLastChild = editor?.state.doc.lastChild?.eq(node) ?? false;
-
   let priceOpen = false;
   let loginRequireOpen = false;
   let postPurchaseOpen = false;
@@ -135,7 +133,7 @@
         boxShadow: '[0 2px 10px 0 {colors.black/4}]',
       })}
     >
-      {#if isLastChild}
+      {#if !node.attrs || node.attrs.price === null}
         <button
           class={css({
             borderRadius: '4px',
@@ -147,12 +145,14 @@
             _hover: { backgroundColor: 'gray.100' },
           })}
           type="button"
-          on:click={() =>
+          on:click={() => {
+            updateAttributes({ price: 0 });
             editor
               ?.chain()
               .insertContentAt(getPos() + node.nodeSize, { type: 'paragraph' })
               .focus()
-              .run()}
+              .run();
+          }}
         >
           여기서부터 유료 분량 만들기
         </button>
@@ -211,11 +211,15 @@
             _hover: { backgroundColor: 'gray.100' },
           })}
           type="button"
-          on:click={() =>
+          on:click={() => {
+            updateAttributes({ price: null });
+
+            const from = getPos();
             editor
               ?.chain()
-              .cut({ from: getPos(), to: getPos() + node.nodeSize }, editor.state.doc.content.size)
-              .run()}
+              .cut({ from, to: from + node.nodeSize }, editor.state.doc.content.size)
+              .run();
+          }}
         >
           해제
         </button>


### PR DESCRIPTION
문제 재현해보니 결제선을 해제해도 가격 정보가 프론트 단에 남겨 있네요...
1. 글 작성 중 유료 분량을 만든다.
2. 임시 저장을 한다.
3. 유료 결제 분량을 해제한다.
4. 유료 분량을 만든다 ➡️ **최근에 설정한 가격이 그대로 바로 설정됨**

현재 에디터 설계를 보면 결제선이 활성화된 여부를 에디터 상에서 문단 끝에 있냐 없냐로 파악하고 있는데,
결제선 해제 시 가격 정보를 초기화하고 있지 않아 에디터 바깎에서는 가격이 있다고 인식하는 문제였습니다.

활성화된 결제 선을 사용자가 문서 맨 끝으로 의도적으로 옮기는 경우 결제선이 비활성화 되었다고 에디터가 간주하는 엣지 케이스도 발견해서 결제선이 비활성화된 기준을 `null` 로 초기화한 경우로 설계하여 같이 해결했습니다.