### PR TITLE
결제선 해제 시 가격 정보 비우기

### DIFF
--- a/apps/penxle.com/src/lib/tiptap/node-views/access-barrier/Component.svelte
+++ b/apps/penxle.com/src/lib/tiptap/node-views/access-barrier/Component.svelte
@@ -211,11 +211,16 @@
             _hover: { backgroundColor: 'gray.100' },
           })}
           type="button"
-          on:click={() =>
-            editor
-              ?.chain()
-              .cut({ from: getPos(), to: getPos() + node.nodeSize }, editor.state.doc.content.size)
-              .run()}
+          on:click={() => {
+            updateAttributes({ price: null });
+            // Hack: "RangeError: Index out of range" 가 일어나서 setTimeout 을 통해 이벤트 루프를 분리하니 해결됨
+            setTimeout(() =>
+              editor
+                ?.chain()
+                .cut({ from: getPos(), to: getPos() + node.nodeSize }, editor.state.doc.content.size)
+                .run(),
+            );
+          }}
         >
           해제
         </button>


### PR DESCRIPTION
 #1563 후속 프론트엔드 작업입니다. 결제선 해제 시 가격 정보를 초깃값 `null` 로 변경하는 코드를 추가했습니다.